### PR TITLE
Revert "Revert "HOS-01 | Lack of Sanity Check - Remove Validator""

### DIFF
--- a/x/stakeibc/keeper/host_zone.go
+++ b/x/stakeibc/keeper/host_zone.go
@@ -125,12 +125,18 @@ func (k Keeper) RemoveValidatorFromHostZone(ctx sdk.Context, chainId string, val
 	}
 	for i, val := range hostZone.Validators {
 		if val.GetAddress() == validatorAddress {
-			hostZone.Validators = append(hostZone.Validators[:i], hostZone.Validators[i+1:]...)
-			return true
+			if val.GetDelegationAmt() == 0 && val.GetWeight() == 0 {
+				hostZone.Validators = append(hostZone.Validators[:i], hostZone.Validators[i+1:]...)
+				return true
+			} else {
+				k.Logger(ctx).Error(fmt.Sprintf("Validator %s has non-zero delegation (%d) or weight (%d)", validatorAddress, val.GetDelegationAmt(), val.GetWeight()))
+
+				return false
+			}
 		}
 	}
 	k.SetHostZone(ctx, hostZone)
-	k.Logger(ctx).Error(fmt.Sprintf("Validator %s not found on Host Zone %s", validatorAddress, chainId))
+	k.Logger(ctx).Error(fmt.Sprintf("Validator %s not found on the host zone %s", validatorAddress, chainId))
 	return false
 }
 

--- a/x/stakeibc/keeper/msg_server_delete_validator.go
+++ b/x/stakeibc/keeper/msg_server_delete_validator.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Stride-Labs/stride/x/stakeibc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Stride-Labs/stride/x/stakeibc/types"
 )
 
 func (k msgServer) DeleteValidator(goCtx context.Context, msg *types.MsgDeleteValidator) (*types.MsgDeleteValidatorResponse, error) {
@@ -13,8 +14,8 @@ func (k msgServer) DeleteValidator(goCtx context.Context, msg *types.MsgDeleteVa
 
 	validatorRemoved := k.RemoveValidatorFromHostZone(ctx, msg.HostZone, msg.ValAddr)
 	if !validatorRemoved {
-		k.Logger(ctx).Error(fmt.Sprintf("Validator %s not found in host zone %s", msg.ValAddr, msg.HostZone))
-		return nil, types.ErrValidatorNotFound
+		k.Logger(ctx).Error(fmt.Sprintf("Validator %s not removed from the host zone %s", msg.ValAddr, msg.HostZone))
+		return nil, types.ErrValidatorNotRemoved
 	}
 
 	return &types.MsgDeleteValidatorResponse{}, nil

--- a/x/stakeibc/keeper/validator_selection.go
+++ b/x/stakeibc/keeper/validator_selection.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cast"
@@ -46,6 +47,13 @@ func (k Keeper) GetTargetValAmtsForHostZone(ctx sdk.Context, hostZone types.Host
 	}
 	targetAmount := make(map[string]uint64)
 	allocatedAmt := uint64(0)
+
+	// sort validators by weight ascending
+	validators := hostZone.GetValidators()
+	sort.Slice(validators, func(i, j int) bool {
+		return validators[i].Weight < validators[j].Weight
+	})
+
 	for i, validator := range hostZone.Validators {
 		if i == len(hostZone.Validators)-1 {
 			// for the last element, we need to make sure that the allocatedAmt is equal to the finalDelegation

--- a/x/stakeibc/types/errors.go
+++ b/x/stakeibc/types/errors.go
@@ -27,5 +27,6 @@ var (
 	ErrInvalidUserRedemptionRecord = sdkerrors.Register(ModuleName, 1515, "user redemption record error")
 	ErrRequiredFieldEmpty          = sdkerrors.Register(ModuleName, 1516, "required field is missing")
 	ErrInvalidNumValidator         = sdkerrors.Register(ModuleName, 1517, "invalid number of validators")
+	ErrValidatorNotRemoved         = sdkerrors.Register(ModuleName, 1518, "validator not removed")
 	ErrHostZoneNotFound            = sdkerrors.Register(ModuleName, 1519, "host zone not found")
 )


### PR DESCRIPTION
adds back https://github.com/Stride-Labs/stride/pull/139

## What is the purpose of the change
When removing a validator with non-zero delegation amount from the set, those funds will be stranded until we re-add this validator.

## Brief Changelog

- ensure that Validator.DelegationAmt and Validator.Weight is ZERO before removing the target validator from a host zone.
- when rebalanding validators, sort ascending to avoid last-validator precision amount issue. See this example code: https://go.dev/play/p/3Zd_cVKZVyU

## Testing and verifying

CI + integration

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? audit