### PR TITLE
Fix logging

### DIFF
--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -214,16 +214,15 @@ func (k Keeper) StakeExistingDepositsOnHostZones(ctx sdk.Context, epochNumber in
 	})
 	for _, depositRecord := range stakeDepositRecords {
 		if depositRecord.DepositEpochNumber < cast.ToUint64(epochNumber) {
-			pstr := fmt.Sprintf("\t[StakeExistingDepositsOnHostZones] Processing deposit ID:{%d} DENOM:{%s} AMT:{%d}", depositRecord.Id, depositRecord.Denom, depositRecord.Amount)
-			k.Logger(ctx).Info(pstr)
+			k.Logger(ctx).Info(fmt.Sprintf("\t[StakeExistingDepositsOnHostZones] Processing deposit ID:{%d} DENOM:{%s} AMT:{%d}", depositRecord.Id, depositRecord.Denom, depositRecord.Amount))
 			hostZone, hostZoneFound := k.GetHostZone(ctx, depositRecord.HostZoneId)
 			if !hostZoneFound {
-				k.Logger(ctx).Error("[StakeExistingDepositsOnHostZones] Host zone not found for deposit record {%d}", depositRecord.Id)
+				k.Logger(ctx).Error(fmt.Sprintf("[StakeExistingDepositsOnHostZones] Host zone not found for deposit record {%d}", depositRecord.Id))
 				continue
 			}
 			delegateAccount := hostZone.GetDelegationAccount()
 			if delegateAccount == nil || delegateAccount.GetAddress() == "" {
-				k.Logger(ctx).Error("[StakeExistingDepositsOnHostZones] Zone %s is missing a delegation address!", hostZone.ChainId)
+				k.Logger(ctx).Error(fmt.Sprintf("[StakeExistingDepositsOnHostZones] Zone %s is missing a delegation address!", hostZone.ChainId))
 				continue
 			}
 			k.Logger(ctx).Info(fmt.Sprintf("\tdelegation staking on %s", hostZone.HostDenom))
@@ -262,8 +261,7 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 	var emptyRecords []uint64
 	for _, depositRecord := range transferDepositRecords {
 		if depositRecord.DepositEpochNumber < cast.ToUint64(epochNumber) {
-			pstr := fmt.Sprintf("\t[TransferExistingDepositsToHostZones] Processing deposits {%d} {%s} {%d}", depositRecord.Id, depositRecord.Denom, depositRecord.Amount)
-			k.Logger(ctx).Info(pstr)
+			k.Logger(ctx).Info(fmt.Sprintf("\t[TransferExistingDepositsToHostZones] Processing deposits {%d} {%s} {%d}", depositRecord.Id, depositRecord.Denom, depositRecord.Amount))
 
 			// skip empty records
 			if depositRecord.Amount <= 0 {
@@ -274,12 +272,12 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 
 			hostZone, hostZoneFound := k.GetHostZone(ctx, depositRecord.HostZoneId)
 			if !hostZoneFound {
-				k.Logger(ctx).Error("[TransferExistingDepositsToHostZones] Host zone not found for deposit record {%d}", depositRecord.Id)
+				k.Logger(ctx).Error(fmt.Sprintf("[TransferExistingDepositsToHostZones] Host zone not found for deposit record {%d}", depositRecord.Id))
 				continue
 			}
 			delegateAccount := hostZone.GetDelegationAccount()
 			if delegateAccount == nil || delegateAccount.GetAddress() == "" {
-				k.Logger(ctx).Error("[TransferExistingDepositsToHostZones] Zone %s is missing a delegation address!", hostZone.ChainId)
+				k.Logger(ctx).Error(fmt.Sprintf("[TransferExistingDepositsToHostZones] Zone %s is missing a delegation address!", hostZone.ChainId))
 				continue
 			}
 			delegateAddress := delegateAccount.GetAddress()

--- a/x/stakeibc/keeper/ibc_handlers.go
+++ b/x/stakeibc/keeper/ibc_handlers.go
@@ -49,7 +49,7 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 			}
 			record, found := k.RecordsKeeper.GetUserRedemptionRecord(ctx, userRedemptionRecordKey)
 			if !found {
-				k.Logger(ctx).Error("failed to get user redemption record from key %s", userRedemptionRecordKey)
+				k.Logger(ctx).Error(fmt.Sprintf("failed to get user redemption record from key %s", userRedemptionRecordKey))
 				return err
 			}
 			record.IsClaimable = true
@@ -63,30 +63,30 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 					sdk.NewAttribute(types.AttributeKeyAckError, ackErr.Error),
 				),
 			)
-			k.Logger(ctx).Error("Unable to unmarshal acknowledgement error", "error", err, "data", acknowledgement)
+			k.Logger(ctx).Error(fmt.Sprintf("Unable to unmarshal acknowledgement error: %s, data: %s", err.Error(), acknowledgement))
 			return err
 		}
-		k.Logger(ctx).Error("Unable to unmarshal acknowledgement result", "error", err, "remote_err", ackErr, "data", acknowledgement)
+		k.Logger(ctx).Error(fmt.Sprintf("Unable to unmarshal acknowledgement result, error: %s, remote_err: %v, data: %v", err.Error(), ackErr, acknowledgement))
 		return err
 	}
 
 	txMsgData := &sdk.TxMsgData{}
 	err = proto.Unmarshal(ack.Result, txMsgData)
 	if err != nil {
-		k.Logger(ctx).Error("Unable to unmarshal acknowledgement", "error", err, "ack", ack.Result)
+		k.Logger(ctx).Error(fmt.Sprintf("Unable to unmarshal acknowledgement, error: %s, ack result: %v", err, ack.Result))
 		return err
 	}
 
 	var packetData icatypes.InterchainAccountPacketData
 	err = icatypes.ModuleCdc.UnmarshalJSON(modulePacket.GetData(), &packetData)
 	if err != nil {
-		k.Logger(ctx).Error("unable to unmarshal acknowledgement packet data", "error", err, "data", packetData)
+		k.Logger(ctx).Error(fmt.Sprintf("unable to unmarshal acknowledgement packet data, error: %s, data: %s", err, packetData))
 		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())
 	}
 
 	msgs, err := icatypes.DeserializeCosmosTx(k.cdc, packetData.Data)
 	if err != nil {
-		k.Logger(ctx).Error("unable to decode messages", "err", err)
+		k.Logger(ctx).Error(fmt.Sprintf("unable to decode messages, err: %s", err))
 		return err
 	}
 
@@ -101,7 +101,7 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 			response := stakingtypes.MsgDelegateResponse{}
 			err := proto.Unmarshal(msgData.Data, &response)
 			if err != nil {
-				k.Logger(ctx).Error("unable to unmarshal MsgDelegate response", "error", err)
+				k.Logger(ctx).Error(fmt.Sprintf("unable to unmarshal MsgDelegate response, error: %s", err))
 				return err
 			}
 			delegateMsg, ok := src.(*stakingtypes.MsgDelegate)
@@ -124,7 +124,7 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 				k.Logger(ctx).Error("unable to unmarshal MsgDelegate response", "error", err)
 				return err
 			}
-			k.Logger(ctx).Info("Delegated", "response", response)
+			k.Logger(ctx).Info(fmt.Sprintf("Delegated response: %v", response))
 			// we should update delegation records here.
 			recordIdToDelete, err = k.HandleDelegate(ctx, src, totalMsgDelegate)
 			if err != nil {
@@ -136,10 +136,10 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 			response := stakingtypes.MsgUndelegateResponse{}
 			err := proto.Unmarshal(msgData.Data, &response)
 			if err != nil {
-				k.Logger(ctx).Error("Unable to unmarshal MsgUndelegate response", "error", err)
+				k.Logger(ctx).Error(fmt.Sprintf("Unable to unmarshal MsgUndelegate response, error: %s", err.Error()))
 				return err
 			}
-			k.Logger(ctx).Info("Undelegated", "response", response)
+			k.Logger(ctx).Info(fmt.Sprintf("Undelegated response: %v", response))
 			// we should update delegation records here.
 			if err := k.HandleUndelegate(ctx, src, response.CompletionTime); err != nil {
 				return err
@@ -153,10 +153,10 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 			response := banktypes.MsgSendResponse{}
 			err := proto.Unmarshal(msgData.Data, &response)
 			if err != nil {
-				k.Logger(ctx).Error("unable to unmarshal MsgSend response", "error", err)
+				k.Logger(ctx).Error(fmt.Sprintf("unable to unmarshal MsgSend response, error: %s", err.Error()))
 				return err
 			}
-			k.Logger(ctx).Info("Sent", "response", response)
+			k.Logger(ctx).Info(fmt.Sprintf("Sent response: %v", response))
 
 			// we should update delegation records here.
 			if err := k.HandleSend(ctx, src, packetSequenceKey); err != nil {
@@ -167,13 +167,13 @@ func (k Keeper) HandleAcknowledgement(ctx sdk.Context, modulePacket channeltypes
 			response := distributiontypes.MsgSetWithdrawAddressResponse{}
 			err := proto.Unmarshal(msgData.Data, &response)
 			if err != nil {
-				k.Logger(ctx).Error("unable to unmarshal MsgSend response", "error", err)
+				k.Logger(ctx).Error(fmt.Sprintf("unable to unmarshal MsgSend response, error: %s", err.Error()))
 				return err
 			}
-			k.Logger(ctx).Info("WithdrawalAddress set", "response", response)
+			k.Logger(ctx).Info(fmt.Sprintf("WithdrawalAddress set response: %v", response))
 			continue
 		default:
-			k.Logger(ctx).Error("Unhandled acknowledgement packet", "type", msgData.MsgType)
+			k.Logger(ctx).Error(fmt.Sprintf("Unhandled acknowledgement packet type: %v", msgData.MsgType))
 		}
 	}
 
@@ -252,7 +252,7 @@ func (k *Keeper) HandleSend(ctx sdk.Context, msg sdk.Msg, sequence string) error
 			// NOTE: at the beginning of the epoch we mark all PENDING_TRANSFER HostZoneUnbondingRecords as UNBONDED
 			// so that they're retried if the transfer fails
 			if hostZoneUnbonding.Status != recordstypes.HostZoneUnbonding_PENDING_TRANSFER {
-				k.Logger(ctx).Error("hostZoneUnbonding.Status != recordstypes.HostZoneUnbonding_PENDING_TRANSFER")
+				k.Logger(ctx).Error(fmt.Sprintf("hostZoneUnbonding.Status != recordstypes.HostZoneUnbonding_PENDING_TRANSFER (%v)", hostZoneUnbonding.Status))
 				continue
 			}
 			hostZoneUnbonding.Status = recordstypes.HostZoneUnbonding_TRANSFERRED

--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -61,28 +61,28 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	// NOTE: in the future, if we implement proxy governance, we'll need many more delegate accounts
 	delegateAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_DELEGATION)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, delegateAccount); err != nil {
-		k.Logger(ctx).Error("unable to register delegate account", "error", err)
+		k.Logger(ctx).Error(fmt.Sprintf("unable to register delegate account, err: %s", err.Error()))
 		return nil, err
 	}
 
 	// generate fee account
 	feeAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_FEE)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, feeAccount); err != nil {
-		k.Logger(ctx).Error("unable to register fee account", "error", err)
+		k.Logger(ctx).Error(fmt.Sprintf("unable to register fee account, err: %s", err.Error()))
 		return nil, err
 	}
 
 	// generate withdrawal account
 	withdrawalAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_WITHDRAWAL)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, withdrawalAccount); err != nil {
-		k.Logger(ctx).Error("unable to register withdrawal account", "error", err)
+		k.Logger(ctx).Error("unable to register withdrawal account, err: %s", err.Error())
 		return nil, err
 	}
 
 	// generate redemption account
 	redemptionAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_REDEMPTION)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, redemptionAccount); err != nil {
-		k.Logger(ctx).Error("unable to register redemption account", "error", err)
+		k.Logger(ctx).Error(fmt.Sprintf("unable to register redemption account, err: %s", err.Error()))
 		return nil, err
 	}
 

--- a/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -128,12 +128,12 @@ func (k Keeper) SetWithdrawalAddressOnHost(ctx sdk.Context, hostZone types.HostZ
 	// Fetch the relevant ICA
 	delegationIca := hostZone.GetDelegationAccount()
 	if delegationIca == nil || delegationIca.Address == "" {
-		k.Logger(ctx).Error("Zone %s is missing a delegation address!", hostZone.ChainId)
+		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a delegation address!", hostZone.ChainId))
 		return nil
 	}
 	withdrawalIca := hostZone.GetWithdrawalAccount()
 	if withdrawalIca == nil || withdrawalIca.Address == "" {
-		k.Logger(ctx).Error("Zone %s is missing a withdrawal address!", hostZone.ChainId)
+		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a withdrawal address!", hostZone.ChainId))
 		return nil
 	}
 	withdrawalIcaAddr := hostZone.GetWithdrawalAccount().GetAddress()
@@ -155,14 +155,14 @@ func (k Keeper) UpdateWithdrawalBalance(ctx sdk.Context, zoneInfo types.HostZone
 
 	withdrawalIca := zoneInfo.GetWithdrawalAccount()
 	if withdrawalIca == nil || withdrawalIca.Address == "" {
-		k.Logger(ctx).Error("Zone %s is missing a withdrawal address!", zoneInfo.ChainId)
+		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a withdrawal address!", zoneInfo.ChainId))
 	}
 	k.Logger(ctx).Info(fmt.Sprintf("\tQuerying withdrawalBalances for %s", zoneInfo.ChainId))
 
 	_, addr, _ := bech32.DecodeAndConvert(withdrawalIca.GetAddress())
 	data := bankTypes.CreateAccountBalancesPrefix(addr)
 	key := "store/bank/key"
-	k.Logger(ctx).Info("Querying for value", "key", key, "denom", zoneInfo.HostDenom)
+	k.Logger(ctx).Info(fmt.Sprintf("Querying for value key: %s, denom: %s", key, zoneInfo.HostDenom))
 	err := k.InterchainQueryKeeper.MakeRequest(
 		ctx,
 		zoneInfo.ConnectionId,
@@ -176,7 +176,7 @@ func (k Keeper) UpdateWithdrawalBalance(ctx sdk.Context, zoneInfo types.HostZone
 		0, // height always 0 (which means current height)
 	)
 	if err != nil {
-		k.Logger(ctx).Error("Error querying for withdrawal balance", "error", err)
+		k.Logger(ctx).Error(fmt.Sprintf("Error querying for withdrawal balance, error: %s", err.Error()))
 		return err
 	}
 	return nil
@@ -204,7 +204,7 @@ func (k Keeper) SubmitTxsEpoch(ctx sdk.Context, connectionId string, msgs []sdk.
 	k.Logger(ctx).Info(fmt.Sprintf("SubmitTxsEpoch: %v", msgs))
 	epochTracker, found := k.GetEpochTracker(ctx, epochType)
 	if !found {
-		k.Logger(ctx).Error("Failed to get epoch tracker for %s", epochType)
+		k.Logger(ctx).Error(fmt.Sprintf("Failed to get epoch tracker for %s", epochType))
 		return 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "Failed to get epoch tracker for %s", epochType)
 	}
 	// BUFFER by 5% of the epoch length
@@ -216,7 +216,7 @@ func (k Keeper) SubmitTxsEpoch(ctx sdk.Context, connectionId string, msgs []sdk.
 	if err != nil {
 		return 0, err
 	}
-	k.Logger(ctx).Info("Submitted Txs", "connectionId", connectionId, "sequence", sequence)
+	k.Logger(ctx).Info(fmt.Sprintf("Submitted Txs, connectionId: %s, sequence: %d", connectionId, sequence))
 	return sequence, nil
 }
 


### PR DESCRIPTION
## What is the purpose of the change

The logger throws an error if a string is formatted incorrectly (e.g. Logger.Info("This should be an int: %s", 1)). This pollutes our error logs, a better pattern to enforce is to use `k.Logger(ctx).Info(fmt.Sprintf("... %s", stringToLog))`


## Brief Changelog

- Update logging to use `Sprintf` throughout the codebase

## Testing and Verifying

**Before**
run the following command with an account that has a 0 balance
```
```
this outputs the following transaction hash
```
```
which, when queried, shows this (unhelpful) error

**After**
run the same command with a 0 balance, then query the transaction hash

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? na
