### PR TITLE
Local Mode Admin

### DIFF
--- a/scripts-local/init_gaia.sh
+++ b/scripts-local/init_gaia.sh
@@ -21,6 +21,8 @@ for NODE_NAME in gaia gaia2; do
     sed -i -E 's|"stake"|"uatom"|g' "${STATE}/${NODE_NAME}/config/genesis.json"
     sed -i -E 's|"full"|"validator"|g' "${STATE}/${NODE_NAME}/config/config.toml"
     sed -i -E "s|timeout_commit = \"5s\"|timeout_commit = \"${BLOCK_TIME}\"|g" "${STATE}/${NODE_NAME}/config/config.toml"
+    sed -i -E "s|chain-id = \"\"|chain-id = \"${GAIA_CHAIN}\"|g" "${STATE}/${NODE_NAME}/config/client.toml"
+    sed -i -E "s|keyring-backend = \"os\"|keyring-backend = \"test\"|g" "${STATE}/${NODE_NAME}/config/client.toml"
 done
 
 MAIN_NODE_ID=$($GAIA_CMD tendermint show-node-id)@localhost:$GAIA_PEER_PORT,
@@ -60,46 +62,46 @@ sed -i -E "s|persistent_peers = \"\"|persistent_peers = \"$MAIN_NODE_ID\"|g" "${
 mkdir $GAIA_HOME/config/gentx/
 
 # ============================== SETUP CHAIN 2 ======================================
-echo $GAIA_VAL_MNEMONIC_2 | $GAIA_CMD_2 keys add $GAIA_VAL_ACCT_2 --recover --keyring-backend=test 
+echo $GAIA_VAL_MNEMONIC_2 | $GAIA_CMD_2 keys add $GAIA_VAL_ACCT_2 --recover
 $GAIA_CMD_2 add-genesis-account $GAIA_VAL_2_ADDR 500000000000000uatom
 $GAIA_CMD add-genesis-account $GAIA_VAL_2_ADDR 500000000000000uatom
-$GAIA_CMD_2 gentx $GAIA_VAL_ACCT_2 1000000000uatom --chain-id $GAIA_CHAIN --keyring-backend test --output-document=$GAIA_HOME/config/gentx/gval2.json
+$GAIA_CMD_2 gentx $GAIA_VAL_ACCT_2 1000000000uatom --chain-id $GAIA_CHAIN --output-document=$GAIA_HOME/config/gentx/gval2.json
 
 # ============================== SETUP CHAIN 3 ======================================
-# echo $GAIA_VAL_MNEMONIC_3 | $GAIA_CMD_3 keys add $GAIA_VAL_ACCT_3 --recover --keyring-backend=test 
+# echo $GAIA_VAL_MNEMONIC_3 | $GAIA_CMD_3 keys add $GAIA_VAL_ACCT_3 --recover 
 # $GAIA_CMD_3 add-genesis-account $GAIA_VAL_3_ADDR 500000000000000uatom
 # $GAIA_CMD add-genesis-account $GAIA_VAL_3_ADDR 500000000000000uatom
-# $GAIA_CMD_3 gentx $GAIA_VAL_ACCT_3 1000000000uatom --chain-id $GAIA_CHAIN --keyring-backend test --output-document=$GAIA_HOME/config/gentx/gval3.json
+# $GAIA_CMD_3 gentx $GAIA_VAL_ACCT_3 1000000000uatom --output-document=$GAIA_HOME/config/gentx/gval3.json
 
 # set the unbonding time
 GAIA_CFG_TMP="${STATE}/${GAIA_NODE_NAME}/config/genesis.json"
 jq '.app_state.staking.params.unbonding_time = $newVal' --arg newVal "200s" $GAIA_CFG_TMP > json.tmp && mv json.tmp $GAIA_CFG_TMP
 
 # add validator account
-echo $GAIA_VAL_MNEMONIC | $GAIA_CMD keys add $GAIA_VAL_ACCT --recover --keyring-backend=test 
+echo $GAIA_VAL_MNEMONIC | $GAIA_CMD keys add $GAIA_VAL_ACCT --recover 
 # get validator address
-val_addr=$($GAIA_CMD keys show $GAIA_VAL_ACCT --keyring-backend test -a) > /dev/null
+val_addr=$($GAIA_CMD keys show $GAIA_VAL_ACCT -a) > /dev/null
 # add money for this validator account
 $GAIA_CMD add-genesis-account ${val_addr} 500000000000000uatom
 # actually set this account as a validator
-$GAIA_CMD gentx $GAIA_VAL_ACCT 1000000000uatom --chain-id $GAIA_CHAIN --keyring-backend test 2> /dev/null
+$GAIA_CMD gentx $GAIA_VAL_ACCT 1000000000uatom --chain-id $GAIA_CHAIN 2> /dev/null
 
 # Add hermes relayer account
-echo $HERMES_GAIA_MNEMONIC | $GAIA_CMD keys add $HERMES_GAIA_ACCT --recover --keyring-backend=test 
-HERMES_GAIA_ADDRESS=$($GAIA_CMD keys show $HERMES_GAIA_ACCT --keyring-backend test -a)
+echo $HERMES_GAIA_MNEMONIC | $GAIA_CMD keys add $HERMES_GAIA_ACCT --recover 
+HERMES_GAIA_ADDRESS=$($GAIA_CMD keys show $HERMES_GAIA_ACCT -a)
 # Give relayer account token balance
 $GAIA_CMD add-genesis-account ${HERMES_GAIA_ADDRESS} 5000000000000uatom
 
 # Add ICQ relayer account
-echo $ICQ_GAIA_MNEMONIC | $GAIA_CMD keys add $ICQ_GAIA_ACCT --recover --keyring-backend=test 
-ICQ_GAIA_ADDRESS=$($GAIA_CMD keys show $ICQ_GAIA_ACCT --keyring-backend test -a)
+echo $ICQ_GAIA_MNEMONIC | $GAIA_CMD keys add $ICQ_GAIA_ACCT --recover 
+ICQ_GAIA_ADDRESS=$($GAIA_CMD keys show $ICQ_GAIA_ACCT -a)
 # Give relayer account token balance
 $GAIA_CMD add-genesis-account ${ICQ_GAIA_ADDRESS} 5000000000000uatom
 
 # add revenue account
-echo $GAIA_REV_MNEMONIC | $GAIA_CMD keys add $GAIA_REV_ACCT --recover --keyring-backend=test 
+echo $GAIA_REV_MNEMONIC | $GAIA_CMD keys add $GAIA_REV_ACCT --recover 
 # get revenue address
-rev_addr=$($GAIA_CMD keys show $GAIA_REV_ACCT --keyring-backend test -a) > /dev/null
+rev_addr=$($GAIA_CMD keys show $GAIA_REV_ACCT -a) > /dev/null
 
 # Collect genesis transactions
 $GAIA_CMD collect-gentxs 2> /dev/null

--- a/scripts-local/init_stride.sh
+++ b/scripts-local/init_stride.sh
@@ -14,41 +14,46 @@ echo 'Initializing stride state...'
 
 # initialize the chain
 $STRIDE_CMD init test --chain-id $STRIDE_CHAIN --overwrite 2> /dev/null
-# change the denom
-sed -i -E 's|"stake"|"ustrd"|g' "${STATE}/${STRIDE_NODE_NAME}/config/genesis.json"
-sed -i -E "s|timeout_commit = \"5s\"|timeout_commit = \"${BLOCK_TIME}\"|g" "${STATE}/${STRIDE_NODE_NAME}/config/config.toml"
-sed -i -E "s|cors_allowed_origins = \[\]|cors_allowed_origins = [\"\*\"]|g" "${STATE}/${STRIDE_NODE_NAME}/config/config.toml"
-# modify Stride epoch to be 3s
-main_config=$STATE/$STRIDE_NODE_NAME/config/genesis.json
-# NOTE: If you add new epochs, these indexes will need to be updated
-jq '.app_state.epochs.epochs[$epochIndex].duration = $epochLen' --arg epochLen $DAY_EPOCH_LEN --argjson epochIndex $DAY_EPOCH_INDEX  $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.epochs.epochs[$epochIndex].duration = $epochLen' --arg epochLen $STRIDE_EPOCH_LEN --argjson epochIndex $STRIDE_EPOCH_INDEX $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.stakeibc.params.rewards_interval = $interval' --arg interval $INTERVAL_LEN $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.stakeibc.params.delegate_interval = $interval' --arg interval $INTERVAL_LEN $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.stakeibc.params.deposit_interval = $interval' --arg interval $INTERVAL_LEN $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.stakeibc.params.redemption_rate_interval = $interval' --arg interval $INTERVAL_LEN $main_config > json.tmp && mv json.tmp $main_config
-jq '.app_state.stakeibc.params.reinvest_interval = $interval' --arg interval $INTERVAL_LEN $main_config > json.tmp && mv json.tmp $main_config
 
+genesis_config="$STATE/${STRIDE_NODE_NAME}/config/genesis.json"
+configtoml="${STATE}/${STRIDE_NODE_NAME}/config/config.toml"
+clienttoml="${STATE}/${STRIDE_NODE_NAME}/config/client.toml"
+# change the denom
+sed -i -E 's|"stake"|"ustrd"|g' $genesis_config
+sed -i -E "s|timeout_commit = \"5s\"|timeout_commit = \"${BLOCK_TIME}\"|g" $configtoml
+sed -i -E "s|cors_allowed_origins = \[\]|cors_allowed_origins = [\"\*\"]|g" $configtoml
+# modify Stride epoch to be 3s
+# NOTE: If you add new epochs, these indexes will need to be updated
+jq '.app_state.epochs.epochs[$epochIndex].duration = $epochLen' --arg epochLen $DAY_EPOCH_LEN --argjson epochIndex $DAY_EPOCH_INDEX  $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.epochs.epochs[$epochIndex].duration = $epochLen' --arg epochLen $STRIDE_EPOCH_LEN --argjson epochIndex $STRIDE_EPOCH_INDEX $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.stakeibc.params.rewards_interval = $interval' --arg interval $INTERVAL_LEN $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.stakeibc.params.delegate_interval = $interval' --arg interval $INTERVAL_LEN $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.stakeibc.params.deposit_interval = $interval' --arg interval $INTERVAL_LEN $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.stakeibc.params.redemption_rate_interval = $interval' --arg interval $INTERVAL_LEN $genesis_config > json.tmp && mv json.tmp $genesis_config
+jq '.app_state.stakeibc.params.reinvest_interval = $interval' --arg interval $INTERVAL_LEN $genesis_config > json.tmp && mv json.tmp $genesis_config
+# update the client config
+sed -i -E "s|chain-id = \"\"|chain-id = \"${STRIDE_CHAIN}\"|g" $clienttoml
+sed -i -E "s|keyring-backend = \"os\"|keyring-backend = \"test\"|g" $clienttoml
 # add validator account
-echo $STRIDE_VAL_MNEMONIC | $STRIDE_CMD keys add $STRIDE_VAL_ACCT --recover --keyring-backend=test 
+echo $STRIDE_VAL_MNEMONIC | $STRIDE_CMD keys add $STRIDE_VAL_ACCT --recover 
 # get validator address
-val_addr=$($STRIDE_CMD keys show $STRIDE_VAL_ACCT --keyring-backend test -a) > /dev/null
+val_addr=$($STRIDE_CMD keys show $STRIDE_VAL_ACCT -a) > /dev/null
 # add money for this validator account
 $STRIDE_CMD add-genesis-account ${val_addr} 500000000000ustrd
 # actually set this account as a validator
-$STRIDE_CMD gentx $STRIDE_VAL_ACCT 1000000000ustrd --chain-id $STRIDE_CHAIN --keyring-backend test 2> /dev/null
+$STRIDE_CMD gentx $STRIDE_VAL_ACCT 1000000000ustrd --chain-id $STRIDE_CHAIN 2> /dev/null
 
 # source $SCRIPT_DIR/genesis.sh
 
 # Add hermes relayer account
-echo $HERMES_STRIDE_MNEMONIC | $STRIDE_CMD keys add $HERMES_STRIDE_ACCT --recover --keyring-backend=test 
-HERMES_STRIDE_ADDRESS=$($STRIDE_CMD keys show $HERMES_STRIDE_ACCT --keyring-backend test -a)
+echo $HERMES_STRIDE_MNEMONIC | $STRIDE_CMD keys add $HERMES_STRIDE_ACCT --recover
+HERMES_STRIDE_ADDRESS=$($STRIDE_CMD keys show $HERMES_STRIDE_ACCT -a)
 # Give relayer account token balance
 $STRIDE_CMD add-genesis-account ${HERMES_STRIDE_ADDRESS} 500000000000ustrd
 
 # Add ICQ relayer account
-echo $ICQ_STRIDE_MNEMONIC | $STRIDE_CMD keys add $ICQ_STRIDE_ACCT --recover --keyring-backend=test 
-ICQ_STRIDE_ADDRESS=$($STRIDE_CMD keys show $ICQ_STRIDE_ACCT --keyring-backend test -a)
+echo $ICQ_STRIDE_MNEMONIC | $STRIDE_CMD keys add $ICQ_STRIDE_ACCT --recover
+ICQ_STRIDE_ADDRESS=$($STRIDE_CMD keys show $ICQ_STRIDE_ACCT -a)
 # Give relayer account token balance
 $STRIDE_CMD add-genesis-account ${ICQ_STRIDE_ADDRESS} 500000000000ustrd
 

--- a/scripts-local/register_host.sh
+++ b/scripts-local/register_host.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $SCRIPT_DIR/vars.sh
+
+if [ -z ${STRIDE_ADMIN_MNEMONIC+x} ]; then
+    echo "ERROR: STRIDE_ADMIN_MNEMONIC must be set as an environment variable in order to register a host zone."
+    exit 1
+fi
+
+# Add stride admin to keychain
+STRIDE_ADMIN_ACCT=admin
+echo $STRIDE_ADMIN_MNEMONIC | $STRIDE_CMD keys add $STRIDE_ADMIN_ACCT --recover &> /dev/null
+
+echo "Funding stride admin account..."
+STRIDE_ADMIN_ADDRESS=$($STRIDE_CMD keys show $STRIDE_ADMIN_ACCT -a) 
+$STRIDE_CMD tx bank send $STRIDE_VAL_ADDR $STRIDE_ADMIN_ADDRESS 10000000ustrd --from $STRIDE_VAL_ACCT -y
+sleep 10
+
+# Submit a transaction on stride to register the gaia host zone
+printf "\nCreating host zone...\n"
+$STRIDE_CMD tx stakeibc register-host-zone \
+    connection-0 $ATOM_DENOM cosmos $IBC_ATOM_DENOM channel-0 1 \
+    --home $STATE/stride --from $STRIDE_ADMIN_ACCT --gas 1000000 -y
+
+# sleep a while longer to wait for ICA accounts to set up
+sleep 60
+
+printf "\nRegistering validators on host zone...\n"
+CSLEEP 10
+$GAIA_CMD tx bank send gval1 $GAIA_VAL_2_ADDR 10000uatom -y
+CSLEEP 10
+$GAIA_CMD tx bank send gval1 $GAIA_VAL_3_ADDR 10000uatom -y
+
+CSLEEP 10
+$STRIDE_CMD tx stakeibc add-validator GAIA gval1 $GAIA_DELEGATE_VAL 10 5 --from $STRIDE_ADMIN_ACCT -y
+CSLEEP 30
+$STRIDE_CMD tx stakeibc add-validator GAIA gval2 $GAIA_DELEGATE_VAL_2 10 10 --from $STRIDE_ADMIN_ACCT -y
+CSLEEP 30
+
+echo "Done"

--- a/scripts-local/start_network.sh
+++ b/scripts-local/start_network.sh
@@ -2,10 +2,7 @@
 
 set -eu
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-
 source $SCRIPT_DIR/vars.sh
-
 
 mkdir -p $SCRIPT_DIR/logs
 
@@ -89,29 +86,8 @@ rm -rf $SCRIPT_DIR/.state.backup
 cp -r $SCRIPT_DIR/state $SCRIPT_DIR/.state.backup
 
 if [ "$CACHE" != "true" ]; then
-    # Submit a transaction on stride to register the gaia host zone
-    echo "Creating host zone..."
-    $STRIDE_CMD tx stakeibc register-host-zone \
-        connection-0 $ATOM_DENOM cosmos $IBC_ATOM_DENOM channel-0 1 \
-        --chain-id $STRIDE_CHAIN --home $STATE/stride \
-        --keyring-backend test --from $STRIDE_VAL_ACCT --gas 1000000 -y
+    bash $SCRIPT_DIR/register_host.sh
 fi
-# sleep a while longer to wait for ICA accounts to set up
-sleep 60
-
-echo "Registering validators on host zone..."
-
-CSLEEP 10
-$GAIA_CMD tx bank send gval1 $GAIA_VAL_2_ADDR 10000uatom --chain-id $GAIA_CHAIN --keyring-backend test -y
-CSLEEP 10
-$GAIA_CMD tx bank send gval1 $GAIA_VAL_3_ADDR 10000uatom --chain-id $GAIA_CHAIN --keyring-backend test -y
-
-CSLEEP 10
-$STRIDE_CMD tx stakeibc add-validator GAIA gval1 $GAIA_DELEGATE_VAL 10 5 --chain-id $STRIDE_CHAIN --keyring-backend test --from $STRIDE_VAL_ACCT -y
-CSLEEP 30
-$STRIDE_CMD tx stakeibc add-validator GAIA gval2 $GAIA_DELEGATE_VAL_2 10 10 --chain-id $STRIDE_CHAIN --keyring-backend test --from $STRIDE_VAL_ACCT -y
-CSLEEP 30
-
 
 # Add more detailed log files
 $SCRIPT_DIR/create_logs.sh &

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 var ADMINS = map[string]bool{
-	"stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7": true, // stride 1
+	"stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8": true, // stride localnet
 	"stride159atdlc3ksl50g0659w5tq42wwer334ajl7xnq": true, // stride testnet
 	"stride10d07y265gmmuvt4z0w9aw880jnsr700jefnezl": true, // gov module
 }

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -274,7 +274,8 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 			// TODO(TEST-90): why do we have two gaia LCs?
 			blockHeight, found := k.GetLightClientHeightSafely(ctx, hostZone.ConnectionId)
 			if !found {
-				k.Logger(ctx).Error(fmt.Sprintf("Could not find blockHeight for host zone %s, aborting transfers to host zone this epoch", hostZone.ConnectionId))				continue
+				k.Logger(ctx).Error(fmt.Sprintf("Could not find blockHeight for host zone %s, aborting transfers to host zone this epoch", hostZone.ConnectionId))
+				continue
 			} else {
 				k.Logger(ctx).Info(fmt.Sprintf("Found blockHeight for host zone %s: %d", hostZone.ConnectionId, blockHeight))
 			}


### PR DESCRIPTION
## Summary
* Created local mode admin key. Mnemonic must be set in the zshrc with `export STRIDE_ADMIN_MNEMONIC='seed phrase here ...'`. 
 
I still think there's a better way we could do this, but I think this is marginally better than the constant comment/uncomment approach. Let's try and think of something better by launch.
* Moved post-chain startup logic to separate script (e.g. register host zone, create validators)
* Updated the client configs for local mode so we don't have to specify the chain-id and keyring-backend in every command
* **Question for y'all**: Does it make more sense to have a separate address for local mode or should we re-use the testnet one?