### PR TITLE
Update mod name

### DIFF
--- a/stride/app/app.go
+++ b/stride/app/app.go
@@ -51,9 +51,9 @@ import (
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/Stride-Labs/stride/x/mint"
-	mintkeeper "github.com/Stride-Labs/stride/x/mint/keeper"
-	minttypes "github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint"
+	mintkeeper "github.com/Stride-Labs/stride/stride/x/mint/keeper"
+	minttypes "github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
@@ -100,17 +100,17 @@ import (
 	// monitoringp "github.com/tendermint/spn/x/monitoringp"
 	// monitoringpkeeper "github.com/tendermint/spn/x/monitoringp/keeper"
 
-	epochsmodule "github.com/Stride-Labs/stride/x/epochs"
-	epochsmodulekeeper "github.com/Stride-Labs/stride/x/epochs/keeper"
-	epochsmoduletypes "github.com/Stride-Labs/stride/x/epochs/types"
+	epochsmodule "github.com/Stride-Labs/stride/stride/x/epochs"
+	epochsmodulekeeper "github.com/Stride-Labs/stride/stride/x/epochs/keeper"
+	epochsmoduletypes "github.com/Stride-Labs/stride/stride/x/epochs/types"
 
-	"github.com/Stride-Labs/stride/x/interchainquery"
-	interchainquerykeeper "github.com/Stride-Labs/stride/x/interchainquery/keeper"
-	interchainquerytypes "github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery"
+	interchainquerykeeper "github.com/Stride-Labs/stride/stride/x/interchainquery/keeper"
+	interchainquerytypes "github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 
-	stakeibcmodule "github.com/Stride-Labs/stride/x/stakeibc"
-	stakeibcmodulekeeper "github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	stakeibcmoduletypes "github.com/Stride-Labs/stride/x/stakeibc/types"
+	stakeibcmodule "github.com/Stride-Labs/stride/stride/x/stakeibc"
+	stakeibcmodulekeeper "github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	stakeibcmoduletypes "github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 )
 

--- a/stride/app/simulation_test.go
+++ b/stride/app/simulation_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/stride/app"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp"

--- a/stride/cmd/strided/main.go
+++ b/stride/cmd/strided/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"os"
 
-	"github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/stride/app"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	cmdcfg "github.com/Stride-Labs/stride/cmd/strided/config"
+	cmdcfg "github.com/Stride-Labs/stride/stride/cmd/strided/config"
 )
 
 func main() {

--- a/stride/cmd/strided/root.go
+++ b/stride/cmd/strided/root.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
-	"github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/stride/app"
 	// "github.com/Stride-labs/stride/app/params"
 	// this line is used by starport scaffolding # stargate/root/import
 )

--- a/stride/go.mod
+++ b/stride/go.mod
@@ -1,4 +1,4 @@
-module github.com/Stride-Labs/stride
+module github.com/Stride-Labs/stride/stride
 
 go 1.16
 

--- a/stride/proto/epochs/genesis.proto
+++ b/stride/proto/epochs/genesis.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/epochs/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/epochs/types";
 
 message EpochInfo {
   string identifier = 1;

--- a/stride/proto/epochs/query.proto
+++ b/stride/proto/epochs/query.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "epochs/genesis.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/epochs/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/epochs/types";
 
 // Query defines the gRPC querier service.
 service Query {
@@ -42,7 +42,7 @@ message QueryCurrentEpochResponse { int64 current_epoch = 1; }
 // import "epochs/params.proto";
 // // this line is used by starport scaffolding # 1
 
-// option go_package = "github.com/Stride-Labs/stride/x/epochs/types";
+// option go_package = "github.com/Stride-Labs/stride/stride/x/epochs/types";
 
 // // Query defines the gRPC querier service.
 // service Query {

--- a/stride/proto/interchainquery/genesis.proto
+++ b/stride/proto/interchainquery/genesis.proto
@@ -4,7 +4,7 @@ package stride.interchainquery;
 import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/interchainquery/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/interchainquery/types";
 
 message Query {
   string id = 1;

--- a/stride/proto/interchainquery/messages.proto
+++ b/stride/proto/interchainquery/messages.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 import "google/api/annotations.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/interchainquery/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/interchainquery/types";
 
 // Msg defines the interchainquery Msg service.
 service Msg {

--- a/stride/proto/mint/v1beta1/genesis.proto
+++ b/stride/proto/mint/v1beta1/genesis.proto
@@ -4,7 +4,7 @@ package stride.mint.v1beta1;
 import "gogoproto/gogo.proto";
 import "mint/v1beta1/mint.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/mint/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/mint/types";
 
 // GenesisState defines the mint module's genesis state.
 message GenesisState {

--- a/stride/proto/mint/v1beta1/mint.proto
+++ b/stride/proto/mint/v1beta1/mint.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package stride.mint.v1beta1;
 
-option go_package = "github.com/Stride-Labs/stride/x/mint/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/mint/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/stride/proto/mint/v1beta1/query.proto
+++ b/stride/proto/mint/v1beta1/query.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "mint/v1beta1/mint.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/mint/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/mint/types";
 
 // Query provides defines the gRPC querier service.
 service Query {

--- a/stride/proto/stakeibc/delegation.proto
+++ b/stride/proto/stakeibc/delegation.proto
@@ -3,7 +3,7 @@ package Stridelabs.stride.stakeibc;
 
 import "stakeibc/validator.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 message Delegation {
   string delegateAcctAddress = 1; 

--- a/stride/proto/stakeibc/deposit_record.proto
+++ b/stride/proto/stakeibc/deposit_record.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package Stridelabs.stride.stakeibc;
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 import "stakeibc/host_zone.proto"; 
 
 message DepositRecord {

--- a/stride/proto/stakeibc/genesis.proto
+++ b/stride/proto/stakeibc/genesis.proto
@@ -8,7 +8,7 @@ import "stakeibc/host_zone.proto";
 import "stakeibc/deposit_record.proto";
 // this line is used by starport scaffolding # genesis/proto/import
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 // GenesisState defines the stakeibc module's genesis state.
 message GenesisState {

--- a/stride/proto/stakeibc/host_zone.proto
+++ b/stride/proto/stakeibc/host_zone.proto
@@ -4,7 +4,7 @@ package Stridelabs.stride.stakeibc;
 import "stakeibc/validator.proto";
 import "stakeibc/ica_account.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 // next id: 10
 message HostZone {

--- a/stride/proto/stakeibc/ica_account.proto
+++ b/stride/proto/stakeibc/ica_account.proto
@@ -3,7 +3,7 @@ package Stridelabs.stride.stakeibc;
 
 import "stakeibc/delegation.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 enum ICAAccountType {
   DELEGATION = 0;

--- a/stride/proto/stakeibc/min_validator_requirements.proto
+++ b/stride/proto/stakeibc/min_validator_requirements.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package Stridelabs.stride.stakeibc;
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 message MinValidatorRequirements {
   int32 commissionRate = 1; 

--- a/stride/proto/stakeibc/packet.proto
+++ b/stride/proto/stakeibc/packet.proto
@@ -3,7 +3,7 @@ package Stridelabs.stride.stakeibc;
 
 // this line is used by starport scaffolding # proto/packet/import
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 message StakeibcPacketData {
     oneof packet {

--- a/stride/proto/stakeibc/params.proto
+++ b/stride/proto/stakeibc/params.proto
@@ -4,7 +4,7 @@ package Stridelabs.stride.stakeibc;
 import "gogoproto/gogo.proto";
 import "stakeibc/ica_account.proto";
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 // Params defines the parameters for the module.
 message Params {

--- a/stride/proto/stakeibc/query.proto
+++ b/stride/proto/stakeibc/query.proto
@@ -13,7 +13,7 @@ import "stakeibc/host_zone.proto";
 import "stakeibc/deposit_record.proto";
 // this line is used by starport scaffolding # 1
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/stride/proto/stakeibc/tx.proto
+++ b/stride/proto/stakeibc/tx.proto
@@ -3,7 +3,7 @@ package Stridelabs.stride.stakeibc;
 
 // this line is used by starport scaffolding # proto/tx/import
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 

--- a/stride/proto/stakeibc/validator.proto
+++ b/stride/proto/stakeibc/validator.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package Stridelabs.stride.stakeibc;
 
-option go_package = "github.com/Stride-Labs/stride/x/stakeibc/types";
+option go_package = "github.com/Stride-Labs/stride/stride/x/stakeibc/types";
 
 message Validator {
   string name = 1; 

--- a/stride/testutil/keeper/epochs.go
+++ b/stride/testutil/keeper/epochs.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"testing"
 
-	"github.com/Stride-Labs/stride/x/epochs/keeper"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/keeper"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"

--- a/stride/testutil/keeper/interchainquery.go
+++ b/stride/testutil/keeper/interchainquery.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"testing"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/keeper"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"

--- a/stride/testutil/keeper/stakeibc.go
+++ b/stride/testutil/keeper/stakeibc.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"testing"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"

--- a/stride/testutil/network/network.go
+++ b/stride/testutil/network/network.go
@@ -18,7 +18,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmdb "github.com/tendermint/tm-db"
 
-	"github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/stride/app"
 )
 
 type (

--- a/stride/x/epochs/client/cli/query.go
+++ b/stride/x/epochs/client/cli/query.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/stride/x/epochs/genesis.go
+++ b/stride/x/epochs/genesis.go
@@ -5,8 +5,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/epochs/keeper"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/keeper"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/stride/x/epochs/genesis_test.go
+++ b/stride/x/epochs/genesis_test.go
@@ -3,10 +3,10 @@ package epochs_test
 import (
 	"testing"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/epochs"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/epochs"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/stride/x/epochs/handler.go
+++ b/stride/x/epochs/handler.go
@@ -6,8 +6,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/Stride-Labs/stride/x/epochs/keeper"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/keeper"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // NewHandler returns a handler for epochs module messages

--- a/stride/x/epochs/keeper/abci.go
+++ b/stride/x/epochs/keeper/abci.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // BeginBlocker of epochs module

--- a/stride/x/epochs/keeper/abci_test.go
+++ b/stride/x/epochs/keeper/abci_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Stride-Labs/stride/x/epochs"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {

--- a/stride/x/epochs/keeper/epoch.go
+++ b/stride/x/epochs/keeper/epoch.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // GetEpochInfo returns epoch info by identifier

--- a/stride/x/epochs/keeper/epoch_test.go
+++ b/stride/x/epochs/keeper/epoch_test.go
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"time"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 func (suite *KeeperTestSuite) TestEpochLifeCycle() {

--- a/stride/x/epochs/keeper/grpc_query.go
+++ b/stride/x/epochs/keeper/grpc_query.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/stride/x/epochs/keeper/grpc_query_test.go
+++ b/stride/x/epochs/keeper/grpc_query_test.go
@@ -4,7 +4,7 @@ import (
 	gocontext "context"
 	"time"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 func (suite *KeeperTestSuite) TestQueryEpochInfos() {

--- a/stride/x/epochs/keeper/keeper.go
+++ b/stride/x/epochs/keeper/keeper.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // Keeper of this module maintains collections of epochs and hooks.

--- a/stride/x/epochs/keeper/keeper_test.go
+++ b/stride/x/epochs/keeper/keeper_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	"github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/app"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 type KeeperTestSuite struct {

--- a/stride/x/epochs/module.go
+++ b/stride/x/epochs/module.go
@@ -20,10 +20,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/Stride-Labs/stride/x/epochs/client/cli"
-	"github.com/Stride-Labs/stride/x/epochs/keeper"
-	"github.com/Stride-Labs/stride/x/epochs/simulation"
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/epochs/keeper"
+	"github.com/Stride-Labs/stride/stride/x/epochs/simulation"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 var (

--- a/stride/x/epochs/simulation/genesis.go
+++ b/stride/x/epochs/simulation/genesis.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/epochs/types"
 )
 
 // RandomizedGenState generates a random GenesisState for mint

--- a/stride/x/interchainquery/genesis.go
+++ b/stride/x/interchainquery/genesis.go
@@ -3,8 +3,8 @@ package interchainquery
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/keeper"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 // InitGenesis initializes the capability module's state from a provided genesis

--- a/stride/x/interchainquery/handler.go
+++ b/stride/x/interchainquery/handler.go
@@ -6,8 +6,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/keeper"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 // NewHandler returns a handler for interchainquery module messages

--- a/stride/x/interchainquery/keeper/abci.go
+++ b/stride/x/interchainquery/keeper/abci.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 const (

--- a/stride/x/interchainquery/keeper/keeper.go
+++ b/stride/x/interchainquery/keeper/keeper.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 // Keeper of this module maintains collections of registered zones.

--- a/stride/x/interchainquery/keeper/msg_server.go
+++ b/stride/x/interchainquery/keeper/msg_server.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/stride/x/interchainquery/keeper/queries.go
+++ b/stride/x/interchainquery/keeper/queries.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/crypto"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 func GenerateQueryHash(connection_id string, chain_id string, query_type string, query_params map[string]string) string {

--- a/stride/x/interchainquery/module.go
+++ b/stride/x/interchainquery/module.go
@@ -18,9 +18,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/keeper"
 
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
+	"github.com/Stride-Labs/stride/stride/x/interchainquery/types"
 )
 
 var (

--- a/stride/x/mint/client/cli/cli_test.go
+++ b/stride/x/mint/client/cli/cli_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 
-	"github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/mint/client/cli"
+	"github.com/Stride-Labs/stride/stride/app"
+	"github.com/Stride-Labs/stride/stride/x/mint/client/cli"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"

--- a/stride/x/mint/client/cli/query.go
+++ b/stride/x/mint/client/cli/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/stride/x/mint/client/rest/grpc_query_test.go
+++ b/stride/x/mint/client/rest/grpc_query_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/Stride-Labs/stride/app"
-	minttypes "github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/app"
+	minttypes "github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 )

--- a/stride/x/mint/client/rest/query.go
+++ b/stride/x/mint/client/rest/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/rest"

--- a/stride/x/mint/genesis.go
+++ b/stride/x/mint/genesis.go
@@ -1,8 +1,8 @@
 package mint
 
 import (
-	"github.com/Stride-Labs/stride/x/mint/keeper"
-	"github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/keeper"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/mint/keeper/grpc_query.go
+++ b/stride/x/mint/keeper/grpc_query.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 )
 
 var _ types.QueryServer = Querier{}

--- a/stride/x/mint/keeper/hooks.go
+++ b/stride/x/mint/keeper/hooks.go
@@ -3,8 +3,8 @@ package keeper
 import (
 	"fmt"
 
-	epochstypes "github.com/Stride-Labs/stride/x/epochs/types"
-	"github.com/Stride-Labs/stride/x/mint/types"
+	epochstypes "github.com/Stride-Labs/stride/stride/x/epochs/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/stride/x/mint/keeper/keeper.go
+++ b/stride/x/mint/keeper/keeper.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/mint/types"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/stride/x/mint/module.go
+++ b/stride/x/mint/module.go
@@ -17,12 +17,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/Stride-Labs/stride/x/mint/client/cli"
-	"github.com/Stride-Labs/stride/x/mint/client/rest"
-	"github.com/Stride-Labs/stride/x/mint/keeper"
+	"github.com/Stride-Labs/stride/stride/x/mint/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/mint/client/rest"
+	"github.com/Stride-Labs/stride/stride/x/mint/keeper"
 
-	//"github.com/Stride-Labs/stride/x/mint/simulation"
-	"github.com/Stride-Labs/stride/x/mint/types"
+	//"github.com/Stride-Labs/stride/stride/x/mint/simulation"
+	"github.com/Stride-Labs/stride/stride/x/mint/types"
 )
 
 var (

--- a/stride/x/mint/types/expected_keepers.go
+++ b/stride/x/mint/types/expected_keepers.go
@@ -1,7 +1,7 @@
 package types // noalias
 
 import (
-	epochstypes "github.com/Stride-Labs/stride/x/epochs/types"
+	epochstypes "github.com/Stride-Labs/stride/stride/x/epochs/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"

--- a/stride/x/mint/types/params.go
+++ b/stride/x/mint/types/params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	epochtypes "github.com/Stride-Labs/stride/x/epochs/types"
+	epochtypes "github.com/Stride-Labs/stride/stride/x/epochs/types"
 	yaml "gopkg.in/yaml.v2"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/stride/x/stakeibc/abci.go
+++ b/stride/x/stakeibc/abci.go
@@ -3,8 +3,8 @@ package stakeibc
 import (
 	"time"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/client/cli/query.go
+++ b/stride/x/stakeibc/client/cli/query.go
@@ -10,7 +10,7 @@ import (
 	// "github.com/cosmos/cosmos-sdk/client/flags"
 	// sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/stride/x/stakeibc/client/cli/query_delegation.go
+++ b/stride/x/stakeibc/client/cli/query_delegation.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_delegation_test.go
+++ b/stride/x/stakeibc/client/cli/query_delegation_test.go
@@ -9,10 +9,10 @@ import (
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithDelegationObjects(t *testing.T) (*network.Network, types.Delegation) {

--- a/stride/x/stakeibc/client/cli/query_deposit_record.go
+++ b/stride/x/stakeibc/client/cli/query_deposit_record.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_deposit_record_test.go
+++ b/stride/x/stakeibc/client/cli/query_deposit_record_test.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithDepositRecordObjects(t *testing.T, n int) (*network.Network, []types.DepositRecord) {

--- a/stride/x/stakeibc/client/cli/query_host_zone.go
+++ b/stride/x/stakeibc/client/cli/query_host_zone.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_host_zone_test.go
+++ b/stride/x/stakeibc/client/cli/query_host_zone_test.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithHostZoneObjects(t *testing.T, n int) (*network.Network, []types.HostZone) {

--- a/stride/x/stakeibc/client/cli/query_ica_account.go
+++ b/stride/x/stakeibc/client/cli/query_ica_account.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_ica_account_test.go
+++ b/stride/x/stakeibc/client/cli/query_ica_account_test.go
@@ -9,10 +9,10 @@ import (
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithICAAccountObjects(t *testing.T) (*network.Network, types.ICAAccount) {

--- a/stride/x/stakeibc/client/cli/query_min_validator_requirements.go
+++ b/stride/x/stakeibc/client/cli/query_min_validator_requirements.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_min_validator_requirements_test.go
+++ b/stride/x/stakeibc/client/cli/query_min_validator_requirements_test.go
@@ -9,10 +9,10 @@ import (
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithMinValidatorRequirementsObjects(t *testing.T) (*network.Network, types.MinValidatorRequirements) {

--- a/stride/x/stakeibc/client/cli/query_params.go
+++ b/stride/x/stakeibc/client/cli/query_params.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_register_ica.go
+++ b/stride/x/stakeibc/client/cli/query_register_ica.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_validator.go
+++ b/stride/x/stakeibc/client/cli/query_validator.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/stride/x/stakeibc/client/cli/query_validator_test.go
+++ b/stride/x/stakeibc/client/cli/query_validator_test.go
@@ -9,10 +9,10 @@ import (
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/status"
 
-	"github.com/Stride-Labs/stride/testutil/network"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/network"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func networkWithValidatorObjects(t *testing.T) (*network.Network, types.Validator) {

--- a/stride/x/stakeibc/client/cli/tx.go
+++ b/stride/x/stakeibc/client/cli/tx.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	// "github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 var (

--- a/stride/x/stakeibc/client/cli/tx_liquid_stake.go
+++ b/stride/x/stakeibc/client/cli/tx_liquid_stake.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/stride/x/stakeibc/client/cli/tx_register_host_zone.go
+++ b/stride/x/stakeibc/client/cli/tx_register_host_zone.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/stride/x/stakeibc/client/cli/tx_register_ica.go
+++ b/stride/x/stakeibc/client/cli/tx_register_ica.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/stride/x/stakeibc/client/cli/tx_submit_tx.go
+++ b/stride/x/stakeibc/client/cli/tx_submit_tx.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/stride/x/stakeibc/genesis.go
+++ b/stride/x/stakeibc/genesis.go
@@ -1,8 +1,8 @@
 package stakeibc
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/stride/x/stakeibc/genesis_test.go
+++ b/stride/x/stakeibc/genesis_test.go
@@ -3,10 +3,10 @@ package stakeibc_test
 import (
 	"testing"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/stride/x/stakeibc/handler.go
+++ b/stride/x/stakeibc/handler.go
@@ -3,8 +3,8 @@ package stakeibc
 import (
 	"fmt"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/stride/x/stakeibc/keeper/delegation.go
+++ b/stride/x/stakeibc/keeper/delegation.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/delegation_test.go
+++ b/stride/x/stakeibc/keeper/delegation_test.go
@@ -6,10 +6,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func createTestDelegation(keeper *keeper.Keeper, ctx sdk.Context) types.Delegation {

--- a/stride/x/stakeibc/keeper/deposit_record.go
+++ b/stride/x/stakeibc/keeper/deposit_record.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"encoding/binary"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/deposit_record_test.go
+++ b/stride/x/stakeibc/keeper/deposit_record_test.go
@@ -3,10 +3,10 @@ package keeper_test
 import (
 	"testing"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )

--- a/stride/x/stakeibc/keeper/grpc_query.go
+++ b/stride/x/stakeibc/keeper/grpc_query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/stride/x/stakeibc/keeper/grpc_query_delegation.go
+++ b/stride/x/stakeibc/keeper/grpc_query_delegation.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/stride/x/stakeibc/keeper/grpc_query_delegation_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_delegation_test.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestDelegationQuery(t *testing.T) {

--- a/stride/x/stakeibc/keeper/grpc_query_deposit_record.go
+++ b/stride/x/stakeibc/keeper/grpc_query_deposit_record.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/stride/x/stakeibc/keeper/grpc_query_deposit_record_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_deposit_record_test.go
@@ -10,9 +10,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestDepositRecordQuerySingle(t *testing.T) {

--- a/stride/x/stakeibc/keeper/grpc_query_host_zone.go
+++ b/stride/x/stakeibc/keeper/grpc_query_host_zone.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/stride/x/stakeibc/keeper/grpc_query_host_zone_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_host_zone_test.go
@@ -10,9 +10,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestHostZoneQuerySingle(t *testing.T) {

--- a/stride/x/stakeibc/keeper/grpc_query_ica_account.go
+++ b/stride/x/stakeibc/keeper/grpc_query_ica_account.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/stride/x/stakeibc/keeper/grpc_query_ica_account_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_ica_account_test.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestICAAccountQuery(t *testing.T) {

--- a/stride/x/stakeibc/keeper/grpc_query_min_validator_requirements.go
+++ b/stride/x/stakeibc/keeper/grpc_query_min_validator_requirements.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/stride/x/stakeibc/keeper/grpc_query_min_validator_requirements_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_min_validator_requirements_test.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestMinValidatorRequirementsQuery(t *testing.T) {

--- a/stride/x/stakeibc/keeper/grpc_query_params.go
+++ b/stride/x/stakeibc/keeper/grpc_query_params.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/stride/x/stakeibc/keeper/grpc_query_params_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_params_test.go
@@ -3,8 +3,8 @@ package keeper_test
 import (
 	"testing"
 
-	testkeeper "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	testkeeper "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )

--- a/stride/x/stakeibc/keeper/grpc_query_register_ica.go
+++ b/stride/x/stakeibc/keeper/grpc_query_register_ica.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 // InterchainAccountFromAddress implements the Query/InterchainAccountFromAddress gRPC method

--- a/stride/x/stakeibc/keeper/grpc_query_validator.go
+++ b/stride/x/stakeibc/keeper/grpc_query_validator.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/stride/x/stakeibc/keeper/grpc_query_validator_test.go
+++ b/stride/x/stakeibc/keeper/grpc_query_validator_test.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func TestValidatorQuery(t *testing.T) {

--- a/stride/x/stakeibc/keeper/hooks.go
+++ b/stride/x/stakeibc/keeper/hooks.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"fmt"
 
-	epochstypes "github.com/Stride-Labs/stride/x/epochs/types"
+	epochstypes "github.com/Stride-Labs/stride/stride/x/epochs/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/stride/x/stakeibc/keeper/host_zone.go
+++ b/stride/x/stakeibc/keeper/host_zone.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"encoding/binary"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/host_zone_test.go
+++ b/stride/x/stakeibc/keeper/host_zone_test.go
@@ -3,10 +3,10 @@ package keeper_test
 import (
 	"testing"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )

--- a/stride/x/stakeibc/keeper/ica_account.go
+++ b/stride/x/stakeibc/keeper/ica_account.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/ica_account_test.go
+++ b/stride/x/stakeibc/keeper/ica_account_test.go
@@ -6,10 +6,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func createTestICAAccount(keeper *keeper.Keeper, ctx sdk.Context) types.ICAAccount {

--- a/stride/x/stakeibc/keeper/keeper.go
+++ b/stride/x/stakeibc/keeper/keeper.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankKeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"

--- a/stride/x/stakeibc/keeper/min_validator_requirements.go
+++ b/stride/x/stakeibc/keeper/min_validator_requirements.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/min_validator_requirements_test.go
+++ b/stride/x/stakeibc/keeper/min_validator_requirements_test.go
@@ -6,10 +6,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func createTestMinValidatorRequirements(keeper *keeper.Keeper, ctx sdk.Context) types.MinValidatorRequirements {

--- a/stride/x/stakeibc/keeper/msg_server.go
+++ b/stride/x/stakeibc/keeper/msg_server.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 type msgServer struct {

--- a/stride/x/stakeibc/keeper/msg_server_liquid_stake.go
+++ b/stride/x/stakeibc/keeper/msg_server_liquid_stake.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/stride/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/stride/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/msg_server_register_ica.go
+++ b/stride/x/stakeibc/keeper/msg_server_register_ica.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/stride/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"

--- a/stride/x/stakeibc/keeper/msg_server_test.go
+++ b/stride/x/stakeibc/keeper/msg_server_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/stride/x/stakeibc/keeper/params.go
+++ b/stride/x/stakeibc/keeper/params.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/stride/x/stakeibc/keeper/params_test.go
+++ b/stride/x/stakeibc/keeper/params_test.go
@@ -3,8 +3,8 @@ package keeper_test
 import (
 	"testing"
 
-	testkeeper "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	testkeeper "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/stride/x/stakeibc/keeper/validator.go
+++ b/stride/x/stakeibc/keeper/validator.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/stride/x/stakeibc/keeper/validator_test.go
+++ b/stride/x/stakeibc/keeper/validator_test.go
@@ -6,10 +6,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	keepertest "github.com/Stride-Labs/stride/testutil/keeper"
-	"github.com/Stride-Labs/stride/testutil/nullify"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	keepertest "github.com/Stride-Labs/stride/stride/testutil/keeper"
+	"github.com/Stride-Labs/stride/stride/testutil/nullify"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 )
 
 func createTestValidator(keeper *keeper.Keeper, ctx sdk.Context) types.Validator {

--- a/stride/x/stakeibc/module.go
+++ b/stride/x/stakeibc/module.go
@@ -13,9 +13,9 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/client/cli"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/client/cli"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/stride/x/stakeibc/module_ibc.go
+++ b/stride/x/stakeibc/module_ibc.go
@@ -3,8 +3,8 @@ package stakeibc
 import (
 	"fmt"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"

--- a/stride/x/stakeibc/module_simulation.go
+++ b/stride/x/stakeibc/module_simulation.go
@@ -3,9 +3,9 @@ package stakeibc
 import (
 	"math/rand"
 
-	"github.com/Stride-Labs/stride/testutil/sample"
-	stakeibcsimulation "github.com/Stride-Labs/stride/x/stakeibc/simulation"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/testutil/sample"
+	stakeibcsimulation "github.com/Stride-Labs/stride/stride/x/stakeibc/simulation"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/stride/x/stakeibc/simulation/liquid_stake.go
+++ b/stride/x/stakeibc/simulation/liquid_stake.go
@@ -3,8 +3,8 @@ package simulation
 import (
 	"math/rand"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"

--- a/stride/x/stakeibc/types/genesis_test.go
+++ b/stride/x/stakeibc/types/genesis_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/stride/x/stakeibc/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/stride/x/stakeibc/types/message_liquid_stake_test.go
+++ b/stride/x/stakeibc/types/message_liquid_stake_test.go
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	"github.com/Stride-Labs/stride/testutil/sample"
+	"github.com/Stride-Labs/stride/stride/testutil/sample"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
**Summary**
`github.com/Stride-Labs/stride` was impossible to import in other directories as a go module because the go code was nested under `github.com/Stride-Labs/stride/stride`. Rename module name to `github.com/Stride-Labs/stride/stride`

**Test plan**
going to merge & run `go get github.com/Stride-Labs/stride/stride/x/interchainquery/types` (this command fails with the current module name)