### PR TITLE
The dead discord link has been replaced with my new invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can learn more about the install process [here](https://github.com/allinbits
 - [Tutorials](https://docs.starport.com/guide)
 - [Starport docs](https://docs.starport.com)
 - [Cosmos SDK docs](https://docs.cosmos.network)
-- [Developer Chat](https://discord.gg/npKnCK4q)
+- [Developer Chat](https://stride.zone/discord)
 
 ### Developing on Stride
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can learn more about the install process [here](https://github.com/allinbits
 - [Tutorials](https://docs.starport.com/guide)
 - [Starport docs](https://docs.starport.com)
 - [Cosmos SDK docs](https://docs.cosmos.network)
-- [Developer Chat](https://discord.gg/H6wGTY8sxw)
+- [Developer Chat](https://discord.gg/npKnCK4q)
 
 ### Developing on Stride
 


### PR DESCRIPTION

## You published PoolParty Bounty Tasks

>As  Adversarial Tasks 1 "find a bug in [stride's core repo](https://github.com/Stride-Labs/stride) (must be a non-trivial bug)"

*I think that I found. Maybe I can clear that line...
