### PR TITLE
[TEST-12][1] Prep ICA staking by fixing some bugs

### DIFF
--- a/stride/Makefile
+++ b/stride/Makefile
@@ -298,10 +298,10 @@ init:
 			sh scripts/init.sh;\
 	elif [ ${build} == "stride" ]; \
 		then \
-			sh scripts/init.sh -b;\
+			sh scripts/init.sh -bs;\
 	elif [ ${build} == "strideall" ]; \
 		then \
-			sh scripts/init.sh - ;\
+			sh scripts/init.sh -ba ;\
 	else\
 		echo "Init type ${build} not recognized.";\
 	fi

--- a/stride/app/app.go
+++ b/stride/app/app.go
@@ -407,6 +407,14 @@ func NewStrideApp(
 	// )
 	// monitoringModule := monitoringp.NewAppModule(appCodec, app.MonitoringKeeper)
 
+	// Note: must be above app.StakeibcKeeper
+	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
+		appCodec, keys[icacontrollertypes.StoreKey], app.GetSubspace(icacontrollertypes.SubModuleName),
+		app.IBCKeeper.ChannelKeeper, // may be replaced with middleware such as ics29 fee
+		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
+		scopedICAControllerKeeper, app.MsgServiceRouter(),
+	)
+
 	scopedStakeibcKeeper := app.CapabilityKeeper.ScopeToModule(stakeibcmoduletypes.ModuleName)
 	app.ScopedStakeibcKeeper = scopedStakeibcKeeper
 	app.StakeibcKeeper = stakeibcmodulekeeper.NewKeeper(
@@ -424,12 +432,6 @@ func NewStrideApp(
 	stakeibcModule := stakeibcmodule.NewAppModule(appCodec, app.StakeibcKeeper, app.AccountKeeper, app.BankKeeper)
 	stakeibcIBCModule := stakeibcmodule.NewIBCModule(app.StakeibcKeeper)
 
-	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
-		appCodec, keys[icacontrollertypes.StoreKey], app.GetSubspace(icacontrollertypes.SubModuleName),
-		app.IBCKeeper.ChannelKeeper, // may be replaced with middleware such as ics29 fee
-		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
-		scopedICAControllerKeeper, app.MsgServiceRouter(),
-	)
 	app.ICAHostKeeper = icahostkeeper.NewKeeper(
 		appCodec, keys[icahosttypes.StoreKey], app.GetSubspace(icahosttypes.SubModuleName),
 		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,

--- a/stride/go.mod
+++ b/stride/go.mod
@@ -27,6 +27,10 @@ require (
 )
 
 replace (
+	// TODO(TEST-54): Should we delete this replace statement and use the core cosmos-sdk for mainnet?
+	// NOTE: If you need to bump the cosmos-sdk version, create a branch at the commit hash
+	// of the target version on github.com/Stride-Labs/cosmos-sdk, then remove the error redaction
+	// logic and push a new tag and the branch to github (use that tag below)
 	github.com/cosmos/cosmos-sdk => github.com/Stride-Labs/cosmos-sdk v0.45.4-debug-2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/ignite-hq/cli => github.com/ignite-hq/cli v0.21.0

--- a/stride/scripts/init_gaia.sh
+++ b/stride/scripts/init_gaia.sh
@@ -76,6 +76,11 @@ for i in ${!GAIA_CHAINS[@]}; do
     sed -i -E "s|minimum-gas-prices = \"\"|minimum-gas-prices = \"0uatom\"|g" "${STATE}/${chain_name}/config/app.toml"
 done
 
+## add the message types ICA should allow to the host chain
+ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
+sed -i -E "s|\"allow_messages\": \[\]|\"allow_messages\": \[${ALLOW_MESSAGES}\]|g" "${STATE}/${main_gaia_chain}/config/genesis.json"
+
+
 # make sure all Stride chains have the same genesis
 for i in "${!GAIA_CHAINS[@]}"; do
     if [ $i -ne $MAIN_ID ]


### PR DESCRIPTION
**Summary**
In preparation to add ICA staking functionality, fix a few bugs. These are
- Fix `make init`, @vish-stride pointed out that the reason `make init build={stride, strideall}` wasn't working was that some flags were missing
- Move the initialization of `app.ICAControllerKeeper` above `app.StakeibcKeeper` in `app.go`. `app.ICAControllerKeeper` was initialized below `app.StakeibcKeeper`, so calls to `ICAControllerKeeper` currently fail.
- add `ALLOW_MESSAGES` to the gaia `genesis.json` files so that ICA calls are enabled. Per the [ICA docs](https://ibc.cosmos.network/main/apps/interchain-accounts/parameters.html#allowmessages), allow messages must be defined in order for a controller chain to control an ICA.

This is the first of 3 PRs to add interchain staking to `stakeibc`, the remaining PRs will
- Add ICA client functionality and tests to Stride
- Update `stakeibc` so that host chain staking happens on a regular cadence

**Test plan**
`ignite chain build` and `ignite chain serve`

Draft PR: https://github.com/Stride-Labs/stride/pull/12
