### PR TITLE
UNB-01 | Incorrect `if` Condition

### DIFF
--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -198,7 +198,7 @@ func (k Keeper) SweepAllUnbondedTokens(ctx sdk.Context) {
 			shouldProcess := (unbonding.Status == recordstypes.HostZoneUnbonding_PENDING_TRANSFER || unbonding.Status == recordstypes.HostZoneUnbonding_UNBONDED)
 			// if the unbonding period has elapsed, then we can send the ICA call to sweep this hostZone's unbondings to the rewards account (in a batch)
 			k.Logger(ctx).Info(fmt.Sprintf("\tUnbonding time:  %d blockTime %d", unbonding.UnbondingTime, blockTime))
-			if unbonding.UnbondingTime < blockTime && shouldProcess {
+			if (unbonding.UnbondingTime < blockTime) && shouldProcess {
 				// we have a match, so we can process this unbonding
 				k.Logger(ctx).Info(fmt.Sprintf("\t\tAdding %d to amt to batch transfer from delegation acct to rewards acct for host zone %s", unbonding.Amount, zone.ChainId))
 				totalAmtTransferToRedemptionAcct += unbonding.Amount

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -195,14 +195,10 @@ func (k Keeper) SweepAllUnbondedTokens(ctx sdk.Context) {
 				return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "\t\tCould not find blockTime for host zone")
 			}
 
-			if (unbonding.Status != recordstypes.HostZoneUnbonding_UNBONDED) &&
-				(unbonding.Status != recordstypes.HostZoneUnbonding_PENDING_TRANSFER) {
-				continue
-			}
-
+			shouldProcess := (unbonding.Status == recordstypes.HostZoneUnbonding_PENDING_TRANSFER || unbonding.Status == recordstypes.HostZoneUnbonding_UNBONDED)
 			// if the unbonding period has elapsed, then we can send the ICA call to sweep this hostZone's unbondings to the rewards account (in a batch)
 			k.Logger(ctx).Info(fmt.Sprintf("\tUnbonding time:  %d blockTime %d", unbonding.UnbondingTime, blockTime))
-			if unbonding.UnbondingTime < blockTime {
+			if unbonding.UnbondingTime < blockTime && shouldProcess {
 				// we have a match, so we can process this unbonding
 				k.Logger(ctx).Info(fmt.Sprintf("\t\tAdding %d to amt to batch transfer from delegation acct to rewards acct for host zone %s", unbonding.Amount, zone.ChainId))
 				totalAmtTransferToRedemptionAcct += unbonding.Amount


### PR DESCRIPTION
## What is the purpose of the change

When the unbonding.Status is recordstypes.HostZoneUnbonding_PENDING_TRANSFER, the logic in the linked position will processing continues as well, so the code on line 210 will change to a status that unbonding.Status already was.


## Brief Changelog

- Make logic more readable


## Testing and Verifying

CI

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? audit report