### PR TITLE
bump hermes to v1.0.0 (stable)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "deps/hermes"]
 	path = deps/hermes
 	url = git@github.com:informalsystems/ibc-rs.git
-	branch = 4e83aae8a
+	branch = ed4dd8c8b4ebd6
 [submodule "deps/gaia"]
 	path = deps/gaia
 	url = git@github.com:Stride-Labs/gaia.git

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -4,7 +4,7 @@ RUN apt update && apt install git -y
 
 WORKDIR /app/src
 
-RUN git clone https://github.com/informalsystems/ibc-rs --branch v0.15.0
+RUN git clone https://github.com/informalsystems/ibc-rs --branch v1.0.0
 
 WORKDIR ibc-rs
 

--- a/scripts/testnet/dockerfiles/base/Dockerfile.hermes
+++ b/scripts/testnet/dockerfiles/base/Dockerfile.hermes
@@ -4,7 +4,7 @@ RUN apt update && apt install git -y
 
 WORKDIR /app/src
 
-RUN git clone https://github.com/informalsystems/ibc-rs --branch v0.15.0
+RUN git clone https://github.com/informalsystems/ibc-rs --branch v1.0.0
 
 WORKDIR /app/src/ibc-rs
 


### PR DESCRIPTION
## What is the purpose of the change

Hermes has its first stable build! https://github.com/informalsystems/ibc-rs/releases/tag/v1.0.0 let's use it

also... hermes now builds in 2 minutes?!?
```
Finished release [optimized] target(s) in 1m 55s
```


## Brief Changelog

- bump hermes in .gitmodules
- bump hermes in docker


## Testing and Verifying
```
rm -rf deps
git submodule update --init
git submodule update --recursive
make init-local build=sghioj && sleep 15 && make test-integration
```

results
```
gaia_tests.bats
 ✓ [INTEGRATION-BASIC] address names are correct
 ✓ [INTEGRATION-BASIC] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mints stATOM
 ✓ [INTEGRATION-BASIC-GAIA] tokens were transferred to GAIA after liquid staking
 ✓ [INTEGRATION-BASIC-GAIA] tokens on GAIA were staked
 ✓ [INTEGRATION-BASIC-GAIA] redemption works
 ✓ [INTEGRATION-BASIC-GAIA] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being reinvested, exchange rate updating
 ✓ [NOT-IMPLEMENTED] reinvestment and revenue amounts are correct

10 tests, 0 failures
```

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? na
  - Does this pull request update existing proto field values (and require a backend and frontend migration)? no
  - Does this pull request change existing proto field names (and require a frontend migration)? no

