### PR TITLE
HOS-02 : registerHostZone duplicate denom check

### DIFF
--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -29,6 +29,14 @@ func (k Keeper) RegisterHostZone(goCtx context.Context, msg *types.MsgRegisterHo
 		return nil, fmt.Errorf("invalid chain id, zone for \"%s\" already registered", chainId)
 	}
 
+	// check the denom is not already registered
+	hostZones := k.GetAllHostZone(ctx)
+	for _, hostZone := range hostZones {
+		if hostZone.HostDenom == msg.HostDenom {
+			return nil, fmt.Errorf("host denom \"%s\" already registered", msg.HostDenom)
+		}
+	}
+
 	// set the zone
 	zone := types.HostZone{
 		ChainId:           chainId,

--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -35,6 +35,12 @@ func (k Keeper) RegisterHostZone(goCtx context.Context, msg *types.MsgRegisterHo
 		if hostZone.HostDenom == msg.HostDenom {
 			return nil, fmt.Errorf("host denom \"%s\" already registered", msg.HostDenom)
 		}
+		if hostZone.ConnectionId == msg.ConnectionId {
+			return nil, fmt.Errorf("connectionId \"%s\" already registered", msg.HostDenom)
+		}
+		if hostZone.Bech32Prefix == msg.Bech32Prefix {
+			return nil, fmt.Errorf("host denom \"%s\" already registered", msg.HostDenom)
+		}
 	}
 
 	// set the zone


### PR DESCRIPTION
## What is the purpose of the change

> The only place hostZones are created is in msg_register_host_zone, so we check for already-existing hostZones with the same denom as that which is being registered. If one is found, we error

## Brief Changelog

  - Add the check in `x/stakeibc/keeper/msg_server_register_host_zone.go`.


## Testing and Verifying
Run the integration and unit tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? audit