### PR TITLE
add validateBasic() checks to most of x/stakeibc

### DIFF
--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -29,10 +29,6 @@ func (k Keeper) RegisterHostZone(goCtx context.Context, msg *types.MsgRegisterHo
 		return nil, fmt.Errorf("invalid chain id, zone for \"%s\" already registered", chainId)
 	}
 
-	if msg.UnbondingFrequency < 1 {
-		return nil, fmt.Errorf("invalid unbonding frequency %d, must be positive", msg.UnbondingFrequency)
-	}
-
 	// set the zone
 	zone := types.HostZone{
 		ChainId:           chainId,

--- a/x/stakeibc/types/message_add_validator.go
+++ b/x/stakeibc/types/message_add_validator.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/Stride-Labs/stride/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -50,5 +51,21 @@ func (msg *MsgAddValidator) ValidateBasic() error {
 	if err := utils.ValidateWhitelistedAddress(msg.Creator); err != nil {
 		return err
 	}
+	// name validation
+	if len(msg.Name) == 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "name is required")
+	}
+	// commission validation
+	if msg.Commission > 100 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "commission must be between 0 and 100")
+	}
+	if msg.Commission > 10 {
+		fmt.Sprintf("WARNING: commission is %d (greater than 10%)", msg.Commission)
+	}
+	// weight validation
+	if msg.Weight < 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "cannot add validator with negative weight (weights passed: %d)", msg.Weight)
+	}
+
 	return nil
 }

--- a/x/stakeibc/types/message_change_validator_weight.go
+++ b/x/stakeibc/types/message_change_validator_weight.go
@@ -48,5 +48,9 @@ func (msg *MsgChangeValidatorWeight) ValidateBasic() error {
 	if err := utils.ValidateWhitelistedAddress(msg.Creator); err != nil {
 		return err
 	}
+	// validate new weight
+	if msg.Weight < 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "new validator weight must be positive")
+	}
 	return nil
 }

--- a/x/stakeibc/types/message_claim_undelegated_tokens.go
+++ b/x/stakeibc/types/message_claim_undelegated_tokens.go
@@ -43,5 +43,9 @@ func (msg *MsgClaimUndelegatedTokens) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	// max claims must be greater than 0
+	if msg.MaxClaims <= 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "max claims must be greater than 0")
+	}
 	return nil
 }

--- a/x/stakeibc/types/message_liquid_stake.go
+++ b/x/stakeibc/types/message_liquid_stake.go
@@ -59,5 +59,9 @@ func (msg *MsgLiquidStake) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	// validate amount is positive nonzero
+	if msg.Amount <= 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "amount liquid staked must be positive and nonzero")
+	}
 	return nil
 }

--- a/x/stakeibc/types/message_register_host_zone.go
+++ b/x/stakeibc/types/message_register_host_zone.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"strings"
 	"github.com/Stride-Labs/stride/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -50,5 +51,35 @@ func (msg *MsgRegisterHostZone) ValidateBasic() error {
 	if err := utils.ValidateWhitelistedAddress(msg.Creator); err != nil {
 		return err
 	}
+	// host denom cannot be empty
+	if msg.HostDenom == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "host denom cannot be empty")
+	}
+	// connection id cannot be empty and must begin with "connection"
+	if msg.ConnectionId == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "connection id cannot be empty")
+	}
+	if !strings.HasPrefix(msg.ConnectionId, "connection") {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "connection id must begin with 'connection'")
+	}
+	// ibc denom cannot be empty and must begin with "ibc"
+	if msg.IbcDenom == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "ibc denom cannot be empty")
+	}
+	if !strings.HasPrefix(msg.IbcDenom, "ibc") {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "ibc denom must begin with 'ibc'")
+	}
+	// transfer channel id cannot be empty and must begin with "transfer"
+	if msg.TransferChannelId == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "transfer channel id cannot be empty")
+	}
+	if !strings.HasPrefix(msg.TransferChannelId, "channel") {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "transfer channel id must begin with 'channel'")
+	}
+	// unbonding frequency must be positive nonzero
+	if msg.UnbondingFrequency < 1 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "unbonding frequency must be greater than zero")
+	}
+
 	return nil
 }

--- a/x/stakeibc/types/message_submit_tx.go
+++ b/x/stakeibc/types/message_submit_tx.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	fmt "fmt"
-
+	"strings"
 	"github.com/Stride-Labs/stride/utils"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -90,6 +90,10 @@ func (msg *MsgSubmitTx) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Owner)
 	if err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "invalid owner address")
+	}
+	// connectionid should not be empty and should begin with "connection"
+	if msg.ConnectionId == "" || !strings.HasPrefix(msg.ConnectionId, "connection") {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "invalid connection id (can't be empty and must begin with connection)")
 	}
 	if err := utils.ValidateWhitelistedAddress(msg.Owner); err != nil {
 		return err


### PR DESCRIPTION
**Summary**
Add some basic input checking to most the stakeibc functions, with particular emphasis on those exposed to the public

**Test plan**
Run through the expected testing flow:

Observe balances and records being updated live in scripts-local/logs/accounts.log. Build with
`make init-build build=sghi`
Once built, ibc some tokens from gaia to stride and register gaia's validator set with
`sh ./scripts-local/tests/1.sh`
Then liquid stake some tokens on gaia. We will 60s to allow them to be delegated on the host zone...
`sh ./scripts-local/tests/2.sh`
Liquid stake some more tokens. Anytime a new delegation is made after the first, accrued rewards are automatically claimed and compounding begins!
`sh ./scripts-local/tests/2.sh`
Now you might want to redeem some of your staked atom from the cosmos hub. To being unbonding to address cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf (you can choose where to unbond to with Stride), run
`sh ./scripts-local/tests/3.sh`
You'll see unbonding-delegations in accounts.log and their completion_time. Once the completion time elapses, the tokens will be available to transfer to the address specified when redemption was invoked. Run
`sh ./scripts-local/tests/4.sh`
You should see the balance of cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf increased! Everything is working as expected.

A few more things to look for in accounts.log:

The exchange rate should begin increasing (fairly rapidly) once rewards begin to compound
At the bottom of the logfile, you'll see records being created. This is a window into Stride's internal accounting system.