### PR TITLE
TEST-15: re-added cosmos_proto fields to ICQ proto types

### DIFF
--- a/stride/proto/interchainquery/genesis.proto
+++ b/stride/proto/interchainquery/genesis.proto
@@ -12,15 +12,13 @@ message Query {
   string chain_id = 3;
   string query_type = 4;
   map<string, string> query_parameters = 5;
-  // TODO(TEST-15): Add this type annotation back after installing cosmos_proto   
-  // (cosmos_proto.scalar) = "cosmos.Int",
   string period = 6 [
+    (cosmos_proto.scalar) = "cosmos.Int",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable) = false
   ];
-  // TODO(TEST-15): Add this type annotation back after installing cosmos_proto   
-  // (cosmos_proto.scalar) = "cosmos.Int",
   string last_height = 7 [
+    (cosmos_proto.scalar) = "cosmos.Int",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable) = false
   ];
@@ -28,15 +26,13 @@ message Query {
 
 message DataPoint {
   string id = 1;
-  // TODO(TEST-15): Add this type annotation back after installing cosmos_proto   
-  // (cosmos_proto.scalar) = "cosmos.Int",
   string remote_height = 2 [
+    (cosmos_proto.scalar) = "cosmos.Int",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable) = false
   ];
-  // TODO(TEST-15): Add this type annotation back after installing cosmos_proto   
-  // (cosmos_proto.scalar) = "cosmos.Int",
   string local_height = 3 [
+    (cosmos_proto.scalar) = "cosmos.Int",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable) = false
   ];

--- a/stride/proto/interchainquery/messages.proto
+++ b/stride/proto/interchainquery/messages.proto
@@ -29,9 +29,7 @@ message MsgSubmitQueryResponse {
   string query_id = 2 [ (gogoproto.moretags) = "yaml:\"query_id\"" ];
   bytes result = 3 [ (gogoproto.moretags) = "yaml:\"result\"" ];
   int64 height = 4 [ (gogoproto.moretags) = "yaml:\"height\"" ];
-  // TODO(TEST-15): Add this type annotation back after installing cosmos_proto   
-  // string from_address = 5 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
-  string from_address = 5;
+  string from_address = 5 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
 }
 
 // MsgSubmitQueryResponseResponse defines the MsgSubmitQueryResponse response


### PR DESCRIPTION
**Summary**
This PR relied on TEST-47 to add in third_party libraries. It uncomments some cosmos_proto types in the interchain queries proto filse
