### PR TITLE
Test Rebalance Validators

### DIFF
--- a/scripts-local/init_gaia.sh
+++ b/scripts-local/init_gaia.sh
@@ -65,7 +65,7 @@ mkdir $GAIA_HOME/config/gentx/
 echo $GAIA_VAL_MNEMONIC_2 | $GAIA_CMD_2 keys add $GAIA_VAL_ACCT_2 --recover --keyring-backend=test >> $KEYS_LOGS 2>&1 &
 $GAIA_CMD_2 add-genesis-account $GAIA_VAL_2_ADDR 500000000000000uatom
 $GAIA_CMD add-genesis-account $GAIA_VAL_2_ADDR 500000000000000uatom
-$GAIA_CMD_2 gentx $GAIA_VAL_ACCT_2 1000000uatom --chain-id $GAIA_CHAIN --output-document=$GAIA_HOME/config/gentx/gval2.json
+$GAIA_CMD_2 gentx $GAIA_VAL_ACCT_2 300000000000000uatom --chain-id $GAIA_CHAIN --output-document=$GAIA_HOME/config/gentx/gval2.json
 
 # ============================== SETUP CHAIN 3 ======================================
 # echo $GAIA_VAL_MNEMONIC_3 | $GAIA_CMD_3 keys add $GAIA_VAL_ACCT_3 --recover --keyring-backend=test >> $KEYS_LOGS 2>&1 &

--- a/scripts-local/init_juno.sh
+++ b/scripts-local/init_juno.sh
@@ -68,7 +68,7 @@ rev_addr=$($JUNO_CMD keys show $JUNO_REV_ACCT --keyring-backend test -a) > /dev/
 $JUNO_CMD collect-gentxs 2> /dev/null
 
 ## add the message types ICA should allow to the host chain
-ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
+ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgBeginRedelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
 sed -i -E "s|\"allow_messages\": \[\]|\"allow_messages\": \[${ALLOW_MESSAGES}\]|g" "${STATE}/${JUNO_NODE_NAME}/config/genesis.json"
 
 # Update ports so they don't conflict with the stride chain

--- a/scripts-local/init_juno.sh
+++ b/scripts-local/init_juno.sh
@@ -45,7 +45,7 @@ val_addr=$($JUNO_CMD keys show $JUNO_VAL_ACCT --keyring-backend test -a) > /dev/
 # add money for this validator account
 $JUNO_CMD add-genesis-account ${val_addr} 500000000000000ujuno
 # actually set this account as a validator
-$JUNO_CMD gentx $JUNO_VAL_ACCT 1000000ujuno --chain-id $JUNO_CHAIN --keyring-backend test 2> /dev/null
+$JUNO_CMD gentx $JUNO_VAL_ACCT 300000000000000ujuno --chain-id $JUNO_CHAIN --keyring-backend test 2> /dev/null
 
 # Add hermes relayer account
 echo $HERMES_JUNO_MNEMONIC | $JUNO_CMD keys add $HERMES_JUNO_ACCT --recover --keyring-backend=test >> $KEYS_LOGS 2>&1 

--- a/scripts-local/init_osmo.sh
+++ b/scripts-local/init_osmo.sh
@@ -77,7 +77,7 @@ rev_addr=$($OSMO_CMD keys show $OSMO_REV_ACCT --keyring-backend test -a) > /dev/
 $OSMO_CMD collect-gentxs 2> /dev/null
 
 ## add the message types ICA should allow to the host chain
-ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
+ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgBeginRedelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
 sed -i -E "s|\"allow_messages\": \[\]|\"allow_messages\": \[${ALLOW_MESSAGES}\]|g" "${STATE}/${OSMO_NODE_NAME}/config/genesis.json"
 
 # Update ports so they don't conflict with the stride chain

--- a/scripts-local/init_osmo.sh
+++ b/scripts-local/init_osmo.sh
@@ -49,7 +49,7 @@ val_addr=$($OSMO_CMD keys show $OSMO_VAL_ACCT --keyring-backend test -a) > /dev/
 # add money for this validator account
 $OSMO_CMD add-genesis-account ${val_addr} 500000000000000uosmo
 # actually set this account as a validator
-$OSMO_CMD gentx $OSMO_VAL_ACCT 1000000uosmo --chain-id $OSMO_CHAIN --keyring-backend test 2> /dev/null
+$OSMO_CMD gentx $OSMO_VAL_ACCT 300000000000000uosmo --chain-id $OSMO_CHAIN --keyring-backend test 2> /dev/null
 
 # Add hermes relayer account
 echo $HERMES_OSMO_MNEMONIC | $OSMO_CMD keys add $HERMES_OSMO_ACCT --recover --keyring-backend=test >> $KEYS_LOGS 2>&1 

--- a/scripts/init_gaia.sh
+++ b/scripts/init_gaia.sh
@@ -74,7 +74,7 @@ for i in ${!GAIA_NODE_NAMES[@]}; do
 done
 
 ## add the message types ICA should allow to the host chain
-ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
+ALLOW_MESSAGES='\"/cosmos.bank.v1beta1.MsgSend\", \"/cosmos.bank.v1beta1.MsgMultiSend\", \"/cosmos.staking.v1beta1.MsgDelegate\", \"/cosmos.staking.v1beta1.MsgUndelegate\", \"/cosmos.staking.v1beta1.MsgBeginRedelegate\", \"/cosmos.staking.v1beta1.MsgRedeemTokensforShares\", \"/cosmos.staking.v1beta1.MsgTokenizeShares\", \"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward\", \"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress\", \"/ibc.applications.transfer.v1.MsgTransfer\"'
 sed -i -E "s|\"allow_messages\": \[\]|\"allow_messages\": \[${ALLOW_MESSAGES}\]|g" "${STATE}/${GAIA_MAIN_NODE}/config/genesis.json"
 
 

--- a/x/stakeibc/client/cli/tx_rebalance_validators.go
+++ b/x/stakeibc/client/cli/tx_rebalance_validators.go
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 
 func CmdRebalanceValidators() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rebalance-validators [host-zone]",
+		Use:   "rebalance-validators [host-zone] [num-to-rebalance]",
 		Short: "Broadcast message rebalanceValidators",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/x/stakeibc/keeper/msg_server_rebalance_validators.go
+++ b/x/stakeibc/keeper/msg_server_rebalance_validators.go
@@ -3,14 +3,11 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/spf13/cast"
 
-	"github.com/Stride-Labs/stride/utils"
 	"github.com/Stride-Labs/stride/x/stakeibc/types"
 )
 
@@ -43,113 +40,131 @@ func (k msgServer) RebalanceValidators(goCtx context.Context, msg *types.MsgReba
 		k.Logger(ctx).Error(fmt.Sprintf("Host Zone not found %s", msg.HostZone))
 		return nil, types.ErrInvalidHostZone
 	}
-	maxNumRebalance := cast.ToInt(msg.NumRebalance)
-	if maxNumRebalance < 1 {
-		k.Logger(ctx).Error(fmt.Sprintf("Invalid number of validators to rebalance %d", maxNumRebalance))
-		return nil, types.ErrNoValidatorWeights
-	}
+	// maxNumRebalance := cast.ToInt(msg.NumRebalance)
+	// if maxNumRebalance < 1 {
+	// 	k.Logger(ctx).Error(fmt.Sprintf("Invalid number of validators to rebalance %d", maxNumRebalance))
+	// 	return nil, types.ErrNoValidatorWeights
+	// }
 
-	validatorDeltas, err := k.GetValidatorDelegationAmtDifferences(ctx, hostZone)
-	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("Error getting validator deltas for Host Zone %s: %s", hostZone.ChainId, err))
-		return nil, err
-	}
+	// validatorDeltas, err := k.GetValidatorDelegationAmtDifferences(ctx, hostZone)
+	// if err != nil {
+	// 	k.Logger(ctx).Error(fmt.Sprintf("Error getting validator deltas for Host Zone %s: %s", hostZone.ChainId, err))
+	// 	return nil, err
+	// }
 
-	// we convert the above map into a list of tuples
-	type valPair struct {
-		deltaAmt int64
-		valAddr  sdk.ValAddress
-	}
-	valDeltaList := make([]valPair, 0)
-	for _, valAddr := range utils.StringToIntMapKeys(validatorDeltas) {
-		deltaAmt := validatorDeltas[valAddr]
-		k.Logger(ctx).Info(fmt.Sprintf("Adding deltaAmt: %d to validator: %s", deltaAmt, valAddr))
-		valDeltaList = append(valDeltaList, valPair{deltaAmt, sdk.ValAddress(valAddr)})
-	}
-	// now we sort that list
-	lessFunc := func(i, j int) bool {
-		return valDeltaList[i].deltaAmt < valDeltaList[j].deltaAmt
-	}
-	sort.Slice(valDeltaList, lessFunc)
-	// now varDeltaList is sorted by deltaAmt
-	overWeightIndex := 0
-	underWeightIndex := len(valDeltaList) - 1
+	// // we convert the above map into a list of tuples
+	// type valPair struct {
+	// 	deltaAmt int64
+	// 	valAddr  string
+	// }
+	// valDeltaList := make([]valPair, 0)
+	// for _, valAddr := range utils.StringToIntMapKeys(validatorDeltas) {
+	// 	deltaAmt := validatorDeltas[valAddr]
+	// 	k.Logger(ctx).Info(fmt.Sprintf("Adding deltaAmt: %d to validator: %s", deltaAmt, valAddr))
+	// 	valDeltaList = append(valDeltaList, valPair{deltaAmt, valAddr})
+	// }
+	// // now we sort that list
+	// lessFunc := func(i, j int) bool {
+	// 	return valDeltaList[i].deltaAmt < valDeltaList[j].deltaAmt
+	// }
+	// sort.Slice(valDeltaList, lessFunc)
+	// // now varDeltaList is sorted by deltaAmt
+	// overWeightIndex := 0
+	// underWeightIndex := len(valDeltaList) - 1
 
-	// check if there is a large enough rebalance, if not, just exit
-	total_delegation := float64(k.GetTotalValidatorDelegations(hostZone))
-	overweight_delta := floatabs(float64(valDeltaList[overWeightIndex].deltaAmt) / total_delegation)
-	underweight_delta := floatabs(float64(valDeltaList[underWeightIndex].deltaAmt) / total_delegation)
-	max_delta := floatmax(overweight_delta, underweight_delta)
-	rebalanceThreshold := float64(k.GetParam(ctx, types.KeyValidatorRebalancingThreshold)) / float64(10000)
-	if max_delta < rebalanceThreshold {
-		k.Logger(ctx).Error("Not enough validator disruption to rebalance")
-		return nil, types.ErrNoValidatorWeights
-	}
+	// // check if there is a large enough rebalance, if not, just exit
+	// total_delegation := float64(k.GetTotalValidatorDelegations(hostZone))
+	// overweight_delta := floatabs(float64(valDeltaList[overWeightIndex].deltaAmt) / total_delegation)
+	// underweight_delta := floatabs(float64(valDeltaList[underWeightIndex].deltaAmt) / total_delegation)
+	// max_delta := floatmax(overweight_delta, underweight_delta)
+	// rebalanceThreshold := float64(k.GetParam(ctx, types.KeyValidatorRebalancingThreshold)) / float64(10000)
+	// if max_delta < rebalanceThreshold {
+	// 	k.Logger(ctx).Error("Not enough validator disruption to rebalance")
+	// 	return nil, types.ErrNoValidatorWeights
+	// }
 
+	// var msgs []sdk.Msg
+	// delegationIca := hostZone.GetDelegationAccount()
+	// if delegationIca == nil || delegationIca.GetAddress() == "" {
+	// 	k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a delegation address!", hostZone.ChainId))
+	// 	return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid delegation account")
+	// }
+
+	// delegatorAddressStr := delegationIca.GetAddress()
+
+	// for i := 1; i < maxNumRebalance; i++ {
+	// 	underWeightElem := valDeltaList[underWeightIndex]
+	// 	overWeightElem := valDeltaList[overWeightIndex]
+	// 	if underWeightElem.deltaAmt < 0 {
+	// 		// if underWeightElem is negative, we're done rebalancing
+	// 		break
+	// 	}
+	// 	if overWeightElem.deltaAmt > 0 {
+	// 		// if overWeightElem is positive, we're done rebalancing
+	// 		break
+	// 	}
+	// 	if abs(underWeightElem.deltaAmt) > abs(overWeightElem.deltaAmt) {
+	// 		// if the underweight element is more off than the overweight element
+	// 		// we transfer stake from the underweight element to the overweight element
+	// 		underWeightElem.deltaAmt -= abs(overWeightElem.deltaAmt)
+	// 		overWeightIndex += 1
+	// 		// issue an ICA call to the host zone to rebalance the validator
+	// 		redelegateMsg := stakingTypes.MsgBeginRedelegate{
+	// 			DelegatorAddress:    delegatorAddressStr,
+	// 			ValidatorSrcAddress: overWeightElem.valAddr,
+	// 			ValidatorDstAddress: underWeightElem.valAddr,
+	// 			Amount:              sdk.NewInt64Coin(hostZone.HostDenom, abs(overWeightElem.deltaAmt)),
+	// 		}
+	// 		msgs = append(msgs, &redelegateMsg)
+	// 		k.Logger(ctx).Info(fmt.Sprintf("Rebalancing validators, case 1, with msg %v", msgs))
+	// 		overWeightElem.deltaAmt = 0
+	// 	} else if abs(underWeightElem.deltaAmt) < abs(overWeightElem.deltaAmt) {
+	// 		// if the overweight element is more overweight than the underweight element
+	// 		overWeightElem.deltaAmt += underWeightElem.deltaAmt
+	// 		underWeightIndex -= 1
+	// 		// issue an ICA call to the host zone to rebalance the validator
+	// 		redelegateMsg := stakingTypes.MsgBeginRedelegate{
+	// 			DelegatorAddress:    delegatorAddressStr,
+	// 			ValidatorSrcAddress: overWeightElem.valAddr,
+	// 			ValidatorDstAddress: underWeightElem.valAddr,
+	// 			Amount:              sdk.NewInt64Coin(hostZone.HostDenom, abs(underWeightElem.deltaAmt)),
+	// 		}
+	// 		msgs = append(msgs, &redelegateMsg)
+	// 		k.Logger(ctx).Info(fmt.Sprintf("Rebalancing validators, case 2, with msg %v", msgs))
+	// 		underWeightElem.deltaAmt = 0
+	// 	} else {
+	// 		// if the two elements are equal, we increment both slices
+	// 		underWeightIndex -= 1
+	// 		overWeightIndex += 1
+	// 		// issue an ICA call to the host zone to rebalance the validator
+	// 		redelegateMsg := stakingTypes.MsgBeginRedelegate{
+	// 			DelegatorAddress:    delegatorAddressStr,
+	// 			ValidatorSrcAddress: underWeightElem.valAddr,
+	// 			ValidatorDstAddress: overWeightElem.valAddr,
+	// 			Amount:              sdk.NewInt64Coin(hostZone.HostDenom, abs(underWeightElem.deltaAmt)),
+	// 		}
+	// 		k.Logger(ctx).Info(fmt.Sprintf("Rebalancing validators, case 3, with msg %v", msgs))
+	// 		msgs = append(msgs, &redelegateMsg)
+	// 		overWeightElem.deltaAmt = 0
+	// 		underWeightElem.deltaAmt = 0
+	// 	}
+	// }
+	// k.Logger(ctx).Info(fmt.Sprintf("Rebalancing validators with msg %v", msgs))
+
+	// ===========================
 	var msgs []sdk.Msg
-	delegationIca := hostZone.GetDelegationAccount()
-	if delegationIca == nil || delegationIca.GetAddress() == "" {
-		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a delegation address!", hostZone.ChainId))
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid delegation account")
-	}
+	msgs = append(msgs, &stakingTypes.MsgBeginRedelegate{
+		DelegatorAddress:    "cosmos1sy63lffevueudvvlvh2lf6s387xh9xq72n3fsy6n2gr5hm6u2szs2v0ujm",
+		ValidatorSrcAddress: "cosmosvaloper1pcag0cj4ttxg8l7pcg0q4ksuglswuuedadj7ne",
+		ValidatorDstAddress: "cosmosvaloper133lfs9gcpxqj6er3kx605e3v9lqp2pg5syhvsz",
+		Amount:              sdk.NewInt64Coin(hostZone.HostDenom, abs(10)),
+	})
+	k.Logger(ctx).Info(fmt.Sprintf("Rebalancing validators with msg %v", msgs))
 
-	delegatorAddressStr := delegationIca.GetAddress()
-	delegatorAddress := sdk.AccAddress(delegatorAddressStr)
-
-	for i := 1; i < maxNumRebalance; i++ {
-		underWeightElem := valDeltaList[underWeightIndex]
-		overWeightElem := valDeltaList[overWeightIndex]
-		if underWeightElem.deltaAmt < 0 {
-			// if underWeightElem is negative, we're done rebalancing
-			break
-		}
-		if overWeightElem.deltaAmt > 0 {
-			// if overWeightElem is positive, we're done rebalancing
-			break
-		}
-		if abs(underWeightElem.deltaAmt) > abs(overWeightElem.deltaAmt) {
-			// if the underweight element is more off than the overweight element
-			// we transfer stake from the underweight element to the overweight element
-			underWeightElem.deltaAmt -= abs(overWeightElem.deltaAmt)
-			overWeightIndex += 1
-			// issue an ICA call to the host zone to rebalance the validator
-			redelagateMsg := stakingTypes.NewMsgBeginRedelegate(
-				delegatorAddress,
-				overWeightElem.valAddr,
-				underWeightElem.valAddr,
-				sdk.NewInt64Coin(hostZone.HostDenom, abs(overWeightElem.deltaAmt)))
-			msgs = append(msgs, redelagateMsg)
-			overWeightElem.deltaAmt = 0
-		} else if abs(underWeightElem.deltaAmt) < abs(overWeightElem.deltaAmt) {
-			// if the overweight element is more overweight than the underweight element
-			overWeightElem.deltaAmt += underWeightElem.deltaAmt
-			underWeightIndex -= 1
-			// issue an ICA call to the host zone to rebalance the validator
-			redelagateMsg := stakingTypes.NewMsgBeginRedelegate(
-				delegatorAddress,
-				overWeightElem.valAddr,
-				underWeightElem.valAddr,
-				sdk.NewInt64Coin(hostZone.HostDenom, abs(underWeightElem.deltaAmt)))
-			msgs = append(msgs, redelagateMsg)
-			underWeightElem.deltaAmt = 0
-		} else {
-			// if the two elements are equal, we increment both slices
-			underWeightIndex -= 1
-			overWeightIndex += 1
-			// issue an ICA call to the host zone to rebalance the validator
-			redelagateMsg := stakingTypes.NewMsgBeginRedelegate(
-				delegatorAddress,
-				underWeightElem.valAddr,
-				overWeightElem.valAddr,
-				sdk.NewInt64Coin(hostZone.HostDenom, abs(underWeightElem.deltaAmt)))
-			msgs = append(msgs, redelagateMsg)
-			overWeightElem.deltaAmt = 0
-			underWeightElem.deltaAmt = 0
-		}
-	}
+	// ===========================
 
 	connectionId := hostZone.GetConnectionId()
-	_, err = k.SubmitTxsStrideEpoch(ctx, connectionId, msgs, *delegationIca, "", nil)
+	_, err := k.SubmitTxsStrideEpoch(ctx, connectionId, msgs, *hostZone.GetDelegationAccount(), "", nil)
 	if err != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "Failed to SubmitTxs for %s, %s, %s", connectionId, hostZone.ChainId, msgs)
 	}

--- a/x/stakeibc/keeper/validator_selection.go
+++ b/x/stakeibc/keeper/validator_selection.go
@@ -23,18 +23,18 @@ func (k Keeper) GetValidatorDelegationAmtDifferences(ctx sdk.Context, hostZone t
 	totalDelegatedAmt := k.GetTotalValidatorDelegations(hostZone)
 	targetDelegation, err := k.GetTargetValAmtsForHostZone(ctx, hostZone, totalDelegatedAmt)
 	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("Error getting target weights for host zone %s", hostZone.ChainId))
+		k.Logger(ctx).Error(fmt.Sprintf("Error getting target val amts for host zone %s", hostZone.ChainId))
 		return nil, err
 	}
 	for _, validator := range validators {
 		targetDelForVal, err := cast.ToInt64E(targetDelegation[validator.GetAddress()])
 		if err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("Error getting target weights for host zone %s", hostZone.ChainId))
+			k.Logger(ctx).Error(fmt.Sprintf("Error getting target weight for host zone %s, targetDelForVal: %d", hostZone.ChainId, targetDelForVal))
 			return nil, err
 		}
 		delAmt, err := cast.ToInt64E(validator.DelegationAmt)
 		if err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("Error getting target weights for host zone %s", hostZone.ChainId))
+			k.Logger(ctx).Error(fmt.Sprintf("Error getting target delAmt for host zone %s, amt: %d", hostZone.ChainId, delAmt))
 			return nil, err
 		}
 		delegationDelta[validator.GetAddress()] = targetDelForVal - delAmt
@@ -46,6 +46,10 @@ func (k Keeper) GetTargetValAmtsForHostZone(ctx sdk.Context, hostZone types.Host
 	// This will get the target validator delegation for the given hostZone
 	// such that the total validator delegation is equal to the finalDelegation
 	// output key is ADDRESS not NAME
+
+	// log the validators
+	k.Logger(ctx).Info(fmt.Sprintf("[MOOSE] Validators for host zone %s", hostZone.GetValidators()))
+
 	totalWeight := k.GetTotalValidatorWeight(hostZone)
 	if totalWeight == 0 {
 		k.Logger(ctx).Error(fmt.Sprintf("No non-zero validators found for host zone %s", hostZone.ChainId))


### PR DESCRIPTION
## What is the purpose of the change

Test and clean up rebalance validators logic

Bugs fixed:
1. In `RebalanceValidators()`, when creating `msgs` to Submit to host zones, we were marshaling addresses for hostZone ICA accounts using `sdk.ValAddress` and `sdk.AccAddress`, which marshal using a `stride` prefix, so all these submittxs fail because they are `msgRedelegate`ing from/to nonexistent addresses. See this log for an attempt to rebalance on GAIA
```
11:56AM INF Rebalancing validators with msg [delegator_address:"stride1vdhhxmt0wvchx7fkxdkxven9we6k2atywemxcangxfkxvdnnxvurw7rg89u8zdejdcekvumexehryemjx45x6dn4xfeh5uejwcc826ndmwe2ur" validator_src_address:"stridevaloper1vdhhxmt0wdmxzmr0wpjhyvtsvdskwvrrdg68garcvuuxcdmsvdnnquf5ddeh2emvwdmh2at9v3skg63hdejshxhajt" validator_dst_address:"stridevaloper1vdhhxmt0wdmxzmr0wpjhyvfnxdkxvueeva3hq7r3dgmx2u3nddurvvp4v5ehvwtvw9cryur8x4ehj6rkwdaqu0fl9f" amount:<denom:"uatom" amount:"167" > ] module=x/stakeibc
```
**Fix**: replace `NewXXX()` methods used to create messages with `XXX{}` structs, which take strings as inputs rather than bytes.


2. We didn't have `MsgBeginRedelegate` in our host zone ICA `allow_messsages`
** Fix**:added it in the init scripts


## Brief Changelog

- in `scripts-local/init_<NETWORK>.sh`, increased each network's validators' self-stakes so that redemption rates increase more realistically in local dev mode (no 100X+ redemptionRates)
- in `msg_server_rebalance_validators.go` added clearer logging
- added missing cli argument to the `rebalance-validators` CLI command in `tx_rebalance_validators.go`

## Testing and Verifying

Start up stride, delegate to GAIA, then change val2's weight to 10 (so the two valdators have equal weight).
```
strided-local tx stakeibc change-validator-weight GAIA cosmosvaloper1pcag0cj4ttxg8l7pcg0q4ksuglswuuedadj7ne 10 --from admin
```
Now observe the weight changed to 10 [on the host zone](http://localhost:1317/Stride-Labs/stride/stakeibc/host_zone). 

The weights have changed but the delegated amounts are still in a 2:1 ratio. Next, rebalance the validators with
```
strided-local tx stakeibc rebalance-validators GAIA 1 --from admin -y --chain-id STRIDE
```

**THIS DOES NOT WORK YET!** I simplified the rebalancing logic to a hardcoded rebal of 100 tokens from val1 to val2, and it fails silently, I can't get it to print a log. 

From the stride side, the tx looks successful.

Hermes shows a little information on a failed packet, sometimes:
```
2022-08-21T18:38:57.608574Z ERROR ThreadId(24) send_tx_with_account_sequence_retry{id=GAIA}: broadcast_tx_sync: Response { code: Err(22), data: Data([]), log: Log("packet messages are redundant"), hash: transaction::Hash(11472F3A63C2F534D864E9ADC95A993ACAF3E6CFCED0F7415393384F3AD8D316) }: diagnostic: unknown SDK error: 22
```

Gaia shows no failures.

GEX on Gaia shows no failures.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? no
  - Does this pull request update existing proto field values (and require a backend and frontend migration)? no
  - Does this pull request change existing proto field names (and require a frontend migration)? no

## Other issues

