### PR TITLE
update gosec

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v3
       - name: Run Gosec Security Scanner
-        uses: informalsystems/gosec@master
+        uses: informalsystems/gosec@v0.0.2
         with:
           args: -exclude-dir=deps -severity=high ./...

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v3
       - name: Run Gosec Security Scanner
-        uses: informalsystems/gosec@v0.0.2
+        uses: securego/gosec@master
         with:
           args: -exclude-dir=deps -severity=high ./...

--- a/app/app.go
+++ b/app/app.go
@@ -265,6 +265,7 @@ type StrideApp struct {
 	configurator module.Configurator
 }
 
+// RUN GOSEC
 // New returns a reference to an initialized blockchain app
 func NewStrideApp(
 	logger log.Logger,


### PR DESCRIPTION
## What is the purpose of the change

The informalsystems/gosec docker image was removed for some reason.

evmos is also failing: https://github.com/evmos/evmos/pull/827
opened an issue in the informal repo: https://github.com/informalsystems/gosec/issues/32

This PR switches us over to standard gosec (temporarily). 

## Brief Changelog

CI
