### PR TITLE
Invariant rr

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -359,7 +359,7 @@ func NewStrideApp(
 		appCodec, keys[slashingtypes.StoreKey], &stakingKeeper, app.GetSubspace(slashingtypes.ModuleName),
 	)
 	app.CrisisKeeper = crisiskeeper.NewKeeper(
-		app.GetSubspace(crisistypes.ModuleName), invCheckPeriod, app.BankKeeper, authtypes.FeeCollectorName,
+		app.GetSubspace(crisistypes.ModuleName), 100, app.BankKeeper, authtypes.FeeCollectorName,
 	)
 
 	app.FeeGrantKeeper = feegrantkeeper.NewKeeper(appCodec, keys[feegrant.StoreKey], app.AccountKeeper)
@@ -491,7 +491,6 @@ func NewStrideApp(
 		return nil
 	}
 
-	
 	epochsKeeper := epochsmodulekeeper.NewKeeper(appCodec, keys[epochsmoduletypes.StoreKey])
 	app.EpochsKeeper = *epochsKeeper.SetHooks(
 		epochsmoduletypes.NewMultiEpochHooks(

--- a/x/stakeibc/keeper/invariants.go
+++ b/x/stakeibc/keeper/invariants.go
@@ -1,0 +1,45 @@
+package keeper
+
+// DONTCOVER
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Stride-Labs/stride/x/stakeibc/types"
+)
+
+const redemptionRateInvariantName = "redemption-rate-above-0.9"
+
+// RegisterInvariants registers all governance invariants.
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, redemptionRateInvariantName, RedemptionRateInvariant(k))
+}
+
+// AllInvariants runs all invariants of the gamm module
+func AllInvariants(k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		msg, broke := RedemptionRateInvariant(k)(ctx)
+		// note: once we have >1 invariant here, follow the pattern from staking module invariants here: https://github.com/cosmos/cosmos-sdk/blob/v0.46.0/x/staking/keeper/invariants.go
+		return msg, broke
+	}
+}
+
+// RedemptionRateInvariant checks that all hostZone redemption rates are above a fixed threshold
+func RedemptionRateInvariant(k Keeper) sdk.Invariant {
+
+	// threshold is 0.9
+	THRESHOLD := sdk.NewDec(9).Quo(sdk.NewDec(10))
+
+	return func(ctx sdk.Context) (string, bool) {
+		for _, hz := range k.GetAllHostZone(ctx) {
+			if hz.RedemptionRate.LT(THRESHOLD) {
+				return sdk.FormatInvariant(types.ModuleName, redemptionRateInvariantName,
+					fmt.Sprintf("[INVARIANT BROKEN!!!] %s's RR is %s", hz.GetChainId(), hz.RedemptionRate.String())), true
+			}
+		}
+		return sdk.FormatInvariant(types.ModuleName, redemptionRateInvariantName,
+			fmt.Sprintf("All RR's are GT %s", THRESHOLD.String())), false
+	}
+}

--- a/x/stakeibc/keeper/invariants.go
+++ b/x/stakeibc/keeper/invariants.go
@@ -17,7 +17,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
 	ir.RegisterRoute(types.ModuleName, redemptionRateInvariantName, RedemptionRateInvariant(k))
 }
 
-// AllInvariants runs all invariants of the gamm module
+// AllInvariants runs all invariants of the stakeibc module
 func AllInvariants(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		msg, broke := RedemptionRateInvariant(k)(ctx)
@@ -30,16 +30,16 @@ func AllInvariants(k Keeper) sdk.Invariant {
 func RedemptionRateInvariant(k Keeper) sdk.Invariant {
 
 	// threshold is 0.9
-	THRESHOLD := sdk.NewDec(9).Quo(sdk.NewDec(10))
+	threshold := sdk.NewDec(9).Quo(sdk.NewDec(10))
 
 	return func(ctx sdk.Context) (string, bool) {
 		for _, hz := range k.GetAllHostZone(ctx) {
-			if hz.RedemptionRate.LT(THRESHOLD) {
+			if hz.RedemptionRate.LT(threshold) {
 				return sdk.FormatInvariant(types.ModuleName, redemptionRateInvariantName,
 					fmt.Sprintf("[INVARIANT BROKEN!!!] %s's RR is %s", hz.GetChainId(), hz.RedemptionRate.String())), true
 			}
 		}
 		return sdk.FormatInvariant(types.ModuleName, redemptionRateInvariantName,
-			fmt.Sprintf("All RR's are GT %s", THRESHOLD.String())), false
+			fmt.Sprintf("All RR's are GT %s", threshold.String())), false
 	}
 }

--- a/x/stakeibc/module.go
+++ b/x/stakeibc/module.go
@@ -150,7 +150,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the capability module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	keeper.RegisterInvariants(ir, am.keeper)
+}
 
 // InitGenesis performs the capability module's genesis initialization It returns
 // no validator updates.


### PR DESCRIPTION
## What is the purpose of the change

Add our first invariant check! [Read up on them here](https://docs.cosmos.network/master/building-modules/invariants.html). They run periodically. If invariants are broken, the chain halts.

I start with a simple invariant here: no `redemptionRate` should ever dip below `0.9`. I set invariants assertions to run every `100` stride blocks.

## Brief Changelog

  - Write the invariant logic in `x/stakeibc/keeper/invariants.go`
  - Register stakeibc's invariants in `x/stakeibc/module.go`
  - Set the number of blocks to allow between invariant checks in `app.go`. This param is known as `IntCheckPeriod`. If it's set to 0 (our previously was) the invariants are only checked at chain genesis. 

## Testing and Verifying

First, make sure the invariants are running with `make init-local`. You should see these logs every 100 blocks

```
9:52PM INF asserting crisis invariants inv=0/12 module=x/crisis name=distribution/nonnegative-outstanding
9:52PM INF asserting crisis invariants inv=1/12 module=x/crisis name=distribution/can-withdraw
9:52PM INF asserting crisis invariants inv=2/12 module=x/crisis name=distribution/reference-count
9:52PM INF asserting crisis invariants inv=3/12 module=x/crisis name=distribution/module-account
9:52PM INF asserting crisis invariants inv=4/12 module=x/crisis name=stakeibc/redemption-rate-above-0.9
9:52PM INF asserting crisis invariants inv=5/12 module=x/crisis name=gov/module-account
9:52PM INF asserting crisis invariants inv=6/12 module=x/crisis name=staking/module-accounts
9:52PM INF asserting crisis invariants inv=7/12 module=x/crisis name=staking/nonnegative-power
9:52PM INF asserting crisis invariants inv=8/12 module=x/crisis name=staking/positive-delegation
9:52PM INF asserting crisis invariants inv=9/12 module=x/crisis name=staking/delegator-shares
9:52PM INF asserting crisis invariants inv=10/12 module=x/crisis name=bank/nonnegative-outstanding
9:52PM INF asserting crisis invariants inv=11/12 module=x/crisis name=bank/total-supply
9:52PM INF asserted all invariants duration=0.280875 height=0 module=x/crisis
```

You can check that the invariants halt the chain by modifying `stakeibc/invariants.go:33` to set an unrealistic redemptionRate threshold e.g. `1.1`
```
THRESHOLD := sdk.NewDec(11).Quo(sdk.NewDec(10))

``` 
If you run the chain again, you should halt at block 100 with this error:
```
9:55PM ERR CONSENSUS FAILURE!!! err="invariant broken: stakeibc: redemption-rate-above-0.9 invariant\n[INVARIANT BROKEN!!!] GAIA's RR is 1.000000000000000000
```

## Reviewers:
1. We're currently setting the cadence for invariant checks by hardcoding in `app.go`. There must be a better way to set this, anyone have thoughts?
2. What are some other low-hanging-fruit invariants?

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? no
  - Does this pull request update existing proto field values (and require a backend and frontend migration)? no
  - Does this pull request change existing proto field names (and require a frontend migration)? no
