### PR TITLE
IBC Refund to Module Account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -426,6 +426,7 @@ func NewStrideApp(
 		app.GetSubspace(recordsmoduletypes.ModuleName),
 		scopedRecordsKeeper,
 		app.AccountKeeper,
+		app.BankKeeper,
 	)
 	recordsModule := recordsmodule.NewAppModule(appCodec, app.RecordsKeeper, app.AccountKeeper, app.BankKeeper)
 

--- a/scripts/tests/1.sh
+++ b/scripts/tests/1.sh
@@ -6,6 +6,6 @@ STRIDE_ADDRESS="stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7"
 
 #  ibc over atoms to stride
 $GAIA1_EXEC tx ibc-transfer transfer transfer channel-0 $STRIDE_ADDRESS 100000uatom --from gval1 --chain-id GAIA -y --keyring-backend test
-SLEEP 5
+SLEEP 20
 $STR1_EXEC q bank balances $STRIDE_ADDRESS
 

--- a/x/records/keeper/keeper.go
+++ b/x/records/keeper/keeper.go
@@ -5,23 +5,26 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/Stride-Labs/stride/x/records/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/Stride-Labs/stride/x/records/types"
 )
 
 type (
 	Keeper struct {
 		// *cosmosibckeeper.Keeper
-		Cdc          codec.BinaryCodec
-		storeKey     sdk.StoreKey
-		memKey       sdk.StoreKey
-		paramstore   paramtypes.Subspace
-		scopedKeeper capabilitykeeper.ScopedKeeper
+		Cdc           codec.BinaryCodec
+		storeKey      sdk.StoreKey
+		memKey        sdk.StoreKey
+		paramstore    paramtypes.Subspace
+		scopedKeeper  capabilitykeeper.ScopedKeeper
 		AccountKeeper types.AccountKeeper
+		BankKeeper    bankkeeper.Keeper
 	}
 )
 
@@ -32,7 +35,7 @@ func NewKeeper(
 	ps paramtypes.Subspace,
 	scopedKeeper capabilitykeeper.ScopedKeeper,
 	AccountKeeper types.AccountKeeper,
-
+	BankKeeper bankkeeper.Keeper,
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -40,12 +43,13 @@ func NewKeeper(
 	}
 
 	return &Keeper{
-		Cdc:          Cdc,
-		storeKey:     storeKey,
-		memKey:       memKey,
-		paramstore:   ps,
-		scopedKeeper: scopedKeeper,
+		Cdc:           Cdc,
+		storeKey:      storeKey,
+		memKey:        memKey,
+		paramstore:    ps,
+		scopedKeeper:  scopedKeeper,
 		AccountKeeper: AccountKeeper,
+		BankKeeper:    BankKeeper,
 	}
 }
 

--- a/x/records/module_ibc.go
+++ b/x/records/module_ibc.go
@@ -223,20 +223,7 @@ func (im IBCModule) OnTimeoutPacket(
 	relayer sdk.AccAddress,
 ) error {
 	// doCustomLogic(packet)
-	fmt.Println("IN ON TIMEOUT PACKET RECORDS")
-	moduleAddress := im.keeper.AccountKeeper.GetModuleAddress(stakeibctypes.ModuleName)
-	fmt.Println("ModuleAddress", moduleAddress.String())
-	fmt.Println("Address matches", moduleAddress.String() == "stride1mvdq4nlupl39243qjz7sds5ez3rl9mnx253lza")
-
-	gaiaBalance := im.keeper.BankKeeper.GetBalance(ctx, moduleAddress, "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2")
-	fmt.Println("GAIA BALANCE BEFORE:", gaiaBalance)
-
-	// err := im.app.OnTimeoutPacket(ctx, packet, relayer)
-	err := im.ICS_20_module_patch_OnTimeoutPacket(ctx, packet, relayer)
-
-	gaiaBalance = im.keeper.BankKeeper.GetBalance(ctx, moduleAddress, "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2")
-	fmt.Println("GAIA BALANCE AFTER:", gaiaBalance)
-	return err
+	return im.ICS_20_module_patch_OnTimeoutPacket(ctx, packet, relayer)
 }
 
 // Wrapper for the refundPacketToken patch

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -248,7 +248,7 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 	transferDepositRecords := utils.FilterDepositRecords(depositRecords, func(record recordstypes.DepositRecord) (condition bool) {
 		return record.Status == recordstypes.DepositRecord_TRANSFER
 	})
-	// ibcTimeoutBlocks := cast.ToUint64(k.GetParam(ctx, types.KeyIbcTimeoutBlocks))
+	ibcTimeoutBlocks := cast.ToUint64(k.GetParam(ctx, types.KeyIbcTimeoutBlocks))
 	addr := k.accountKeeper.GetModuleAccount(ctx, types.ModuleName).GetAddress().String()
 	var emptyRecords []uint64
 	for _, depositRecord := range transferDepositRecords {
@@ -282,13 +282,9 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 			} else {
 				k.Logger(ctx).Info(fmt.Sprintf("Found blockHeight for host zone %s: %d", hostZone.ConnectionId, blockHeight))
 			}
-			timeoutHeight := clienttypes.NewHeight(0, cast.ToUint64(blockHeight)+1)
+			timeoutHeight := clienttypes.NewHeight(0, cast.ToUint64(blockHeight)+ibcTimeoutBlocks)
 			transferCoin := sdk.NewCoin(hostZone.GetIBCDenom(), sdk.NewInt(int64(depositRecord.Amount)))
 			goCtx := sdk.WrapSDKContext(ctx)
-
-			a, _ := sdk.AccAddressFromBech32("stride1mvdq4nlupl39243qjz7sds5ez3rl9mnx253lza")
-			gaiaBalance := k.bankKeeper.GetBalance(ctx, a, "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2")
-			fmt.Println("GAIA BALANCE BEFORE TRANSFER:", gaiaBalance)
 
 			msg := ibctypes.NewMsgTransfer("transfer", hostZone.TransferChannelId, transferCoin, addr, delegateAddress, timeoutHeight, 0)
 			k.Logger(ctx).Info("TransferExistingDepositsToHostZones msg:", msg)

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -248,7 +248,7 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 	transferDepositRecords := utils.FilterDepositRecords(depositRecords, func(record recordstypes.DepositRecord) (condition bool) {
 		return record.Status == recordstypes.DepositRecord_TRANSFER
 	})
-	ibcTimeoutBlocks := cast.ToUint64(k.GetParam(ctx, types.KeyIbcTimeoutBlocks))
+	// ibcTimeoutBlocks := cast.ToUint64(k.GetParam(ctx, types.KeyIbcTimeoutBlocks))
 	addr := k.accountKeeper.GetModuleAccount(ctx, types.ModuleName).GetAddress().String()
 	var emptyRecords []uint64
 	for _, depositRecord := range transferDepositRecords {
@@ -282,9 +282,13 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 			} else {
 				k.Logger(ctx).Info(fmt.Sprintf("Found blockHeight for host zone %s: %d", hostZone.ConnectionId, blockHeight))
 			}
-			timeoutHeight := clienttypes.NewHeight(0, cast.ToUint64(blockHeight)+ibcTimeoutBlocks)
+			timeoutHeight := clienttypes.NewHeight(0, cast.ToUint64(blockHeight)+1)
 			transferCoin := sdk.NewCoin(hostZone.GetIBCDenom(), sdk.NewInt(int64(depositRecord.Amount)))
 			goCtx := sdk.WrapSDKContext(ctx)
+
+			a, _ := sdk.AccAddressFromBech32("stride1mvdq4nlupl39243qjz7sds5ez3rl9mnx253lza")
+			gaiaBalance := k.bankKeeper.GetBalance(ctx, a, "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2")
+			fmt.Println("GAIA BALANCE BEFORE TRANSFER:", gaiaBalance)
 
 			msg := ibctypes.NewMsgTransfer("transfer", hostZone.TransferChannelId, transferCoin, addr, delegateAddress, timeoutHeight, 0)
 			k.Logger(ctx).Info("TransferExistingDepositsToHostZones msg:", msg)


### PR DESCRIPTION
## What is the purpose of the change
* The refund function in IBC Transfer's `OnTimeoutPacket` will panic if trying to refund to a module account
* This is because it tries to send the transfer directly to the module's address, and the module's address is blacklisted in the bank keeper from receiving funds 
* The solution is to process the refund using the `SendCoinsFromModuleToModule` function, rather than `SendCoinsFromAccountToModule`

## Brief Changelog
- Added patches for `OnTimeoutPacket` and `refundPacketToken` to the records IBC Module
- Added bank keeper as attribute in records keeper

## Testing and Verifying
  - *Manually verified the change by ...*
  - Forced a delegation transfer to timeout and verified the following:
    - Before any additional code changes, there was a panic message in hermes and the balance of the module account did not change after the timeout
    - After the code change there was no panic and the balance changed in accordance with the refund
    - Feel free to revert to commit 3e88a9de59788b6e99aac7401a37baf65abc4a00 to test it yourself. Start in local mode, issue a liquid stake and view stride and hermes logs
    - Additionally, to test the refund still succeeds for a non-module address, I added an epochly transfer (hard coded in hooks) directly from one of the validator accounts with a balance log before and after the transfer. Witnessed the validator's balance decrease immediately following the transfer command, yet be replenished come next epoch (because it was refunded).

## Documentation and Release Note
  - Does this pull request introduce a new feature or user-facing behavior changes? **no**
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? **no**
  - How is the feature or change documented? TEST-160 

