### PR TITLE
ignore tendermint, ibc-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
+
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "github.com/tendermint/tendermint"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    - dependency-name: "github.com/cosmos/ibc-go"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  open-pull-requests-limit: 10


### PR DESCRIPTION
**Summary**
Dependabot shouldn't bump tendermint / ibc-go 
https://github.com/Stride-Labs/stride/pull/117

**Test plan**
