### PR TITLE
IBC-02 | Missing Important Validation Step

### DIFF
--- a/x/stakeibc/keeper/ibc_handlers.go
+++ b/x/stakeibc/keeper/ibc_handlers.go
@@ -364,7 +364,8 @@ func (k Keeper) HandleUndelegate(ctx sdk.Context, msg sdk.Msg, completionTime ti
 
 	
 	undelegateAmt := undelegateMsg.Amount.Amount.Int64()
-	if undelegateAmt < 0 {
+	if undelegateAmt <= 0 {
+
 		return sdkerrors.Wrapf(sdkerrors.ErrLogic, "Undelegate amount was negative")
 	}
 	success := k.AddDelegationToValidator(ctx, *zone, undelegateMsg.ValidatorAddress, -undelegateAmt)

--- a/x/stakeibc/keeper/ibc_handlers.go
+++ b/x/stakeibc/keeper/ibc_handlers.go
@@ -365,8 +365,7 @@ func (k Keeper) HandleUndelegate(ctx sdk.Context, msg sdk.Msg, completionTime ti
 	
 	undelegateAmt := undelegateMsg.Amount.Amount.Int64()
 	if undelegateAmt <= 0 {
-
-		return sdkerrors.Wrapf(sdkerrors.ErrLogic, "Undelegate amount was negative")
+		return sdkerrors.Wrapf(sdkerrors.ErrLogic, "Undelegate amount must be positive")
 	}
 	success := k.AddDelegationToValidator(ctx, *zone, undelegateMsg.ValidatorAddress, -undelegateAmt)
 	if !success {

--- a/x/stakeibc/keeper/ibc_handlers.go
+++ b/x/stakeibc/keeper/ibc_handlers.go
@@ -362,7 +362,11 @@ func (k Keeper) HandleUndelegate(ctx sdk.Context, msg sdk.Msg, completionTime ti
 		return sdkerrors.Wrapf(sdkerrors.ErrLogic, "Undelegate message was not for a delegation account")
 	}
 
+	
 	undelegateAmt := undelegateMsg.Amount.Amount.Int64()
+	if undelegateAmt < 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrLogic, "Undelegate amount was negative")
+	}
 	success := k.AddDelegationToValidator(ctx, *zone, undelegateMsg.ValidatorAddress, -undelegateAmt)
 	if !success {
 		return sdkerrors.Wrapf(types.ErrValidatorDelegationChg, "Failed to add delegation to validator")


### PR DESCRIPTION
## What is the purpose of the change

Add validation step to ibc handler

> In L227 in file x/stakeibc/keeper/ibc_handler.go, epochUnbondingRecord.Id is used to compared to the dayEpochTracker.EpochNumber. According to the design, it should be variable epochUnbondingRecord.UnbondingEpochNumber rather than epochUnbondingRecord.Id


## Brief Changelog

- Check that `undelegateAmt` is g.t. 0


## Testing and Verifying

- CI

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no 
  - How is the feature or change documented? audit
