### PR TITLE
Testnet upgrade support

### DIFF
--- a/app/upgrades/README.md
+++ b/app/upgrades/README.md
@@ -61,7 +61,7 @@ func (app *StrideApp) setupUpgradeHandlers() {
     ...
 ```
 
-# Migrations (Only Required if the state changed)
+# Migrations (Only required if the state changed)
 ## Store Old Proto Types
 ```go
 // x/{moduleName}/migrations/{oldVersion}/types/{data_type}.pb.go
@@ -70,7 +70,23 @@ func (app *StrideApp) setupUpgradeHandlers() {
 ## Increment the Module's Consensus Version
 ```go
 // x/{moduleName}/module.go
-func (AppModule) ConsensusVersion() uint64 { return {NewVersion} }
+func (AppModule) ConsensusVersion() uint64 { return 2 }
+```
+
+## Specify the Migration in the Upgrade Handler
+```go
+// app/upgrades/{upgradeVersion}/upgrades.go
+
+// CreateUpgradeHandler creates an SDK upgrade handler for {upgradeVersion}
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		vm[{moduleName}] = 2 // <- ADD THIS
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}
 ```
 
 ## Add Migration Handler

--- a/scripts/testnet/dockerfiles/Dockerfile.stride
+++ b/scripts/testnet/dockerfiles/Dockerfile.stride
@@ -1,18 +1,29 @@
 FROM golang:1.17-alpine3.15 AS golang
 
-WORKDIR /src/app/
+WORKDIR /src
 
-COPY . .
+COPY go.mod .
+COPY go.sum .
+COPY Makefile .
+COPY app /src/app
+COPY cmd /src/cmd
+COPY proto /src/proto
+COPY testutil /src/testutil
+COPY utils /src/utils
+COPY x /src/x
 
 RUN apk add --no-cache make git gcc musl-dev openssl-dev linux-headers \
-    && go build -mod=readonly -trimpath -o /src/app/ ./... 
+    && go build -mod=readonly -trimpath -o /src/ ./... 
 
 
 FROM gcr.io/stride-nodes/base-images/stride:latest
 
 ARG node_name
 
-COPY --from=golang /src/app/strided /usr/local/bin/strided
+RUN mkdir -p /stride/.stride/cosmovisor/genesis/bin \
+    && mkdir -p /stride/.stride/cosmovisor/upgrades 
+
+COPY --from=golang /src/strided /stride/.stride/cosmovisor/genesis/bin/strided
 COPY --chown=stride "./state/$node_name/" /stride/.stride/ 
 COPY --chown=stride "./state/keys.txt" /stride/keys.txt
 COPY --chown=stride "./state/install_faucet.sh" /stride/install_faucet.sh
@@ -24,13 +35,11 @@ COPY --chown=stride "scripts/testnet/tests/verify_testnet_stride.sh" /stride/ver
 COPY --chown=stride "scripts/testnet/bank_sends.sh" /stride/bank_sends.sh
 COPY --chown=stride "scripts/testnet/upgrade.sh" /stride/upgrade.sh
 
-RUN mkdir -p /stride/.stride/cosmovisor/genesis/bin \
-    && mkdir -p /stride/.stride/cosmovisor/upgrades \
-    && cp /usr/local/bin/strided /stride/.stride/cosmovisor/genesis/bin/strided 
+RUN echo 'alias strided=/stride/.stride/cosmovisor/current/bin/strided' >> ~/.bashrc  
 
 ENV DAEMON_NAME=strided
 ENV DAEMON_HOME=/stride/.stride
 ENV DAEMON_RESTART_AFTER_UPGRADE=true
 
 WORKDIR /stride
-CMD ["sh", "-c", "sudo nginx; bash /stride/stride_startup.sh"]
+CMD ["sh", "-c", "source /stride/.bashrc; sudo nginx; bash /stride/stride_startup.sh"]

--- a/scripts/testnet/dockerfiles/Dockerfile.stride
+++ b/scripts/testnet/dockerfiles/Dockerfile.stride
@@ -22,6 +22,7 @@ COPY --chown=stride "./state/$node_name/config/nginx.conf" /etc/nginx/nginx.conf
 COPY --chown=stride "./state/stride_startup.sh" /stride/stride_startup.sh
 COPY --chown=stride "scripts/testnet/tests/verify_testnet_stride.sh" /stride/verify_testnet_stride.sh
 COPY --chown=stride "scripts/testnet/bank_sends.sh" /stride/bank_sends.sh
+COPY --chown=stride "scripts/testnet/upgrade.sh" /stride/upgrade.sh
 
 RUN mkdir -p /stride/.stride/cosmovisor/genesis/bin \
     && mkdir -p /stride/.stride/cosmovisor/upgrades \

--- a/scripts/testnet/upgrade.sh
+++ b/scripts/testnet/upgrade.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu 
+
+UPGRADE_NAME="$1"
+STRIDE_COMMIT_HASH="$2"
+COSMOVISOR_HOME=/stride/.stride/cosmovisor/upgrades
+
+echo "Upgrade Name: $UPGRADE_NAME"
+printf "Stride Commit Hash: $STRIDE_COMMIT_HASH\n\n"
+
+while true; do
+    read -p "Continue? [y/n]" yn
+    case $yn in
+        [Yy]* ) echo ""; break;;
+        [Nn]* ) exit ;;
+        * ) printf "Please answer yes or no.\n";;
+    esac
+done
+
+UPGRADE_DIR=${COSMOVISOR_HOME}/${UPGRADE_NAME}/bin
+
+mkdir -p $UPGRADE_DIR
+git clone https://github.com/Stride-Labs/stride.git
+cd stride
+git checkout $STRIDE_COMMIT_HASH 
+env GOOS=linux GOARCH=amd64 go build -mod=readonly -trimpath -o ${UPGRADE_DIR}/ ./... 
+cd .. 
+rm -rf stride go

--- a/scripts/testnet/upgrade.sh
+++ b/scripts/testnet/upgrade.sh
@@ -3,11 +3,12 @@
 set -eu 
 
 UPGRADE_NAME="$1"
-STRIDE_COMMIT_HASH="$2"
+UPGRADE_COMMIT_HASH="$2"
+
 COSMOVISOR_HOME=/stride/.stride/cosmovisor/upgrades
 
 echo "Upgrade Name: $UPGRADE_NAME"
-printf "Stride Commit Hash: $STRIDE_COMMIT_HASH\n\n"
+printf "Upgrade Commit Hash: $UPGRADE_COMMIT_HASH\n\n"
 
 while true; do
     read -p "Continue? [y/n]" yn
@@ -23,7 +24,7 @@ UPGRADE_DIR=${COSMOVISOR_HOME}/${UPGRADE_NAME}/bin
 mkdir -p $UPGRADE_DIR
 git clone https://github.com/Stride-Labs/stride.git
 cd stride
-git checkout $STRIDE_COMMIT_HASH 
+git checkout $UPGRADE_COMMIT_HASH 
 env GOOS=linux GOARCH=amd64 go build -mod=readonly -trimpath -o ${UPGRADE_DIR}/ ./... 
 cd .. 
 rm -rf stride go

--- a/scripts/testnet/upgrade.sh
+++ b/scripts/testnet/upgrade.sh
@@ -26,5 +26,6 @@ git clone https://github.com/Stride-Labs/stride.git
 cd stride
 git checkout $UPGRADE_COMMIT_HASH 
 env GOOS=linux GOARCH=amd64 go build -mod=readonly -trimpath -o ${UPGRADE_DIR}/ ./... 
+cp ${UPGRADE_DIR}/strided /usr/local/bin/strided 
 cd .. 
 rm -rf stride go

--- a/scripts/testnet/upgrade.sh
+++ b/scripts/testnet/upgrade.sh
@@ -5,7 +5,7 @@ set -eu
 UPGRADE_NAME="$1"
 UPGRADE_COMMIT_HASH="$2"
 
-COSMOVISOR_HOME=/stride/.stride/cosmovisor/upgrades
+COSMOVISOR_HOME=/stride/.stride/cosmovisor
 
 echo "Upgrade Name: $UPGRADE_NAME"
 printf "Upgrade Commit Hash: $UPGRADE_COMMIT_HASH\n\n"
@@ -19,13 +19,12 @@ while true; do
     esac
 done
 
-UPGRADE_DIR=${COSMOVISOR_HOME}/${UPGRADE_NAME}/bin
+UPGRADE_DIR=${COSMOVISOR_HOME}/upgrades/${UPGRADE_NAME}/bin
 
 mkdir -p $UPGRADE_DIR
 git clone https://github.com/Stride-Labs/stride.git
 cd stride
 git checkout $UPGRADE_COMMIT_HASH 
 env GOOS=linux GOARCH=amd64 go build -mod=readonly -trimpath -o ${UPGRADE_DIR}/ ./... 
-cp ${UPGRADE_DIR}/strided /usr/local/bin/strided 
 cd .. 
 rm -rf stride go


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

There's currently no easy way to upgrade our testnet. This PR introduces a script that we can run from each node to create the proper cosmovisor structure for the upgrade. 

## Brief Changelog
- Added upgrade script
- Added alias in dockerfile so `strided` always points to the current binary in use

## Testing and Verifying
- Commented out the stateful lines from the dockerfile (since those depend on a GH actions build) and built the image locally

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  / README.md  /   not documented) n/a
  - Does this pull request update existing proto field values (and require a backend and frontend migration)? (yes / no) no
  - Does this pull request change existing proto field names (and require a frontend migration)? (yes / no) no

