### PR TITLE
TEST-25: Mint params updated

### DIFF
--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	epochtypes "github.com/Stride-Labs/stride/x/epochs/types"
 	yaml "gopkg.in/yaml.v2"
+
+	epochtypes "github.com/Stride-Labs/stride/x/epochs/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -45,19 +46,19 @@ func NewParams(
 	}
 }
 
-// TODO(TEST-25) default minting module parameters.
+// minting params
 func DefaultParams() Params {
 	return Params{
 		MintDenom:               sdk.DefaultBondDenom,
-		GenesisEpochProvisions:  sdk.NewDec(5000000 / 3),
-		EpochIdentifier:         "day",                    // 1 day
-		ReductionPeriodInEpochs: 365,                      // 1 years
-		ReductionFactor:         sdk.NewDecWithPrec(5, 1), // 0.75
+		GenesisEpochProvisions:  sdk.NewDec(6_700_000).QuoInt64(365),
+		EpochIdentifier:         "day",                     // 1 day
+		ReductionPeriodInEpochs: 365,                       // 1 years
+		ReductionFactor:         sdk.NewDec(3).QuoInt64(4), // 3/4
 		DistributionProportions: DistributionProportions{
-			Staking:              sdk.NewDecWithPrec(5, 1), // 0.5
-			PoolIncentives:       sdk.NewDecWithPrec(0, 1), // 0
-			ParticipationRewards: sdk.NewDecWithPrec(2, 1), // 0.2
-			CommunityPool:        sdk.NewDecWithPrec(3, 1), // 0.3
+			Staking:              sdk.MustNewDecFromStr("1.0"), // 1
+			PoolIncentives:       sdk.MustNewDecFromStr("0.0"), // 0
+			ParticipationRewards: sdk.MustNewDecFromStr("0.0"), // 0
+			CommunityPool:        sdk.MustNewDecFromStr("0.0"), // 0
 		},
 		MintingRewardsDistributionStartEpoch: 0,
 	}

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -55,10 +55,10 @@ func DefaultParams() Params {
 		ReductionPeriodInEpochs: 365,                       // 1 years
 		ReductionFactor:         sdk.NewDec(3).QuoInt64(4), // 3/4
 		DistributionProportions: DistributionProportions{
-			Staking:              sdk.MustNewDecFromStr("1.0"), // 1
+			Staking:              sdk.MustNewDecFromStr("0.9"), // 1
 			PoolIncentives:       sdk.MustNewDecFromStr("0.0"), // 0
 			ParticipationRewards: sdk.MustNewDecFromStr("0.0"), // 0
-			CommunityPool:        sdk.MustNewDecFromStr("0.0"), // 0
+			CommunityPool:        sdk.MustNewDecFromStr("0.1"), // 0
 		},
 		MintingRewardsDistributionStartEpoch: 0,
 	}


### PR DESCRIPTION
## What is the purpose of the change

This pull request sets minting parameters aligned with Stride tokenomics

## Brief Changelog

 Updated mint params in `x/mint/types/params.go`.

## Testing and Verifying
This change is a trivial rework / code cleanup without any test coverage.
To verify the new mint params flow through, please build the chain and check:
```
❯ strided-local q mint params
distribution_proportions:
  community_pool: "0.000000000000000000"
  participation_rewards: "0.000000000000000000"
  pool_incentives: "0.000000000000000000"
  staking: "1.000000000000000000"
epoch_identifier: day
genesis_epoch_provisions: "18356.164383561643835616"
mint_denom: ustrd
minting_rewards_distribution_start_epoch: "0"
reduction_factor: "0.750000000000000000"
reduction_period_in_epochs: "365"
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? tokenomics google sheet