### PR TITLE
[UNIT-TESTS] IBC Testing

### DIFF
--- a/app/apptesting/README.md
+++ b/app/apptesting/README.md
@@ -1,0 +1,2 @@
+* The unit testing framework leverages the `ibctesting` package 
+* See [ibc-go/testing](https://github.com/cosmos/ibc-go/tree/main/testing) for an overview

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -184,11 +184,14 @@ func (s *AppTestHelper) CreateICAChannel(owner string) {
 	icaPath.EndpointB.ChanOpenConfirm()
 	s.Require().NoError(err, "ChanOpenConfirm error")
 
-	// Finally, confirm the ICA channel was created properly
+	// Confirm the ICA channel was created properly
 	portID := icaPath.EndpointA.ChannelConfig.PortID
 	channelID := icaPath.EndpointA.ChannelID
 	_, found := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.Ctx(), portID, channelID)
 	s.Require().True(found, fmt.Sprintf("Channel not found after creation, PortID: %s, ChannelID: %s", portID, channelID))
+
+	// Finally set the active channel
+	s.App.ICAControllerKeeper.SetActiveChannelID(s.Ctx(), ibctesting.FirstConnectionID, portID, channelID)
 }
 
 // Register's a new ICA account on the next channel available

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -1,9 +1,16 @@
 package apptesting
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	"github.com/stretchr/testify/suite"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -11,17 +18,35 @@ import (
 	"github.com/Stride-Labs/stride/app"
 )
 
+var (
+	StrideChainID = "STRIDE"
+
+	TestIcaVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
+		Version:                icatypes.Version,
+		ControllerConnectionId: ibctesting.FirstConnectionID,
+		HostConnectionId:       ibctesting.FirstConnectionID,
+		Encoding:               icatypes.EncodingProtobuf,
+		TxType:                 icatypes.TxTypeSDKMultiMsg,
+	}))
+)
+
 type AppTestHelper struct {
 	suite.Suite
 
-	App         *app.StrideApp
-	Ctx         sdk.Context
+	App *app.StrideApp
+	Ctx sdk.Context
+
+	Coordinator  *ibctesting.Coordinator
+	StrideChain  *ibctesting.TestChain
+	HostChain    *ibctesting.TestChain
+	TransferPath *ibctesting.Path
+
 	QueryHelper *baseapp.QueryServiceTestHelper
 	TestAccs    []sdk.AccAddress
 }
 
 func (s *AppTestHelper) Setup() {
-	s.App = app.InitTestApp(true)
+	s.App = app.InitStrideTestApp(true)
 	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "STRIDE"})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
@@ -55,4 +80,137 @@ func CreateRandomAccounts(numAccts int) []sdk.AccAddress {
 	}
 
 	return testAddrs
+}
+
+// Enables IBC support through ibctesting and creates a transfer channel
+func (s *AppTestHelper) SetupIBC(hostChainID string) {
+	s.Coordinator = ibctesting.NewCoordinator(s.T(), 0)
+
+	// Iniitalize stride testing app with by casting a StrideApp -> TestingApp
+	ibctesting.DefaultTestingAppInit = app.InitStrideIBCTestingApp
+	s.StrideChain = ibctesting.NewTestChain(s.T(), s.Coordinator, StrideChainID)
+
+	// Initialize a host testing app using SimApp -> TestingApp
+	ibctesting.DefaultTestingAppInit = ibctesting.SetupTestingApp
+	s.HostChain = ibctesting.NewTestChain(s.T(), s.Coordinator, hostChainID)
+
+	// Update coordinator
+	s.Coordinator.Chains = map[string]*ibctesting.TestChain{
+		StrideChainID: s.StrideChain,
+		hostChainID:   s.HostChain,
+	}
+
+	// Create a clients, connections, and transfer channel
+	s.TransferPath = NewTransferPath(s.StrideChain, s.HostChain)
+	s.Coordinator.Setup(s.TransferPath)
+
+	// Replace AppTestHelper's app with the TestingApp
+	s.App = s.StrideChain.App.(*app.StrideApp)
+
+	// Finally confirm the channel was setup properly
+	s.Require().Equal("07-tendermint-0", s.TransferPath.EndpointA.ClientID, "stride clientID")
+	s.Require().Equal("connection-0", s.TransferPath.EndpointA.ConnectionID, "stride connectionID")
+	s.Require().Equal("channel-0", s.TransferPath.EndpointA.ChannelID, "stride transfer channelID")
+
+	s.Require().Equal("07-tendermint-0", s.TransferPath.EndpointB.ClientID, "host clientID")
+	s.Require().Equal("connection-0", s.TransferPath.EndpointB.ConnectionID, "host connectionID")
+	s.Require().Equal("channel-0", s.TransferPath.EndpointB.ChannelID, "host transfer channelID")
+}
+
+// Creates an ICA channel through ibctesting
+// Also creates a transfer channel is if hasn't been done yet
+func (s *AppTestHelper) CreateICAChannel(owner string) {
+	if s.TransferPath == nil {
+		// If we have yet to setup IBC, do that here
+		ownerSplit := strings.Split(owner, ".")
+		s.Require().Equal(2, len(ownerSplit), "owner should be of the form: {HostZone}.{AccountName}")
+
+		hostChainId := ownerSplit[0]
+		s.SetupIBC(hostChainId)
+	}
+
+	// Create ICA Path and the copy over the client and connection from the transfer path
+	icaPath := NewIcaPath(s.StrideChain, s.HostChain)
+	icaPath = CopyConnectionAndClientToPath(icaPath, s.TransferPath)
+
+	// Register the ICA
+	s.RegisterInterchainAccount(icaPath.EndpointA, owner)
+
+	// Complete the handshake
+	err := icaPath.EndpointB.ChanOpenTry()
+	s.Require().NoError(err, "ChanOpenTry error")
+
+	err = icaPath.EndpointA.ChanOpenAck()
+	s.Require().NoError(err, "ChanOpenAck error")
+
+	icaPath.EndpointB.ChanOpenConfirm()
+	s.Require().NoError(err, "ChanOpenConfirm error")
+
+	// Finally, confirm the ICA channel was created properly
+	portID := icaPath.EndpointA.ChannelConfig.PortID
+	channelID := icaPath.EndpointA.ChannelID
+	_, found := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.StrideChain.GetContext(), portID, channelID)
+	s.Require().True(found, fmt.Sprintf("Channel not found after creation, PortID: %s, ChannelID: %s", portID, channelID))
+}
+
+// Creates a transfer channel between two chains
+func NewTransferPath(chainA *ibctesting.TestChain, chainB *ibctesting.TestChain) *ibctesting.Path {
+	path := ibctesting.NewPath(chainA, chainB)
+	path.EndpointA.ChannelConfig.PortID = ibctesting.TransferPort
+	path.EndpointB.ChannelConfig.PortID = ibctesting.TransferPort
+	path.EndpointA.ChannelConfig.Order = channeltypes.UNORDERED
+	path.EndpointB.ChannelConfig.Order = channeltypes.UNORDERED
+	path.EndpointA.ChannelConfig.Version = transfertypes.Version
+	path.EndpointB.ChannelConfig.Version = transfertypes.Version
+	return path
+}
+
+// Creates an ICA channel between two chains
+func NewIcaPath(chainA *ibctesting.TestChain, chainB *ibctesting.TestChain) *ibctesting.Path {
+	path := ibctesting.NewPath(chainA, chainB)
+	path.EndpointA.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointB.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointA.ChannelConfig.Version = TestIcaVersion
+	path.EndpointB.ChannelConfig.Version = TestIcaVersion
+	return path
+}
+
+// In ibctesting, there's no easy way to create a new channel on an existing connection
+// To get around this, this helper function will copy the client/connection info from an existing channel
+// We use this when creating ICA channels, because we want to reuse the same connections/clients from the transfer channel
+func CopyConnectionAndClientToPath(path *ibctesting.Path, pathToCopy *ibctesting.Path) *ibctesting.Path {
+	path.EndpointA.ClientID = pathToCopy.EndpointA.ClientID
+	path.EndpointB.ClientID = pathToCopy.EndpointB.ClientID
+	path.EndpointA.ConnectionID = pathToCopy.EndpointA.ConnectionID
+	path.EndpointB.ConnectionID = pathToCopy.EndpointB.ConnectionID
+	path.EndpointA.ClientConfig = pathToCopy.EndpointA.ClientConfig
+	path.EndpointB.ClientConfig = pathToCopy.EndpointB.ClientConfig
+	path.EndpointA.ConnectionConfig = pathToCopy.EndpointA.ConnectionConfig
+	path.EndpointB.ConnectionConfig = pathToCopy.EndpointB.ConnectionConfig
+	return path
+}
+
+// Register's a new ICA account on the next channel available
+// This function assumes a connection already exists
+func (s *AppTestHelper) RegisterInterchainAccount(endpoint *ibctesting.Endpoint, owner string) {
+	// Get the port ID from the owner name (i.e. "icacontroller-{owner}")
+	portID, err := icatypes.NewControllerPortID(owner)
+	s.Require().NoError(err, "owner to portID error")
+
+	// Get the next channel available
+	channelSequence := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(endpoint.Chain.GetContext())
+
+	// Register an ICA at that
+	err = s.App.ICAControllerKeeper.RegisterInterchainAccount(endpoint.Chain.GetContext(), endpoint.ConnectionID, owner)
+	s.Require().NoError(err, "register interchain account error")
+
+	// Commit the state
+	endpoint.Chain.App.Commit()
+	endpoint.Chain.NextBlock()
+
+	// Update the endpoint object to the newly created port + channel
+	endpoint.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
+	endpoint.ChannelConfig.PortID = portID
 }

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -11,6 +11,7 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
+	"github.com/cosmos/ibc-go/v3/testing/simapp"
 	"github.com/stretchr/testify/suite"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -33,8 +34,8 @@ var (
 type AppTestHelper struct {
 	suite.Suite
 
-	App *app.StrideApp
-	Ctx sdk.Context
+	App     *app.StrideApp
+	HostApp *simapp.SimApp
 
 	Coordinator  *ibctesting.Coordinator
 	StrideChain  *ibctesting.TestChain
@@ -45,33 +46,56 @@ type AppTestHelper struct {
 	TestAccs    []sdk.AccAddress
 }
 
+// AppTestHelper Constructor
 func (s *AppTestHelper) Setup() {
 	s.App = app.InitStrideTestApp(true)
-	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "STRIDE"})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
-		Ctx:             s.Ctx,
+		Ctx:             s.Ctx(),
 	}
 	s.TestAccs = CreateRandomAccounts(3)
 }
 
+// Dynamically gets the context of the Stride Chain
+func (s *AppTestHelper) Ctx() sdk.Context {
+	// If IBC support is enabled, return a dynamic context that updates with each block
+	if s.StrideChain != nil {
+		return s.StrideChain.GetContext()
+	}
+	// Otherwise return a mock context
+	return s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: StrideChainID})
+}
+
+// Dynamically gets the context of the Host Chain
+func (s *AppTestHelper) HostCtx() sdk.Context {
+	// Host context can only be used if IBC support has been enabled
+	s.Require().NotNil(s.HostChain, "HostChain must be initialzed before accessing a context. "+
+		"To initailze run `s.SetupIBCChains(chainID)`, `s.CreateTransferChannel(chainID)` or `s.CreateICAChannel(owner)`")
+
+	return s.HostChain.GetContext()
+}
+
+// Mints coins directly to a module account
 func (s *AppTestHelper) FundModuleAccount(moduleName string, amount sdk.Coin) {
-	err := s.App.BankKeeper.MintCoins(s.Ctx, moduleName, sdk.NewCoins(amount))
+	err := s.App.BankKeeper.MintCoins(s.Ctx(), moduleName, sdk.NewCoins(amount))
 	s.Require().NoError(err)
 }
 
+// Mints and sends coins to a user account
 func (s *AppTestHelper) FundAccount(acc sdk.AccAddress, amount sdk.Coin) {
 	amountCoins := sdk.NewCoins(amount)
-	err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, amountCoins)
+	err := s.App.BankKeeper.MintCoins(s.Ctx(), minttypes.ModuleName, amountCoins)
 	s.Require().NoError(err)
-	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, minttypes.ModuleName, acc, amountCoins)
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx(), minttypes.ModuleName, acc, amountCoins)
 	s.Require().NoError(err)
 }
 
+// Helper function to compare coins with a more legible error
 func (s *AppTestHelper) CompareCoins(expectedCoin sdk.Coin, actualCoin sdk.Coin, msg string) {
 	s.Require().Equal(expectedCoin.Amount.Int64(), actualCoin.Amount.Int64(), msg)
 }
 
+// Generate random account addresss
 func CreateRandomAccounts(numAccts int) []sdk.AccAddress {
 	testAddrs := make([]sdk.AccAddress, numAccts)
 	for i := 0; i < numAccts; i++ {
@@ -82,11 +106,11 @@ func CreateRandomAccounts(numAccts int) []sdk.AccAddress {
 	return testAddrs
 }
 
-// Enables IBC support through ibctesting and creates a transfer channel
-func (s *AppTestHelper) SetupIBC(hostChainID string) {
+// Initializes a ibctesting coordinator to keep track of Stride and a host chain's state
+func (s *AppTestHelper) SetupIBCChains(hostChainID string) {
 	s.Coordinator = ibctesting.NewCoordinator(s.T(), 0)
 
-	// Iniitalize stride testing app with by casting a StrideApp -> TestingApp
+	// Initialize a stride testing app by casting a StrideApp -> TestingApp
 	ibctesting.DefaultTestingAppInit = app.InitStrideIBCTestingApp
 	s.StrideChain = ibctesting.NewTestChain(s.T(), s.Coordinator, StrideChainID)
 
@@ -99,13 +123,24 @@ func (s *AppTestHelper) SetupIBC(hostChainID string) {
 		StrideChainID: s.StrideChain,
 		hostChainID:   s.HostChain,
 	}
+}
 
-	// Create a clients, connections, and transfer channel
+// Creates clients, connections, and a transfer channel between stride and a host chain
+func (s *AppTestHelper) CreateTransferChannel(hostChainID string) {
+	// If we have yet to create the host chain, do that here
+	if s.Coordinator == nil {
+		s.SetupIBCChains(hostChainID)
+	}
+	s.Require().Equal(s.HostChain.ChainID, hostChainID,
+		fmt.Sprintf("The testing app has already been initialized with a different chainID (%s)", s.HostChain.ChainID))
+
+	// Create clients, connections, and a transfer channel
 	s.TransferPath = NewTransferPath(s.StrideChain, s.HostChain)
 	s.Coordinator.Setup(s.TransferPath)
 
-	// Replace AppTestHelper's app with the TestingApp
+	// Replace stride and host apps with those from TestingApp
 	s.App = s.StrideChain.App.(*app.StrideApp)
+	s.HostApp = s.HostChain.GetSimApp()
 
 	// Finally confirm the channel was setup properly
 	s.Require().Equal("07-tendermint-0", s.TransferPath.EndpointA.ClientID, "stride clientID")
@@ -120,23 +155,22 @@ func (s *AppTestHelper) SetupIBC(hostChainID string) {
 // Creates an ICA channel through ibctesting
 // Also creates a transfer channel is if hasn't been done yet
 func (s *AppTestHelper) CreateICAChannel(owner string) {
+	// If we have yet to create a client/connection (through creating a transfer channel), do that here
 	if s.TransferPath == nil {
-		// If we have yet to setup IBC, do that here
 		ownerSplit := strings.Split(owner, ".")
 		s.Require().Equal(2, len(ownerSplit), "owner should be of the form: {HostZone}.{AccountName}")
 
-		hostChainId := ownerSplit[0]
-		s.SetupIBC(hostChainId)
+		hostChainID := ownerSplit[0]
+		s.CreateTransferChannel(hostChainID)
 	}
 
-	// Create ICA Path and the copy over the client and connection from the transfer path
+	// Create ICA Path and then copy over the client and connection from the transfer path
 	icaPath := NewIcaPath(s.StrideChain, s.HostChain)
 	icaPath = CopyConnectionAndClientToPath(icaPath, s.TransferPath)
 
-	// Register the ICA
+	// Register the ICA and complete the handshake
 	s.RegisterInterchainAccount(icaPath.EndpointA, owner)
 
-	// Complete the handshake
 	err := icaPath.EndpointB.ChanOpenTry()
 	s.Require().NoError(err, "ChanOpenTry error")
 
@@ -149,8 +183,30 @@ func (s *AppTestHelper) CreateICAChannel(owner string) {
 	// Finally, confirm the ICA channel was created properly
 	portID := icaPath.EndpointA.ChannelConfig.PortID
 	channelID := icaPath.EndpointA.ChannelID
-	_, found := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.StrideChain.GetContext(), portID, channelID)
+	_, found := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.Ctx(), portID, channelID)
 	s.Require().True(found, fmt.Sprintf("Channel not found after creation, PortID: %s, ChannelID: %s", portID, channelID))
+}
+
+// Register's a new ICA account on the next channel available
+// This function assumes a connection already exists
+func (s *AppTestHelper) RegisterInterchainAccount(endpoint *ibctesting.Endpoint, owner string) {
+	// Get the port ID from the owner name (i.e. "icacontroller-{owner}")
+	portID, err := icatypes.NewControllerPortID(owner)
+	s.Require().NoError(err, "owner to portID error")
+
+	// Get the next channel available and register the ICA
+	channelSequence := s.App.IBCKeeper.ChannelKeeper.GetNextChannelSequence(s.Ctx())
+
+	err = s.App.ICAControllerKeeper.RegisterInterchainAccount(s.Ctx(), endpoint.ConnectionID, owner)
+	s.Require().NoError(err, "register interchain account error")
+
+	// Commit the state
+	endpoint.Chain.App.Commit()
+	endpoint.Chain.NextBlock()
+
+	// Update the endpoint object to the newly created port + channel
+	endpoint.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
+	endpoint.ChannelConfig.PortID = portID
 }
 
 // Creates a transfer channel between two chains
@@ -190,27 +246,4 @@ func CopyConnectionAndClientToPath(path *ibctesting.Path, pathToCopy *ibctesting
 	path.EndpointA.ConnectionConfig = pathToCopy.EndpointA.ConnectionConfig
 	path.EndpointB.ConnectionConfig = pathToCopy.EndpointB.ConnectionConfig
 	return path
-}
-
-// Register's a new ICA account on the next channel available
-// This function assumes a connection already exists
-func (s *AppTestHelper) RegisterInterchainAccount(endpoint *ibctesting.Endpoint, owner string) {
-	// Get the port ID from the owner name (i.e. "icacontroller-{owner}")
-	portID, err := icatypes.NewControllerPortID(owner)
-	s.Require().NoError(err, "owner to portID error")
-
-	// Get the next channel available
-	channelSequence := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(endpoint.Chain.GetContext())
-
-	// Register an ICA at that
-	err = s.App.ICAControllerKeeper.RegisterInterchainAccount(endpoint.Chain.GetContext(), endpoint.ConnectionID, owner)
-	s.Require().NoError(err, "register interchain account error")
-
-	// Commit the state
-	endpoint.Chain.App.Commit()
-	endpoint.Chain.NextBlock()
-
-	// Update the endpoint object to the newly created port + channel
-	endpoint.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
-	endpoint.ChannelConfig.PortID = portID
 }

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -183,7 +183,7 @@ func (s *AppTestHelper) CreateICAChannel(owner string) {
 	err = icaPath.EndpointA.ChanOpenAck()
 	s.Require().NoError(err, "ChanOpenAck error")
 
-	icaPath.EndpointB.ChanOpenConfirm()
+	err = icaPath.EndpointB.ChanOpenConfirm()
 	s.Require().NoError(err, "ChanOpenConfirm error")
 
 	// Confirm the ICA channel was created properly

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -43,8 +43,9 @@ type AppTestHelper struct {
 	HostChain    *ibctesting.TestChain
 	TransferPath *ibctesting.Path
 
-	QueryHelper *baseapp.QueryServiceTestHelper
-	TestAccs    []sdk.AccAddress
+	QueryHelper  *baseapp.QueryServiceTestHelper
+	TestAccs     []sdk.AccAddress
+	IcaAddresses map[string]string
 }
 
 // AppTestHelper Constructor
@@ -56,6 +57,7 @@ func (s *AppTestHelper) Setup() {
 	}
 	s.TestAccs = CreateRandomAccounts(3)
 	s.IbcEnabled = false
+	s.IcaAddresses = make(map[string]string)
 }
 
 // Dynamically gets the context of the Stride Chain
@@ -189,6 +191,11 @@ func (s *AppTestHelper) CreateICAChannel(owner string) {
 	channelID := icaPath.EndpointA.ChannelID
 	_, found := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.Ctx(), portID, channelID)
 	s.Require().True(found, fmt.Sprintf("Channel not found after creation, PortID: %s, ChannelID: %s", portID, channelID))
+
+	// Store the account address
+	icaAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.Ctx(), ibctesting.FirstConnectionID, portID)
+	s.Require().True(found, "can't get ICA address")
+	s.IcaAddresses[owner] = icaAddress
 
 	// Finally set the active channel
 	s.App.ICAControllerKeeper.SetActiveChannelID(s.Ctx(), ibctesting.FirstConnectionID, portID, channelID)

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -1,13 +1,14 @@
 package apptesting
 
 import (
-	"github.com/Stride-Labs/stride/app"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/stretchr/testify/suite"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/Stride-Labs/stride/app"
 )
 
 type AppTestHelper struct {
@@ -20,9 +21,8 @@ type AppTestHelper struct {
 }
 
 func (s *AppTestHelper) Setup() {
-	checkTx := false
-	s.App = app.InitTestApp(checkTx)
-	s.Ctx = s.App.BaseApp.NewContext(checkTx, tmtypes.Header{Height: 1, ChainID: "STRIDE"})
+	s.App = app.InitTestApp(true)
+	s.Ctx = s.App.BaseApp.NewContext(false, tmtypes.Header{Height: 1, ChainID: "STRIDE"})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,

--- a/app/test_setup.go
+++ b/app/test_setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -12,10 +13,16 @@ import (
 
 const Bech32Prefix = "stride"
 
-// Setup initializes a new StrideApp
-func InitTestApp(isCheckTx bool) *StrideApp {
+func init() {
 	config := sdk.GetConfig()
+	valoper := sdk.PrefixValidator + sdk.PrefixOperator
+	valoperpub := sdk.PrefixValidator + sdk.PrefixOperator + sdk.PrefixPublic
 	config.SetBech32PrefixForAccount(Bech32Prefix, Bech32Prefix+sdk.PrefixPublic)
+	config.SetBech32PrefixForValidator(Bech32Prefix+valoper, Bech32Prefix+valoperpub)
+}
+
+// Setup initializes a new StrideApp
+func InitTestApp(initChain bool) *StrideApp {
 	db := dbm.NewMemDB()
 	app := NewStrideApp(
 		log.NewNopLogger(),
@@ -28,7 +35,7 @@ func InitTestApp(isCheckTx bool) *StrideApp {
 		MakeEncodingConfig(),
 		simapp.EmptyAppOptions{},
 	)
-	if !isCheckTx {
+	if initChain {
 		genesisState := NewDefaultGenesisState()
 		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
 		if err != nil {
@@ -45,4 +52,9 @@ func InitTestApp(isCheckTx bool) *StrideApp {
 	}
 
 	return app
+}
+
+func InitIBCTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
+	app := InitTestApp(false)
+	return app, NewDefaultGenesisState()
 }

--- a/app/test_setup.go
+++ b/app/test_setup.go
@@ -21,8 +21,8 @@ func init() {
 	config.SetBech32PrefixForValidator(Bech32Prefix+valoper, Bech32Prefix+valoperpub)
 }
 
-// Setup initializes a new StrideApp
-func InitTestApp(initChain bool) *StrideApp {
+// Initializes a new StrideApp without IBC functionality
+func InitStrideTestApp(initChain bool) *StrideApp {
 	db := dbm.NewMemDB()
 	app := NewStrideApp(
 		log.NewNopLogger(),
@@ -54,7 +54,8 @@ func InitTestApp(initChain bool) *StrideApp {
 	return app
 }
 
-func InitIBCTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	app := InitTestApp(false)
+// Initializes a new Stride App casted as a TestingApp for IBC support
+func InitStrideIBCTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
+	app := InitStrideTestApp(false)
 	return app, NewDefaultGenesisState()
 }

--- a/testutil/keeper/epochs.go
+++ b/testutil/keeper/epochs.go
@@ -12,7 +12,7 @@ import (
 )
 
 func EpochsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	app := strideapp.InitTestApp(true)
+	app := strideapp.InitStrideTestApp(true)
 	epochsKeeper := app.EpochsKeeper
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 

--- a/testutil/keeper/epochs.go
+++ b/testutil/keeper/epochs.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 	"time"
 
-	strideapp "github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/epochs/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	strideapp "github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/x/epochs/keeper"
 )
 
 func EpochsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	checkTx := false
-	app := strideapp.InitTestApp(checkTx)
+	app := strideapp.InitTestApp(true)
 	epochsKeeper := app.EpochsKeeper
-	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 
 	return &epochsKeeper, ctx
 }

--- a/testutil/keeper/icacallbacks.go
+++ b/testutil/keeper/icacallbacks.go
@@ -12,7 +12,7 @@ import (
 )
 
 func IcacallbacksKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	app := strideapp.InitTestApp(true)
+	app := strideapp.InitStrideTestApp(true)
 	icacallbackskeeper := app.IcacallbacksKeeper
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 

--- a/testutil/keeper/icacallbacks.go
+++ b/testutil/keeper/icacallbacks.go
@@ -12,10 +12,9 @@ import (
 )
 
 func IcacallbacksKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	checkTx := false
-	app := strideapp.InitTestApp(checkTx)
+	app := strideapp.InitTestApp(true)
 	icacallbackskeeper := app.IcacallbacksKeeper
-	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 
 	return &icacallbackskeeper, ctx
 }

--- a/testutil/keeper/interchainquery.go
+++ b/testutil/keeper/interchainquery.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 	"time"
 
-	strideapp "github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	strideapp "github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
 )
 
 func InterchainqueryKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	checkTx := false
-	app := strideapp.InitTestApp(checkTx)
+	app := strideapp.InitTestApp(true)
 	icqKeeper := app.InterchainqueryKeeper
-	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 
 	return &icqKeeper, ctx
 }

--- a/testutil/keeper/interchainquery.go
+++ b/testutil/keeper/interchainquery.go
@@ -12,7 +12,7 @@ import (
 )
 
 func InterchainqueryKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	app := strideapp.InitTestApp(true)
+	app := strideapp.InitStrideTestApp(true)
 	icqKeeper := app.InterchainqueryKeeper
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 

--- a/testutil/keeper/records.go
+++ b/testutil/keeper/records.go
@@ -12,7 +12,7 @@ import (
 )
 
 func RecordsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	app := strideapp.InitTestApp(true)
+	app := strideapp.InitStrideTestApp(true)
 	recordKeeper := app.RecordsKeeper
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 

--- a/testutil/keeper/records.go
+++ b/testutil/keeper/records.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 	"time"
 
-	strideapp "github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/records/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	strideapp "github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/x/records/keeper"
 )
 
 func RecordsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	checkTx := false
-	app := strideapp.InitTestApp(checkTx)
+	app := strideapp.InitTestApp(true)
 	recordKeeper := app.RecordsKeeper
-	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 
 	return &recordKeeper, ctx
 }

--- a/testutil/keeper/stakeibc.go
+++ b/testutil/keeper/stakeibc.go
@@ -12,7 +12,7 @@ import (
 )
 
 func StakeibcKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	app := strideapp.InitTestApp(true)
+	app := strideapp.InitStrideTestApp(true)
 	stakeibcKeeper := app.StakeibcKeeper
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 

--- a/testutil/keeper/stakeibc.go
+++ b/testutil/keeper/stakeibc.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 	"time"
 
-	strideapp "github.com/Stride-Labs/stride/app"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	strideapp "github.com/Stride-Labs/stride/app"
+	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
 )
 
 func StakeibcKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-	checkTx := false
-	app := strideapp.InitTestApp(checkTx)
+	app := strideapp.InitTestApp(true)
 	stakeibcKeeper := app.StakeibcKeeper
-	ctx := app.BaseApp.NewContext(checkTx, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "stride-1", Time: time.Now().UTC()})
 
 	return &stakeibcKeeper, ctx
 }

--- a/x/epochs/keeper/abci_test.go
+++ b/x/epochs/keeper/abci_test.go
@@ -29,9 +29,9 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 			expCurrentEpoch:            1,
 			expInitialEpochStartTime:   now,
 			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+				ctx := suite.Ctx().WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
 		{
@@ -40,22 +40,11 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 			expCurrentEpoch:            1,
 			expInitialEpochStartTime:   now,
 			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
-			},
-		},
-		{
-			expCurrentEpochStartHeight: 2,
-			expCurrentEpochStartTime:   now,
-			expCurrentEpoch:            1,
-			expInitialEpochStartTime:   now,
-			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx = suite.Ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 31))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+				ctx := suite.Ctx().WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 31))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
 		// Test that incrementing _exactly_ 1 month increments the epoch count.
@@ -65,11 +54,11 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 			expCurrentEpoch:            2,
 			expInitialEpochStartTime:   now,
 			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx = suite.Ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+				ctx := suite.Ctx().WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
 		{
@@ -78,13 +67,13 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 			expCurrentEpoch:            2,
 			expInitialEpochStartTime:   now,
 			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx = suite.Ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+				ctx := suite.Ctx().WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
 		{
@@ -93,13 +82,13 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 			expCurrentEpoch:            2,
 			expInitialEpochStartTime:   now,
 			fn: func() {
-				suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx = suite.Ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				suite.Ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
-				suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
-				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+				ctx := suite.Ctx().WithBlockHeight(2).WithBlockTime(now.Add(time.Second))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(time.Hour * 24 * 32))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				ctx.WithBlockHeight(4).WithBlockTime(now.Add(time.Hour * 24 * 33))
+				suite.App.EpochsKeeper.BeginBlocker(ctx)
+				epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 			},
 		},
 	}
@@ -107,25 +96,25 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 	for i, tc := range testCases {
 		suite.Run(fmt.Sprintf("Case %d", i), func() {
 			suite.SetupTest() // reset
+			ctx := suite.Ctx()
 
 			// On init genesis, default epochs information is set
 			// To check init genesis again, should make it fresh status
-			epochInfos := suite.App.EpochsKeeper.AllEpochInfos(suite.Ctx)
+			epochInfos := suite.App.EpochsKeeper.AllEpochInfos(ctx)
 			for _, epochInfo := range epochInfos {
-				suite.App.EpochsKeeper.DeleteEpochInfo(suite.Ctx, epochInfo.Identifier)
+				suite.App.EpochsKeeper.DeleteEpochInfo(ctx, epochInfo.Identifier)
 			}
 
-			suite.Ctx = suite.Ctx.WithBlockHeight(1).WithBlockTime(now)
-
 			// check init genesis
-			epochs.InitGenesis(suite.Ctx, suite.App.EpochsKeeper, types.GenesisState{
+			ctx = ctx.WithBlockHeight(1).WithBlockTime(now)
+			epochs.InitGenesis(ctx, suite.App.EpochsKeeper, types.GenesisState{
 				Epochs: []types.EpochInfo{
 					{
 						Identifier:              "monthly",
 						StartTime:               time.Time{},
 						Duration:                time.Hour * 24 * 31,
 						CurrentEpoch:            0,
-						CurrentEpochStartHeight: suite.Ctx.BlockHeight(),
+						CurrentEpochStartHeight: ctx.BlockHeight(),
 						CurrentEpochStartTime:   time.Time{},
 						EpochCountingStarted:    false,
 					},
@@ -146,27 +135,28 @@ func (suite *KeeperTestSuite) TestEpochInfoChangesBeginBlockerAndInitGenesis() {
 }
 
 func (suite *KeeperTestSuite) TestEpochStartingOneMonthAfterInitGenesis() {
+	ctx := suite.Ctx()
 	// On init genesis, default epochs information is set
 	// To check init genesis again, should make it fresh status
-	epochInfos := suite.App.EpochsKeeper.AllEpochInfos(suite.Ctx)
+	epochInfos := suite.App.EpochsKeeper.AllEpochInfos(ctx)
 	for _, epochInfo := range epochInfos {
-		suite.App.EpochsKeeper.DeleteEpochInfo(suite.Ctx, epochInfo.Identifier)
+		suite.App.EpochsKeeper.DeleteEpochInfo(ctx, epochInfo.Identifier)
 	}
 
 	now := time.Now()
 	week := time.Hour * 24 * 7
 	month := time.Hour * 24 * 30
 	initialBlockHeight := int64(1)
-	suite.Ctx = suite.Ctx.WithBlockHeight(initialBlockHeight).WithBlockTime(now)
+	ctx = ctx.WithBlockHeight(initialBlockHeight).WithBlockTime(now)
 
-	epochs.InitGenesis(suite.Ctx, suite.App.EpochsKeeper, types.GenesisState{
+	epochs.InitGenesis(ctx, suite.App.EpochsKeeper, types.GenesisState{
 		Epochs: []types.EpochInfo{
 			{
 				Identifier:              "monthly",
 				StartTime:               now.Add(month),
 				Duration:                time.Hour * 24 * 30,
 				CurrentEpoch:            0,
-				CurrentEpochStartHeight: suite.Ctx.BlockHeight(),
+				CurrentEpochStartHeight: ctx.BlockHeight(),
 				CurrentEpochStartTime:   time.Time{},
 				EpochCountingStarted:    false,
 			},
@@ -174,31 +164,31 @@ func (suite *KeeperTestSuite) TestEpochStartingOneMonthAfterInitGenesis() {
 	})
 
 	// epoch not started yet
-	epochInfo, _ := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+	epochInfo, _ := suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	suite.Require().Equal(epochInfo.CurrentEpoch, int64(0))
 	suite.Require().Equal(epochInfo.CurrentEpochStartHeight, initialBlockHeight)
 	suite.Require().Equal(epochInfo.CurrentEpochStartTime, time.Time{})
 	suite.Require().Equal(epochInfo.EpochCountingStarted, false)
 
 	// after 1 week
-	suite.Ctx = suite.Ctx.WithBlockHeight(2).WithBlockTime(now.Add(week))
-	suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
+	ctx = ctx.WithBlockHeight(2).WithBlockTime(now.Add(week))
+	suite.App.EpochsKeeper.BeginBlocker(ctx)
 
 	// epoch not started yet
-	epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+	epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	suite.Require().Equal(epochInfo.CurrentEpoch, int64(0))
 	suite.Require().Equal(epochInfo.CurrentEpochStartHeight, initialBlockHeight)
 	suite.Require().Equal(epochInfo.CurrentEpochStartTime, time.Time{})
 	suite.Require().Equal(epochInfo.EpochCountingStarted, false)
 
 	// after 1 month
-	suite.Ctx = suite.Ctx.WithBlockHeight(3).WithBlockTime(now.Add(month))
-	suite.App.EpochsKeeper.BeginBlocker(suite.Ctx)
+	ctx = ctx.WithBlockHeight(3).WithBlockTime(now.Add(month))
+	suite.App.EpochsKeeper.BeginBlocker(ctx)
 
 	// epoch started
-	epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+	epochInfo, _ = suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	suite.Require().Equal(epochInfo.CurrentEpoch, int64(1))
-	suite.Require().Equal(epochInfo.CurrentEpochStartHeight, suite.Ctx.BlockHeight())
+	suite.Require().Equal(epochInfo.CurrentEpochStartHeight, ctx.BlockHeight())
 	suite.Require().Equal(epochInfo.CurrentEpochStartTime.UTC().String(), now.Add(month).UTC().String())
 	suite.Require().Equal(epochInfo.EpochCountingStarted, true)
 }

--- a/x/epochs/keeper/epoch_test.go
+++ b/x/epochs/keeper/epoch_test.go
@@ -3,12 +3,14 @@ package keeper_test
 import (
 	"time"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
 	_ "github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/x/epochs/types"
 )
 
 func (suite *KeeperTestSuite) TestEpochLifeCycle() {
 	suite.SetupTest()
+	ctx := suite.Ctx()
 
 	epochInfo := types.EpochInfo{
 		Identifier:            "monthly",
@@ -18,11 +20,11 @@ func (suite *KeeperTestSuite) TestEpochLifeCycle() {
 		CurrentEpochStartTime: time.Time{},
 		EpochCountingStarted:  false,
 	}
-	suite.App.EpochsKeeper.SetEpochInfo(suite.Ctx, epochInfo)
-	epochInfoSaved, _ := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, "monthly")
+	suite.App.EpochsKeeper.SetEpochInfo(ctx, epochInfo)
+	epochInfoSaved, _ := suite.App.EpochsKeeper.GetEpochInfo(ctx, "monthly")
 	suite.Require().Equal(epochInfo, epochInfoSaved)
 
-	allEpochs := suite.App.EpochsKeeper.AllEpochInfos(suite.Ctx)
+	allEpochs := suite.App.EpochsKeeper.AllEpochInfos(ctx)
 	suite.Require().Len(allEpochs, 4)
 	suite.Require().Equal(allEpochs[0].Identifier, "day") // alphabetical order
 	suite.Require().Equal(allEpochs[1].Identifier, "monthly")

--- a/x/epochs/keeper/grpc_query_test.go
+++ b/x/epochs/keeper/grpc_query_test.go
@@ -4,15 +4,16 @@ import (
 	gocontext "context"
 	"time"
 
-	"github.com/Stride-Labs/stride/x/epochs/types"
 	_ "github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/x/epochs/types"
 )
 
 func (suite *KeeperTestSuite) TestQueryEpochInfos() {
 	suite.SetupTest()
 	queryClient := suite.queryClient
 
-	chainStartTime := suite.Ctx.BlockTime()
+	chainStartTime := suite.Ctx().BlockTime()
 
 	// Invalid param
 	epochInfosResponse, err := queryClient.EpochInfos(gocontext.Background(), &types.QueryEpochsInfoRequest{})

--- a/x/interchainquery/keeper/keeper_test.go
+++ b/x/interchainquery/keeper/keeper_test.go
@@ -6,18 +6,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Stride-Labs/stride/app/apptesting"
-	"github.com/Stride-Labs/stride/x/interchainquery/keeper"
-	"github.com/Stride-Labs/stride/x/interchainquery/types"
 )
 
 type KeeperTestSuite struct {
 	apptesting.AppTestHelper
-	msgServer types.MsgServer
 }
 
 func (s *KeeperTestSuite) SetupTest() {
 	s.Setup()
-	s.msgServer = keeper.NewMsgServerImpl(s.App.InterchainqueryKeeper)
 }
 
 func TestKeeperTestSuite(t *testing.T) {

--- a/x/interchainquery/keeper/new_query_test.go
+++ b/x/interchainquery/keeper/new_query_test.go
@@ -60,7 +60,7 @@ func (s *KeeperTestSuite) TestNewQuerySuccessful() {
 	tc := s.SetupNewQuery()
 
 	actualQuery := s.App.InterchainqueryKeeper.NewQuery(
-		s.Ctx,
+		s.Ctx(),
 		tc.module,
 		tc.connectionId,
 		tc.chainId,

--- a/x/stakeibc/keeper/grpc_query_ica_account_test.go
+++ b/x/stakeibc/keeper/grpc_query_ica_account_test.go
@@ -10,7 +10,7 @@ import (
 
 func (suite KeeperTestSuite) TestICAAccountQuery() {
 	item := suite.createTestICAAccount()
-	wctx := sdk.WrapSDKContext(suite.Ctx)
+	wctx := sdk.WrapSDKContext(suite.Ctx())
 	for _, tc := range []struct {
 		desc     string
 		request  *types.QueryGetICAAccountRequest

--- a/x/stakeibc/keeper/ica_account_test.go
+++ b/x/stakeibc/keeper/ica_account_test.go
@@ -6,20 +6,20 @@ import (
 
 func (suite *KeeperTestSuite) createTestICAAccount() types.ICAAccount {
 	item := types.ICAAccount{}
-	suite.App.StakeibcKeeper.SetICAAccount(suite.Ctx, item)
+	suite.App.StakeibcKeeper.SetICAAccount(suite.Ctx(), item)
 	return item
 }
 
 func (suite *KeeperTestSuite) TestICAAccountGet() {
 	item := suite.createTestICAAccount()
-	rst, found := suite.App.StakeibcKeeper.GetICAAccount(suite.Ctx)
+	rst, found := suite.App.StakeibcKeeper.GetICAAccount(suite.Ctx())
 	suite.Require().True(found)
 	suite.Require().Equal(&item, &rst)
 }
 
 func (suite *KeeperTestSuite) TestICAAccountRemove() {
 	suite.createTestICAAccount()
-	suite.App.StakeibcKeeper.RemoveICAAccount(suite.Ctx)
-	_, found := suite.App.StakeibcKeeper.GetICAAccount(suite.Ctx)
+	suite.App.StakeibcKeeper.RemoveICAAccount(suite.Ctx())
+	_, found := suite.App.StakeibcKeeper.GetICAAccount(suite.Ctx())
 	suite.Require().False(found)
 }

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -4,14 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	"github.com/stretchr/testify/suite"
-
-	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	"github.com/cosmos/ibc-go/v3/testing/simapp"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
@@ -19,23 +15,11 @@ import (
 
 	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
 
-	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 
-	"github.com/Stride-Labs/stride/app"
 	"github.com/Stride-Labs/stride/app/apptesting"
 	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
 	"github.com/Stride-Labs/stride/x/stakeibc/types"
-)
-
-var (
-	TestIcaVersion = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
-		Version:                icatypes.Version,
-		ControllerConnectionId: ibctesting.FirstConnectionID,
-		HostConnectionId:       ibctesting.FirstConnectionID,
-		Encoding:               icatypes.EncodingProtobuf,
-		TxType:                 icatypes.TxTypeSDKMultiMsg,
-	}))
 )
 
 type KeeperTestSuite struct {
@@ -52,159 +36,24 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-type MultiChainKeeperTestSuite struct {
-	apptesting.AppTestHelper
-	coordinator *ibctesting.Coordinator
-
-	chainA       *ibctesting.TestChain
-	chainB       *ibctesting.TestChain
-	transferPath *ibctesting.Path
-}
-
-func NewTransferPath(chainA *ibctesting.TestChain, chainB *ibctesting.TestChain) *ibctesting.Path {
-	path := ibctesting.NewPath(chainA, chainB)
-	path.EndpointA.ChannelConfig.PortID = ibctesting.TransferPort
-	path.EndpointB.ChannelConfig.PortID = ibctesting.TransferPort
-	path.EndpointA.ChannelConfig.Order = channeltypes.UNORDERED
-	path.EndpointB.ChannelConfig.Order = channeltypes.UNORDERED
-	path.EndpointA.ChannelConfig.Version = transfertypes.Version
-	path.EndpointB.ChannelConfig.Version = transfertypes.Version
-	return path
-}
-
-func NewIcaPath(chainA *ibctesting.TestChain, chainB *ibctesting.TestChain) *ibctesting.Path {
-	path := ibctesting.NewPath(chainA, chainB)
-	path.EndpointA.ChannelConfig.PortID = icatypes.PortID
-	path.EndpointB.ChannelConfig.PortID = icatypes.PortID
-	path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
-	path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
-	path.EndpointA.ChannelConfig.Version = TestIcaVersion
-	path.EndpointB.ChannelConfig.Version = TestIcaVersion
-	return path
-}
-
-func CopyConnectionAndClientToPath(path *ibctesting.Path, pathToCopy *ibctesting.Path) *ibctesting.Path {
-	path.EndpointA.ClientID = pathToCopy.EndpointA.ClientID
-	path.EndpointB.ClientID = pathToCopy.EndpointB.ClientID
-	path.EndpointA.ConnectionID = pathToCopy.EndpointA.ConnectionID
-	path.EndpointB.ConnectionID = pathToCopy.EndpointB.ConnectionID
-	path.EndpointA.ClientConfig = pathToCopy.EndpointA.ClientConfig
-	path.EndpointB.ClientConfig = pathToCopy.EndpointB.ClientConfig
-	path.EndpointA.ConnectionConfig = pathToCopy.EndpointA.ConnectionConfig
-	path.EndpointB.ConnectionConfig = pathToCopy.EndpointB.ConnectionConfig
-	return path
-}
-
-func RegisterInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
-	portID, err := icatypes.NewControllerPortID(owner)
-	if err != nil {
-		return err
-	}
-
-	channelSequence := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(endpoint.Chain.GetContext())
-
-	if err := endpoint.Chain.App.(*app.StrideApp).ICAControllerKeeper.RegisterInterchainAccount(endpoint.Chain.GetContext(), endpoint.ConnectionID, owner); err != nil {
-		return err
-	}
-
-	endpoint.Chain.App.Commit()
-	endpoint.Chain.NextBlock()
-
-	endpoint.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
-	endpoint.ChannelConfig.PortID = portID
-
-	return nil
-}
-
-func (s *MultiChainKeeperTestSuite) CreateICAChannel(owner string) error {
-	// Create ICA Path and the copy over the client and connection from the transfer path
-	path := NewIcaPath(s.chainA, s.chainB)
-	path = CopyConnectionAndClientToPath(path, s.transferPath)
-
-	// Register the ICA
-	if err := RegisterInterchainAccount(path.EndpointA, owner); err != nil {
-		return err
-	}
-
-	// Complete the handshake
-	if err := path.EndpointB.ChanOpenTry(); err != nil {
-		return err
-	}
-	if err := path.EndpointA.ChanOpenAck(); err != nil {
-		return err
-	}
-	if err := path.EndpointB.ChanOpenConfirm(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *MultiChainKeeperTestSuite) SetupIbc() {
-	s.coordinator = ibctesting.NewCoordinator(s.T(), 0)
-	ibctesting.DefaultTestingAppInit = app.InitIBCTestingApp
-	s.chainA = ibctesting.NewTestChain(s.T(), s.coordinator, "STRIDE")
-
-	ibctesting.DefaultTestingAppInit = ibctesting.SetupTestingApp
-	s.chainB = ibctesting.NewTestChain(s.T(), s.coordinator, "GAIA")
-
-	s.coordinator.Chains = map[string]*ibctesting.TestChain{
-		"STRIDE": s.chainA,
-		"GAIA":   s.chainB,
-	}
-	s.transferPath = NewTransferPath(s.chainA, s.chainB)
-	s.coordinator.Setup(s.transferPath)
-
-	s.Require().Equal("07-tendermint-0", s.transferPath.EndpointA.ClientID)
-	s.Require().Equal("connection-0", s.transferPath.EndpointA.ConnectionID)
-	s.Require().Equal("channel-0", s.transferPath.EndpointA.ChannelID)
-
-	s.Require().Equal("07-tendermint-0", s.transferPath.EndpointB.ClientID)
-	s.Require().Equal("connection-0", s.transferPath.EndpointB.ConnectionID)
-	s.Require().Equal("channel-0", s.transferPath.EndpointB.ChannelID)
-
-	err := s.CreateICAChannel("GAIA.DELEGATION")
-	s.Require().NoError(err, "create delegation ICA")
-
-	err = s.CreateICAChannel("GAIA.FEE")
-	s.Require().NoError(err, "create fee ICA")
-
-	err = s.CreateICAChannel("GAIA.REDEMPTION")
-	s.Require().NoError(err, "create redemption ICA")
-
-	err = s.CreateICAChannel("GAIA.WITHDRAWAL")
-	s.Require().NoError(err, "create withdrawal ICA")
-
-	channels := s.chainA.App.(*app.StrideApp).IBCKeeper.ChannelKeeper.GetAllChannels(s.chainA.GetContext())
-	for _, channel := range channels {
-		fmt.Printf("%v\n", channel)
-	}
-}
-
-func (s *MultiChainKeeperTestSuite) SetupAccounts() (sdk.AccAddress, sdk.AccAddress) {
+func (s *KeeperTestSuite) TestTransfer() {
+	s.SetupIBC("GAIA")
 	addr1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 	addr2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 
 	coins := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000)))
-	err := s.chainA.App.(*app.StrideApp).BankKeeper.MintCoins(s.chainA.GetContext(), minttypes.ModuleName, coins)
+	err := s.App.BankKeeper.MintCoins(s.StrideChain.GetContext(), minttypes.ModuleName, coins)
 	s.Require().NoError(err)
-	err = s.chainA.App.(*app.StrideApp).BankKeeper.SendCoinsFromModuleToAccount(s.chainA.GetContext(), minttypes.ModuleName, addr1, coins)
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.StrideChain.GetContext(), minttypes.ModuleName, addr1, coins)
 	s.Require().NoError(err)
 
-	return addr1, addr2
-}
-
-func (s *MultiChainKeeperTestSuite) TestTransfer() {
-	s.SetupIbc()
-
-	addr1, addr2 := s.SetupAccounts()
 	fmt.Println(addr1.String())
-	fmt.Printf("%v\n", s.chainA.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
+	fmt.Printf("%v\n", s.App.BankKeeper.GetAllBalances(s.StrideChain.GetContext(), addr1))
 	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.chainB.App.(*simapp.SimApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+	fmt.Printf("%v\n", s.HostChain.GetSimApp().BankKeeper.GetAllBalances(s.HostChain.GetContext(), addr2))
 
-	s.chainA.App.(*app.StrideApp).TransferKeeper.SendTransfer(
-		s.chainA.GetContext(),
+	s.App.TransferKeeper.SendTransfer(
+		s.StrideChain.GetContext(),
 		"transfer",
 		"channel-0",
 		sdk.NewCoin("uatom", sdk.NewInt(500)),
@@ -215,31 +64,46 @@ func (s *MultiChainKeeperTestSuite) TestTransfer() {
 	)
 
 	fmt.Println(addr1.String())
-	fmt.Printf("%v\n", s.chainA.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
+	fmt.Printf("%v\n", s.App.BankKeeper.GetAllBalances(s.StrideChain.GetContext(), addr1))
 	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.chainB.App.(*simapp.SimApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+	fmt.Printf("%v\n", s.HostChain.GetSimApp().BankKeeper.GetAllBalances(s.HostChain.GetContext(), addr2))
 }
 
-func (s *MultiChainKeeperTestSuite) TestIca() {
-	s.SetupIbc()
+func (s *KeeperTestSuite) TestCreateChannels() {
+	s.CreateICAChannel("GAIA.DELEGATION")
+	s.CreateICAChannel("GAIA.FEE")
+	s.CreateICAChannel("GAIA.REDEMPTION")
+	s.CreateICAChannel("GAIA.WITHDRAWAL")
 
-	delegationAddress, found := s.chainA.App.(*app.StrideApp).ICAControllerKeeper.GetInterchainAccountAddress(s.chainA.GetContext(), "connection-0", "icacontroller-GAIA.DELEGATION")
+	channels := s.App.IBCKeeper.ChannelKeeper.GetAllChannels(s.StrideChain.GetContext())
+	for _, channel := range channels {
+		fmt.Printf("%v\n", channel)
+	}
+}
+
+func (s *KeeperTestSuite) TestIca() {
+	s.CreateICAChannel("GAIA.DELEGATION")
+	s.CreateICAChannel("GAIA.FEE")
+	s.CreateICAChannel("GAIA.REDEMPTION")
+	s.CreateICAChannel("GAIA.WITHDRAWAL")
+
+	delegationAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.StrideChain.GetContext(), "connection-0", "icacontroller-GAIA.DELEGATION")
 	s.Require().True(found)
 	fmt.Println("DELEGATION ADDRESS:", delegationAddress)
 
-	feeAddress, found := s.chainA.App.(*app.StrideApp).ICAControllerKeeper.GetInterchainAccountAddress(s.chainA.GetContext(), "connection-0", "icacontroller-GAIA.FEE")
+	feeAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.StrideChain.GetContext(), "connection-0", "icacontroller-GAIA.FEE")
 	s.Require().True(found)
 	fmt.Println("FEE ADDRESS:", feeAddress)
 
-	redemptionAddress, found := s.chainA.App.(*app.StrideApp).ICAControllerKeeper.GetInterchainAccountAddress(s.chainA.GetContext(), "connection-0", "icacontroller-GAIA.REDEMPTION")
+	redemptionAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.StrideChain.GetContext(), "connection-0", "icacontroller-GAIA.REDEMPTION")
 	s.Require().True(found)
 	fmt.Println("REDEMPTION ADDRESS:", redemptionAddress)
 
-	withdrawAddress, found := s.chainA.App.(*app.StrideApp).ICAControllerKeeper.GetInterchainAccountAddress(s.chainA.GetContext(), "connection-0", "icacontroller-GAIA.WITHDRAWAL")
+	withdrawAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.StrideChain.GetContext(), "connection-0", "icacontroller-GAIA.WITHDRAWAL")
 	s.Require().True(found)
 	fmt.Println("WITHDRAWAL ADDRESS:", withdrawAddress)
 
-	timeoutTimestamp := uint64(s.chainA.GetContext().BlockTime().UnixNano() + 100_000_000_000)
+	timeoutTimestamp := uint64(s.StrideChain.GetContext().BlockTime().UnixNano() + 100_000_000_000)
 
 	var msgs []sdk.Msg
 	msgs = append(msgs, &banktypes.MsgSend{
@@ -248,7 +112,7 @@ func (s *MultiChainKeeperTestSuite) TestIca() {
 		Amount:      sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
 	})
 
-	data, err := icatypes.SerializeCosmosTx(s.chainA.Codec, msgs)
+	data, err := icatypes.SerializeCosmosTx(s.StrideChain.Codec, msgs)
 	s.Require().NoError(err)
 
 	packetData := icatypes.InterchainAccountPacketData{
@@ -256,14 +120,10 @@ func (s *MultiChainKeeperTestSuite) TestIca() {
 		Data: data,
 	}
 
-	chanCap, found := s.chainA.App.(*app.StrideApp).ScopedIBCKeeper.GetCapability(s.chainA.GetContext(), host.ChannelCapabilityPath("icacontroller-GAIA.DELEGATION", "channel-1"))
+	chanCap, found := s.App.ScopedIBCKeeper.GetCapability(s.StrideChain.GetContext(), host.ChannelCapabilityPath("icacontroller-GAIA.DELEGATION", "channel-1"))
 	s.Require().True(found)
 
-	seq, err := s.chainA.App.(*app.StrideApp).ICAControllerKeeper.SendTx(s.chainA.GetContext(), chanCap, "connection-0", "icacontroller-GAIA.DELEGATION", packetData, timeoutTimestamp)
+	seq, err := s.App.ICAControllerKeeper.SendTx(s.StrideChain.GetContext(), chanCap, "connection-0", "icacontroller-GAIA.DELEGATION", packetData, timeoutTimestamp)
 	s.Require().NoError(err)
 	fmt.Println("SEQUENCE:", seq)
-}
-
-func TestMultiChainKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(MultiChainKeeperTestSuite))
 }

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -1,21 +1,9 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
-	"github.com/tendermint/tendermint/crypto/ed25519"
-
-	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
-
-	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 
 	"github.com/Stride-Labs/stride/app/apptesting"
 	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
@@ -37,98 +25,4 @@ func (s *KeeperTestSuite) GetMsgServer() types.MsgServer {
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
-}
-
-func (s *KeeperTestSuite) TestLiquidStakeTransfer() {
-	s.CreateTransferChannel("GAIA")
-	addr1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
-	addr2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
-
-	coins := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000)))
-	err := s.App.BankKeeper.MintCoins(s.Ctx(), minttypes.ModuleName, coins)
-	s.Require().NoError(err)
-	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx(), minttypes.ModuleName, addr1, coins)
-	s.Require().NoError(err)
-
-	fmt.Println(addr1.String())
-	fmt.Printf("%v\n", s.App.BankKeeper.GetAllBalances(s.Ctx(), addr1))
-	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.HostChain.GetSimApp().BankKeeper.GetAllBalances(s.HostCtx(), addr2))
-
-	s.App.TransferKeeper.SendTransfer(
-		s.Ctx(),
-		"transfer",
-		"channel-0",
-		sdk.NewCoin("uatom", sdk.NewInt(500)),
-		addr1,
-		addr2.String(),
-		clienttypes.NewHeight(0, 300),
-		0,
-	)
-
-	fmt.Println(addr1.String())
-	fmt.Printf("%v\n", s.App.BankKeeper.GetAllBalances(s.Ctx(), addr1))
-	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.HostChain.GetSimApp().BankKeeper.GetAllBalances(s.HostCtx(), addr2))
-}
-
-func (s *KeeperTestSuite) TestCreateChannels() {
-	s.CreateICAChannel("GAIA.DELEGATION")
-	s.CreateICAChannel("GAIA.FEE")
-	s.CreateICAChannel("GAIA.REDEMPTION")
-	s.CreateICAChannel("GAIA.WITHDRAWAL")
-
-	channels := s.App.IBCKeeper.ChannelKeeper.GetAllChannels(s.Ctx())
-	for _, channel := range channels {
-		fmt.Printf("%v\n", channel)
-	}
-
-	s.FundAccount(s.TestAccs[0], sdk.NewCoin("uatom", sdk.NewInt(500)))
-}
-
-func (s *KeeperTestSuite) TestIca() {
-	s.CreateICAChannel("GAIA.DELEGATION")
-	s.CreateICAChannel("GAIA.FEE")
-	s.CreateICAChannel("GAIA.REDEMPTION")
-	s.CreateICAChannel("GAIA.WITHDRAWAL")
-
-	delegationAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.Ctx(), "connection-0", "icacontroller-GAIA.DELEGATION")
-	s.Require().True(found)
-	fmt.Println("DELEGATION ADDRESS:", delegationAddress)
-
-	feeAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.Ctx(), "connection-0", "icacontroller-GAIA.FEE")
-	s.Require().True(found)
-	fmt.Println("FEE ADDRESS:", feeAddress)
-
-	redemptionAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.Ctx(), "connection-0", "icacontroller-GAIA.REDEMPTION")
-	s.Require().True(found)
-	fmt.Println("REDEMPTION ADDRESS:", redemptionAddress)
-
-	withdrawAddress, found := s.App.ICAControllerKeeper.GetInterchainAccountAddress(s.Ctx(), "connection-0", "icacontroller-GAIA.WITHDRAWAL")
-	s.Require().True(found)
-	fmt.Println("WITHDRAWAL ADDRESS:", withdrawAddress)
-
-	timeoutTimestamp := uint64(s.Ctx().BlockTime().UnixNano() + 100_000_000_000)
-
-	var msgs []sdk.Msg
-	msgs = append(msgs, &banktypes.MsgSend{
-		FromAddress: delegationAddress,
-		ToAddress:   feeAddress,
-		Amount:      sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
-	})
-
-	data, err := icatypes.SerializeCosmosTx(s.StrideChain.Codec, msgs)
-	s.Require().NoError(err)
-
-	packetData := icatypes.InterchainAccountPacketData{
-		Type: icatypes.EXECUTE_TX,
-		Data: data,
-	}
-
-	chanCap, found := s.App.ScopedIBCKeeper.GetCapability(s.Ctx(), host.ChannelCapabilityPath("icacontroller-GAIA.DELEGATION", "channel-1"))
-	s.Require().True(found)
-
-	seq, err := s.App.ICAControllerKeeper.SendTx(s.Ctx(), chanCap, "connection-0", "icacontroller-GAIA.DELEGATION", packetData, timeoutTimestamp)
-	s.Require().NoError(err)
-	fmt.Println("SEQUENCE:", seq)
 }

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -29,7 +29,10 @@ type KeeperTestSuite struct {
 
 func (s *KeeperTestSuite) SetupTest() {
 	s.Setup()
-	s.msgServer = keeper.NewMsgServerImpl(s.App.StakeibcKeeper)
+}
+
+func (s *KeeperTestSuite) GetMsgServer() types.MsgServer {
+	return keeper.NewMsgServerImpl(s.App.StakeibcKeeper)
 }
 
 func TestKeeperTestSuite(t *testing.T) {

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -1,12 +1,40 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
+
+	ibctesting "github.com/cosmos/ibc-go/v3/testing"
+	"github.com/stretchr/testify/suite"
+
+	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+
+	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 
 	"github.com/Stride-Labs/stride/app/apptesting"
 	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
 	"github.com/Stride-Labs/stride/x/stakeibc/types"
-	"github.com/stretchr/testify/suite"
+)
+
+var (
+	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
+	TestVersion      = string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
+		Version:                icatypes.Version,
+		ControllerConnectionId: ibctesting.FirstConnectionID,
+		HostConnectionId:       ibctesting.FirstConnectionID,
+		Encoding:               icatypes.EncodingProtobuf,
+		TxType:                 icatypes.TxTypeSDKMultiMsg,
+	}))
 )
 
 type KeeperTestSuite struct {
@@ -21,4 +49,174 @@ func (s *KeeperTestSuite) SetupTest() {
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
+}
+
+type MultiChainKeeperTestSuite struct {
+	apptesting.AppTestHelper
+	coordinator *ibctesting.Coordinator
+
+	chainA *ibctesting.TestChain
+	chainB *ibctesting.TestChain
+	path   *ibctesting.Path
+}
+
+func (s *MultiChainKeeperTestSuite) SetupTestIbc() {
+	s.coordinator = ibctesting.NewCoordinator(s.T(), 2)
+	s.chainA = s.coordinator.GetChain(ibctesting.GetChainID(1))
+	s.chainB = s.coordinator.GetChain(ibctesting.GetChainID(2))
+
+	s.path = ibctesting.NewPath(s.chainA, s.chainB)
+	s.path.EndpointA.ChannelConfig.PortID = ibctesting.TransferPort
+	s.path.EndpointB.ChannelConfig.PortID = ibctesting.TransferPort
+	s.path.EndpointA.ChannelConfig.Version = transfertypes.Version
+	s.path.EndpointB.ChannelConfig.Version = transfertypes.Version
+
+	s.coordinator.Setup(s.path)
+	s.Require().Equal("07-tendermint-0", s.path.EndpointA.ClientID)
+	s.Require().Equal("connection-0", s.path.EndpointA.ConnectionID)
+	s.Require().Equal("channel-0", s.path.EndpointA.ChannelID)
+}
+
+func (s *MultiChainKeeperTestSuite) CreateAccounts() (sdk.AccAddress, sdk.AccAddress) {
+	addr1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	addr2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+
+	coins := sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000)))
+	err := s.chainA.GetSimApp().BankKeeper.MintCoins(s.chainA.GetContext(), minttypes.ModuleName, coins)
+	s.Require().NoError(err)
+	err = s.chainA.GetSimApp().BankKeeper.SendCoinsFromModuleToAccount(s.chainA.GetContext(), minttypes.ModuleName, addr1, coins)
+	s.Require().NoError(err)
+
+	return addr1, addr2
+}
+
+func (s *MultiChainKeeperTestSuite) TestIbc() {
+	s.SetupTestIbc()
+
+	addr1, addr2 := s.CreateAccounts()
+	fmt.Println(addr1.String())
+	fmt.Printf("%v\n", s.chainA.GetSimApp().BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
+	fmt.Println(addr2.String())
+	fmt.Printf("%v\n", s.chainB.GetSimApp().BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+
+	s.chainA.GetSimApp().TransferKeeper.SendTransfer(
+		s.chainA.GetContext(),
+		"transfer",
+		"channel-0",
+		sdk.NewCoin("uatom", sdk.NewInt(500)),
+		addr1,
+		addr2.String(),
+		clienttypes.NewHeight(0, 300),
+		0,
+	)
+
+	fmt.Println(addr1.String())
+	fmt.Printf("%v\n", s.chainA.GetSimApp().BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
+	fmt.Println(addr2.String())
+	fmt.Printf("%v\n", s.chainB.GetSimApp().BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+}
+
+// RegisterInterchainAccount is a helper function for starting the channel handshake
+func RegisterInterchainAccount(endpoint *ibctesting.Endpoint, owner string) error {
+	portID, err := icatypes.NewControllerPortID(owner)
+	if err != nil {
+		return err
+	}
+
+	channelSequence := endpoint.Chain.App.GetIBCKeeper().ChannelKeeper.GetNextChannelSequence(endpoint.Chain.GetContext())
+
+	if err := endpoint.Chain.GetSimApp().ICAControllerKeeper.RegisterInterchainAccount(endpoint.Chain.GetContext(), endpoint.ConnectionID, owner); err != nil {
+		return err
+	}
+
+	// commit state changes for proof verification
+	endpoint.Chain.App.Commit()
+	endpoint.Chain.NextBlock()
+
+	// update port/channel ids
+	endpoint.ChannelID = channeltypes.FormatChannelIdentifier(channelSequence)
+	endpoint.ChannelConfig.PortID = portID
+
+	return nil
+}
+
+func (s *MultiChainKeeperTestSuite) TestSetupIca() {
+	s.coordinator = ibctesting.NewCoordinator(s.T(), 2)
+	s.chainA = s.coordinator.GetChain(ibctesting.GetChainID(1))
+	s.chainB = s.coordinator.GetChain(ibctesting.GetChainID(2))
+
+	// transferPath := ibctesting.NewPath(s.chainA, s.chainB)
+	// transferPath.EndpointA.ChannelConfig.PortID = ibctesting.TransferPort
+	// transferPath.EndpointB.ChannelConfig.PortID = ibctesting.TransferPort
+	// transferPath.EndpointA.ChannelConfig.Version = transfertypes.Version
+	// transferPath.EndpointB.ChannelConfig.Version = transfertypes.Version
+
+	// s.coordinator.Setup(transferPath)
+	// s.Require().Equal("07-tendermint-0", transferPath.EndpointA.ClientID)
+	// s.Require().Equal("connection-0", transferPath.EndpointA.ConnectionID)
+	// s.Require().Equal("channel-0", transferPath.EndpointA.ChannelID)
+
+	path := ibctesting.NewPath(s.chainA, s.chainB)
+	path.EndpointA.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointB.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointA.ChannelConfig.Version = TestVersion
+	path.EndpointB.ChannelConfig.Version = TestVersion
+
+	s.coordinator.SetupConnections(path)
+
+	// err := s.chainA.GetSimApp().ICAControllerKeeper.RegisterInterchainAccount(s.chainA.GetContext(), "connection-0", "GAIA.DELEGATION")
+	err := RegisterInterchainAccount(path.EndpointA, "GAIA.DELEGATION")
+	s.Require().NoError(err)
+
+	channels := s.chainA.GetSimApp().IBCKeeper.ChannelKeeper.GetAllChannels(s.chainA.GetContext())
+	for _, channel := range channels {
+		fmt.Printf("%v\n", channel)
+	}
+
+	err = path.EndpointB.ChanOpenTry()
+	s.Require().NoError(err)
+
+	err = path.EndpointA.ChanOpenAck()
+	s.Require().NoError(err)
+
+	err = path.EndpointB.ChanOpenConfirm()
+	s.Require().NoError(err)
+
+	channels = s.chainA.GetSimApp().IBCKeeper.ChannelKeeper.GetAllChannels(s.chainA.GetContext())
+	for _, channel := range channels {
+		fmt.Printf("%v\n", channel)
+	}
+
+	icaAddress, found := s.chainA.GetSimApp().ICAControllerKeeper.GetInterchainAccountAddress(s.chainA.GetContext(), "connection-0", "icacontroller-GAIA.DELEGATION")
+	s.Require().True(found)
+
+	fmt.Println(icaAddress)
+
+	timeoutTimestamp := uint64(s.chainA.GetContext().BlockTime().UnixNano() + 100_000_000_000)
+
+	_, addr2 := s.CreateAccounts()
+
+	var msgs []sdk.Msg
+	msgs = append(msgs, &banktypes.MsgSend{
+		FromAddress: icaAddress,
+		ToAddress:   addr2.String(),
+		Amount:      sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(1000))),
+	})
+
+	data, err := icatypes.SerializeCosmosTx(s.chainA.Codec, msgs)
+	s.Require().NoError(err)
+
+	packetData := icatypes.InterchainAccountPacketData{
+		Type: icatypes.EXECUTE_TX,
+		Data: data,
+	}
+	chanCap, found := s.chainA.GetSimApp().ScopedIBCKeeper.GetCapability(s.chainA.GetContext(), host.ChannelCapabilityPath("icacontroller-GAIA.DELEGATION", "channel-0"))
+	s.Require().True(found)
+	s.chainA.GetSimApp().ICAControllerKeeper.SendTx(s.chainA.GetContext(), chanCap, "connection-0", "icacontroller-GAIA.DELEGATION", packetData, timeoutTimestamp)
+}
+
+func TestMultiChainKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(MultiChainKeeperTestSuite))
 }

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -1,15 +1,11 @@
 package keeper_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
-	"github.com/tendermint/tendermint/libs/log"
-
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	"github.com/stretchr/testify/suite"
-	dbm "github.com/tendermint/tm-db"
 
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 
@@ -54,22 +50,6 @@ func (s *KeeperTestSuite) SetupTest() {
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
-}
-
-func SetupStrideTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	db := dbm.NewMemDB()
-	testingApp := app.NewStrideApp(
-		log.NewNopLogger(),
-		db,
-		nil,
-		true,
-		map[int64]bool{},
-		app.DefaultNodeHome,
-		5,
-		app.MakeEncodingConfig(),
-		simapp.EmptyAppOptions{},
-	)
-	return testingApp, app.NewDefaultGenesisState()
 }
 
 type MultiChainKeeperTestSuite struct {
@@ -162,7 +142,7 @@ func (s *MultiChainKeeperTestSuite) CreateICAChannel(owner string) error {
 
 func (s *MultiChainKeeperTestSuite) SetupIbc() {
 	s.coordinator = ibctesting.NewCoordinator(s.T(), 0)
-	ibctesting.DefaultTestingAppInit = SetupStrideTestingApp
+	ibctesting.DefaultTestingAppInit = app.InitIBCTestingApp
 	s.chainA = ibctesting.NewTestChain(s.T(), s.coordinator, "STRIDE")
 
 	ibctesting.DefaultTestingAppInit = ibctesting.SetupTestingApp

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -13,9 +13,9 @@ import (
 
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 
-	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/ibc-go/v3/testing/simapp"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
@@ -56,9 +56,7 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-func SetupTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount("cosmos", "cosmos"+sdk.PrefixPublic)
+func SetupStrideTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
 	db := dbm.NewMemDB()
 	testingApp := app.NewStrideApp(
 		log.NewNopLogger(),
@@ -163,10 +161,13 @@ func (s *MultiChainKeeperTestSuite) CreateICAChannel(owner string) error {
 }
 
 func (s *MultiChainKeeperTestSuite) SetupIbc() {
-	ibctesting.DefaultTestingAppInit = SetupTestingApp
 	s.coordinator = ibctesting.NewCoordinator(s.T(), 0)
+	ibctesting.DefaultTestingAppInit = SetupStrideTestingApp
 	s.chainA = ibctesting.NewTestChain(s.T(), s.coordinator, "STRIDE")
+
+	ibctesting.DefaultTestingAppInit = ibctesting.SetupTestingApp
 	s.chainB = ibctesting.NewTestChain(s.T(), s.coordinator, "GAIA")
+
 	s.coordinator.Chains = map[string]*ibctesting.TestChain{
 		"STRIDE": s.chainA,
 		"GAIA":   s.chainB,
@@ -220,7 +221,7 @@ func (s *MultiChainKeeperTestSuite) TestTransfer() {
 	fmt.Println(addr1.String())
 	fmt.Printf("%v\n", s.chainA.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
 	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.chainB.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+	fmt.Printf("%v\n", s.chainB.App.(*simapp.SimApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
 
 	s.chainA.App.(*app.StrideApp).TransferKeeper.SendTransfer(
 		s.chainA.GetContext(),
@@ -236,7 +237,7 @@ func (s *MultiChainKeeperTestSuite) TestTransfer() {
 	fmt.Println(addr1.String())
 	fmt.Printf("%v\n", s.chainA.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainA.GetContext(), addr1))
 	fmt.Println(addr2.String())
-	fmt.Printf("%v\n", s.chainB.App.(*app.StrideApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
+	fmt.Printf("%v\n", s.chainB.App.(*simapp.SimApp).BankKeeper.GetAllBalances(s.chainB.GetContext(), addr2))
 }
 
 func (s *MultiChainKeeperTestSuite) TestIca() {

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -36,7 +36,7 @@ func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }
 
-func (s *KeeperTestSuite) TestTransfer() {
+func (s *KeeperTestSuite) TestLiquidStakeTransfer() {
 	s.CreateTransferChannel("GAIA")
 	addr1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 	addr2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
@@ -79,6 +79,8 @@ func (s *KeeperTestSuite) TestCreateChannels() {
 	for _, channel := range channels {
 		fmt.Printf("%v\n", channel)
 	}
+
+	s.FundAccount(s.TestAccs[0], sdk.NewCoin("uatom", sdk.NewInt(500)))
 }
 
 func (s *KeeperTestSuite) TestIca() {

--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -12,7 +12,6 @@ import (
 
 type KeeperTestSuite struct {
 	apptesting.AppTestHelper
-	msgServer types.MsgServer
 }
 
 func (s *KeeperTestSuite) SetupTest() {

--- a/x/stakeibc/keeper/msg_server_add_validator_test.go
+++ b/x/stakeibc/keeper/msg_server_add_validator_test.go
@@ -75,7 +75,7 @@ func (s *KeeperTestSuite) SetupAddValidator() AddValidatorTestCase {
 		},
 	}
 
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
 	return AddValidatorTestCase{
 		hostZone:           hostZone,
@@ -88,28 +88,28 @@ func (s *KeeperTestSuite) TestAddValidator_Successful() {
 	tc := s.SetupAddValidator()
 
 	// Add first validator
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[0])
+	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	s.Require().NoError(err)
 
-	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
 	s.Require().True(found, "host zone found")
 	s.Require().Equal(1, len(hostZone.Validators), "number of validators should be 1")
 	s.Require().Equal(tc.expectedValidators[:1], hostZone.Validators, "validators list after adding 1 validator")
 
 	// Add second validator
-	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[1])
+	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
 	s.Require().NoError(err)
 
-	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
+	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
 	s.Require().True(found, "host zone found")
 	s.Require().Equal(2, len(hostZone.Validators), "number of validators should be 2")
 	s.Require().Equal(tc.expectedValidators[:2], hostZone.Validators, "validators list after adding 2 validators")
 
 	// Add third validator
-	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[2])
+	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[2])
 	s.Require().NoError(err)
 
-	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
+	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
 	s.Require().True(found, "host zone found")
 	s.Require().Equal(3, len(hostZone.Validators), "number of validators should be 3")
 	s.Require().Equal(tc.expectedValidators, hostZone.Validators, "validators list after adding 3 validators")
@@ -121,7 +121,7 @@ func (s *KeeperTestSuite) TestAddValidator_HostZoneNotFound() {
 	// Replace hostzone in msg to a host zone that doesn't exist
 	badHostZoneMsg := tc.validMsgs[0]
 	badHostZoneMsg.HostZone = "gaia"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &badHostZoneMsg)
+	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
 	s.Require().EqualError(err, "Host Zone (gaia) not found: host zone not found")
 }
 
@@ -132,13 +132,13 @@ func (s *KeeperTestSuite) TestAddValidator_AddressAlreadyExists() {
 	// With no other changes, you would expect this message to be successful
 	hostZone := tc.hostZone
 	hostZone.Validators = []*types.Validator{tc.expectedValidators[0]} // val1
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 	validMsg := tc.validMsgs[2] // val3
 
 	// Change the validator address to val1 so that the message errors
 	badMsg := validMsg
 	badMsg.Address = "stride_VAL1"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &badMsg)
+	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
 	s.Require().EqualError(err, "Validator address (stride_VAL1) already exists on Host Zone (GAIA): validator already exists")
 }
 
@@ -149,12 +149,12 @@ func (s *KeeperTestSuite) TestAddValidator_NameAlreadyExists() {
 	// With no other changes, you would expect this message to be successful
 	hostZone := tc.hostZone
 	hostZone.Validators = []*types.Validator{tc.expectedValidators[0]} // val1
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 	validMsg := tc.validMsgs[2] // val3
 
 	// Change the validator name to val1 so that the message errors
 	badMsg := validMsg
 	badMsg.Name = "val1"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx), &badMsg)
+	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
 	s.Require().EqualError(err, "Validator name (val1) already exists on Host Zone (GAIA): validator already exists")
 }

--- a/x/stakeibc/keeper/msg_server_add_validator_test.go
+++ b/x/stakeibc/keeper/msg_server_add_validator_test.go
@@ -88,7 +88,7 @@ func (s *KeeperTestSuite) TestAddValidator_Successful() {
 	tc := s.SetupAddValidator()
 
 	// Add first validator
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
+	_, err := s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	s.Require().NoError(err)
 
 	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
@@ -97,7 +97,7 @@ func (s *KeeperTestSuite) TestAddValidator_Successful() {
 	s.Require().Equal(tc.expectedValidators[:1], hostZone.Validators, "validators list after adding 1 validator")
 
 	// Add second validator
-	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
+	_, err = s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
 	s.Require().NoError(err)
 
 	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
@@ -106,7 +106,7 @@ func (s *KeeperTestSuite) TestAddValidator_Successful() {
 	s.Require().Equal(tc.expectedValidators[:2], hostZone.Validators, "validators list after adding 2 validators")
 
 	// Add third validator
-	_, err = s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[2])
+	_, err = s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[2])
 	s.Require().NoError(err)
 
 	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
@@ -121,7 +121,7 @@ func (s *KeeperTestSuite) TestAddValidator_HostZoneNotFound() {
 	// Replace hostzone in msg to a host zone that doesn't exist
 	badHostZoneMsg := tc.validMsgs[0]
 	badHostZoneMsg.HostZone = "gaia"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
+	_, err := s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
 	s.Require().EqualError(err, "Host Zone (gaia) not found: host zone not found")
 }
 
@@ -138,7 +138,7 @@ func (s *KeeperTestSuite) TestAddValidator_AddressAlreadyExists() {
 	// Change the validator address to val1 so that the message errors
 	badMsg := validMsg
 	badMsg.Address = "stride_VAL1"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
+	_, err := s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
 	s.Require().EqualError(err, "Validator address (stride_VAL1) already exists on Host Zone (GAIA): validator already exists")
 }
 
@@ -155,6 +155,6 @@ func (s *KeeperTestSuite) TestAddValidator_NameAlreadyExists() {
 	// Change the validator name to val1 so that the message errors
 	badMsg := validMsg
 	badMsg.Name = "val1"
-	_, err := s.msgServer.AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
+	_, err := s.GetMsgServer().AddValidator(sdk.WrapSDKContext(s.Ctx()), &badMsg)
 	s.Require().EqualError(err, "Validator name (val1) already exists on Host Zone (GAIA): validator already exists")
 }

--- a/x/stakeibc/keeper/msg_server_claim_undelegated_tokens_test.go
+++ b/x/stakeibc/keeper/msg_server_claim_undelegated_tokens_test.go
@@ -110,7 +110,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_Successful() {
 	// TODO: check callback data here
 }
 
-func (s *KeeperTestSuite) TestClaimUndelegatedTokens_SuccessfulTransferMessage() {
+func (s *KeeperTestSuite) TestClaimUndelegatedTokens_SuccessfulMsgSendICA() {
 	tc := s.SetupClaimUndelegatedTokens()
 	redemptionRecord := tc.initialState.redemptionRecord
 

--- a/x/stakeibc/keeper/msg_server_claim_undelegated_tokens_test.go
+++ b/x/stakeibc/keeper/msg_server_claim_undelegated_tokens_test.go
@@ -11,14 +11,9 @@ import (
 
 	epochtypes "github.com/Stride-Labs/stride/x/epochs/types"
 	recordtypes "github.com/Stride-Labs/stride/x/records/types"
-	"github.com/Stride-Labs/stride/x/stakeibc/keeper"
 	stakeibckeeper "github.com/Stride-Labs/stride/x/stakeibc/keeper"
 	"github.com/Stride-Labs/stride/x/stakeibc/types"
 	stakeibc "github.com/Stride-Labs/stride/x/stakeibc/types"
-)
-
-var (
-	HostChainId = "GAIA"
 )
 
 type ClaimUndelegatedState struct {
@@ -36,13 +31,13 @@ type ClaimUndelegatedTestCase struct {
 func (s *KeeperTestSuite) SetupClaimUndelegatedTokens() ClaimUndelegatedTestCase {
 	redemptionIcaOwner := "GAIA.REDEMPTION"
 	s.CreateICAChannel(redemptionIcaOwner)
-	s.msgServer = keeper.NewMsgServerImpl(s.App.StakeibcKeeper)
 
+	hostChainId := "GAIA"
 	epochNumber := uint64(1)
 	senderAddr := "stride_SENDER"
 	receiverAddr := "cosmos_RECEIVER"
 	redemptionAddr := s.IcaAddresses[redemptionIcaOwner]
-	redemptionRecordId := fmt.Sprintf("%s.%d.%s", HostChainId, epochNumber, senderAddr)
+	redemptionRecordId := fmt.Sprintf("%s.%d.%s", hostChainId, epochNumber, senderAddr)
 
 	redemptionAccount := stakeibc.ICAAccount{
 		Address: redemptionAddr,
@@ -79,7 +74,7 @@ func (s *KeeperTestSuite) SetupClaimUndelegatedTokens() ClaimUndelegatedTestCase
 	return ClaimUndelegatedTestCase{
 		validMsg: stakeibc.MsgClaimUndelegatedTokens{
 			Creator:    senderAddr,
-			HostZoneId: HostChainId,
+			HostZoneId: hostChainId,
 			Epoch:      1,
 			Sender:     senderAddr,
 		},
@@ -105,7 +100,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_Successful() {
 	redemptionRecordId := tc.initialState.redemptionRecordId
 	expectedRedemptionRecord := tc.initialState.redemptionRecord
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().NoError(err, "claim undelegated tokens")
 
 	actualRedemptionRecord, found := s.App.RecordsKeeper.GetUserRedemptionRecord(s.Ctx(), redemptionRecordId)
@@ -119,7 +114,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_SuccessfulTransferMessage()
 	tc := s.SetupClaimUndelegatedTokens()
 	redemptionRecord := tc.initialState.redemptionRecord
 
-	icaTx, err := s.App.StakeibcKeeper.GetRedemptionTransferMsg(s.Ctx(), &redemptionRecord, HostChainId)
+	icaTx, err := s.App.StakeibcKeeper.GetRedemptionTransferMsg(s.Ctx(), &redemptionRecord, redemptionRecord.HostZoneId)
 	msgs := icaTx.Msgs
 	s.Require().NoError(err, "get redemption transfer msgs error")
 	s.Require().Equal(1, len(msgs), "number of transfer messages")
@@ -131,7 +126,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_NoUserRedemptionRecord() {
 	// Remove the user redemption record
 	s.App.RecordsKeeper.RemoveUserRedemptionRecord(s.Ctx(), tc.initialState.redemptionRecordId)
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	expectedErr := "unable to find claimable redemption record: "
 	expectedErr += "could not get user redemption record: GAIA.1.stride_SENDER: user redemption record error"
 	s.Require().EqualError(err, expectedErr)
@@ -144,7 +139,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_RecordNotClaimable() {
 	alreadyClaimedRedemptionRecord.IsClaimable = false
 	s.App.RecordsKeeper.SetUserRedemptionRecord(s.Ctx(), alreadyClaimedRedemptionRecord)
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	expectedErr := "unable to find claimable redemption record: "
 	expectedErr += "user redemption record is not claimable: GAIA.1.stride_SENDER: user redemption record error"
 	s.Require().EqualError(err, expectedErr)
@@ -156,7 +151,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_RecordNotFound() {
 	invalidMsg := tc.validMsg
 	invalidMsg.HostZoneId = "fake_host_zone"
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	expectedErr := "unable to find claimable redemption record: "
 	expectedErr += "could not get user redemption record: fake_host_zone.1.stride_SENDER: user redemption record error"
 	s.Require().EqualError(err, expectedErr)
@@ -173,7 +168,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_HostZoneNotFound() {
 	badRedemptionRecord.Id = badRedemptionRecordId
 	s.App.RecordsKeeper.SetUserRedemptionRecord(s.Ctx(), badRedemptionRecord)
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	expectedErr := "unable to build redemption transfer message: Host zone fake_host_zone not found: host zone not registered"
 	s.Require().EqualError(err, expectedErr)
 }
@@ -185,7 +180,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_NoRedemptionAccount() {
 	hostZone.RedemptionAccount = nil
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	expectedErr := "unable to build redemption transfer message: "
 	expectedErr += "Redemption account not found for host zone GAIA: host zone not registered"
 	s.Require().EqualError(err, expectedErr)
@@ -196,7 +191,7 @@ func (s *KeeperTestSuite) TestClaimUndelegatedTokens_NoEpochTracker() {
 	tc := s.SetupClaimUndelegatedTokens()
 	s.App.StakeibcKeeper.RemoveEpochTracker(s.Ctx(), epochtypes.STRIDE_EPOCH)
 
-	_, err := s.msgServer.ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().ClaimUndelegatedTokens(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	expectedErr := "unable to build redemption transfer message: "
 	expectedErr += "Epoch tracker not found for epoch stride_epoch: epoch not found"
 	s.Require().EqualError(err, expectedErr)

--- a/x/stakeibc/keeper/msg_server_delete_validator_test.go
+++ b/x/stakeibc/keeper/msg_server_delete_validator_test.go
@@ -65,7 +65,7 @@ func (s *KeeperTestSuite) TestDeleteValidator_Successful() {
 	tc := s.SetupDeleteValidator()
 
 	// Delete first validator
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
+	_, err := s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	s.Require().NoError(err)
 
 	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
@@ -74,7 +74,7 @@ func (s *KeeperTestSuite) TestDeleteValidator_Successful() {
 	s.Require().Equal(tc.initialValidators[1:], hostZone.Validators, "validators list after removing 1 validator")
 
 	// Delete second validator
-	_, err = s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
+	_, err = s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
 	s.Require().NoError(err)
 
 	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
@@ -88,7 +88,7 @@ func (s *KeeperTestSuite) TestDeleteValidator_HostZoneNotFound() {
 	// Replace hostzone in msg to a host zone that doesn't exist
 	badHostZoneMsg := tc.validMsgs[0]
 	badHostZoneMsg.HostZone = "gaia"
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
+	_, err := s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
 	errMsg := "Validator (stride_VAL1) not removed from host zone (gaia) "
 	errMsg += "| err: HostZone (gaia) not found: host zone not found: validator not removed"
 	s.Require().EqualError(err, errMsg)
@@ -100,7 +100,7 @@ func (s *KeeperTestSuite) TestAddValidator_AddressNotFound() {
 	// Build message with a validator address that does not exist
 	badAddressMsg := tc.validMsgs[0]
 	badAddressMsg.ValAddr = "stride_VAL5"
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badAddressMsg)
+	_, err := s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badAddressMsg)
 
 	errMsg := "Validator (stride_VAL5) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator address (stride_VAL5) not found on host zone (GAIA): "
@@ -116,7 +116,7 @@ func (s *KeeperTestSuite) TestAddValidator_NonZeroDelegation() {
 	hostZone.Validators[0].DelegationAmt = 1
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
+	_, err := s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	errMsg := "Validator (stride_VAL1) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator (stride_VAL1) has non-zero delegation (1) or weight (0): "
 	errMsg += "validator not removed"
@@ -131,7 +131,7 @@ func (s *KeeperTestSuite) TestAddValidator_NonZeroWeight() {
 	hostZone.Validators[0].Weight = 1
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
+	_, err := s.GetMsgServer().DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	errMsg := "Validator (stride_VAL1) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator (stride_VAL1) has non-zero delegation (0) or weight (1): "
 	errMsg += "validator not removed"

--- a/x/stakeibc/keeper/msg_server_delete_validator_test.go
+++ b/x/stakeibc/keeper/msg_server_delete_validator_test.go
@@ -52,7 +52,7 @@ func (s *KeeperTestSuite) SetupDeleteValidator() DeleteValidatorTestCase {
 		},
 	}
 
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
 	return DeleteValidatorTestCase{
 		hostZone:          hostZone,
@@ -65,19 +65,19 @@ func (s *KeeperTestSuite) TestDeleteValidator_Successful() {
 	tc := s.SetupDeleteValidator()
 
 	// Delete first validator
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[0])
+	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	s.Require().NoError(err)
 
-	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
 	s.Require().True(found, "host zone found")
 	s.Require().Equal(1, len(hostZone.Validators), "number of validators should be 1")
 	s.Require().Equal(tc.initialValidators[1:], hostZone.Validators, "validators list after removing 1 validator")
 
 	// Delete second validator
-	_, err = s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[1])
+	_, err = s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[1])
 	s.Require().NoError(err)
 
-	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
+	hostZone, found = s.App.StakeibcKeeper.GetHostZone(s.Ctx(), "GAIA")
 	s.Require().True(found, "host zone found")
 	s.Require().Equal(0, len(hostZone.Validators), "number of validators should be 0")
 }
@@ -88,7 +88,7 @@ func (s *KeeperTestSuite) TestDeleteValidator_HostZoneNotFound() {
 	// Replace hostzone in msg to a host zone that doesn't exist
 	badHostZoneMsg := tc.validMsgs[0]
 	badHostZoneMsg.HostZone = "gaia"
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &badHostZoneMsg)
+	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badHostZoneMsg)
 	errMsg := "Validator (stride_VAL1) not removed from host zone (gaia) "
 	errMsg += "| err: HostZone (gaia) not found: host zone not found: validator not removed"
 	s.Require().EqualError(err, errMsg)
@@ -100,7 +100,7 @@ func (s *KeeperTestSuite) TestAddValidator_AddressNotFound() {
 	// Build message with a validator address that does not exist
 	badAddressMsg := tc.validMsgs[0]
 	badAddressMsg.ValAddr = "stride_VAL5"
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &badAddressMsg)
+	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &badAddressMsg)
 
 	errMsg := "Validator (stride_VAL5) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator address (stride_VAL5) not found on host zone (GAIA): "
@@ -114,9 +114,9 @@ func (s *KeeperTestSuite) TestAddValidator_NonZeroDelegation() {
 	// Update val1 to have a non-zero delegation
 	hostZone := tc.hostZone
 	hostZone.Validators[0].DelegationAmt = 1
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[0])
+	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	errMsg := "Validator (stride_VAL1) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator (stride_VAL1) has non-zero delegation (1) or weight (0): "
 	errMsg += "validator not removed"
@@ -129,9 +129,9 @@ func (s *KeeperTestSuite) TestAddValidator_NonZeroWeight() {
 	// Update val1 to have a non-zero weight
 	hostZone := tc.hostZone
 	hostZone.Validators[0].Weight = 1
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
-	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx), &tc.validMsgs[0])
+	_, err := s.msgServer.DeleteValidator(sdk.WrapSDKContext(s.Ctx()), &tc.validMsgs[0])
 	errMsg := "Validator (stride_VAL1) not removed from host zone (GAIA) "
 	errMsg += "| err: Validator (stride_VAL1) has non-zero delegation (0) or weight (1): "
 	errMsg += "validator not removed"

--- a/x/stakeibc/keeper/msg_server_liquid_stake_test.go
+++ b/x/stakeibc/keeper/msg_server_liquid_stake_test.go
@@ -77,9 +77,9 @@ func (s *KeeperTestSuite) SetupLiquidStake() LiquidStakeTestCase {
 		Amount:             initialDepositAmount,
 	}
 
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, epochTracker)
-	s.App.RecordsKeeper.SetDepositRecord(s.Ctx, initialDepositRecord)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx(), epochTracker)
+	s.App.RecordsKeeper.SetDepositRecord(s.Ctx(), initialDepositRecord)
 
 	return LiquidStakeTestCase{
 		user:        user,
@@ -102,24 +102,24 @@ func (s *KeeperTestSuite) TestLiquidStake_Successful() {
 	zoneAccount := tc.zoneAccount
 	msg := tc.validMsg
 	stakeAmount := sdk.NewInt(int64(msg.Amount))
-	initialStAtomSupply := s.App.BankKeeper.GetSupply(s.Ctx, stAtom)
+	initialStAtomSupply := s.App.BankKeeper.GetSupply(s.Ctx(), stAtom)
 
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &msg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &msg)
 	s.Require().NoError(err)
 
 	// Confirm balances
 	// User IBC/UATOM balance should have DECREASED by the size of the stake
 	expectedUserAtomBalance := user.atomBalance.SubAmount(stakeAmount)
-	actualUserAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, user.acc, ibcAtom)
+	actualUserAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), user.acc, ibcAtom)
 	// zoneAccount IBC/UATOM balance should have INCREASED by the size of the stake
 	expectedzoneAccountAtomBalance := zoneAccount.atomBalance.AddAmount(stakeAmount)
-	actualzoneAccountAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, zoneAccount.acc, ibcAtom)
+	actualzoneAccountAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), zoneAccount.acc, ibcAtom)
 	// User STUATOM balance should have INCREASED by the size of the stake
 	expectedUserStAtomBalance := user.stAtomBalance.AddAmount(stakeAmount)
-	actualUserStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, user.acc, stAtom)
+	actualUserStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), user.acc, stAtom)
 	// Bank supply of STUATOM should have INCREASED by the size of the stake
 	expectedBankSupply := initialStAtomSupply.AddAmount(stakeAmount)
-	actualBankSupply := s.App.BankKeeper.GetSupply(s.Ctx, stAtom)
+	actualBankSupply := s.App.BankKeeper.GetSupply(s.Ctx(), stAtom)
 
 	s.CompareCoins(expectedUserStAtomBalance, actualUserStAtomBalance, "user stuatom balance")
 	s.CompareCoins(expectedUserAtomBalance, actualUserAtomBalance, "user ibc/uatom balance")
@@ -127,7 +127,7 @@ func (s *KeeperTestSuite) TestLiquidStake_Successful() {
 	s.CompareCoins(expectedBankSupply, actualBankSupply, "bank stuatom supply")
 
 	// Confirm deposit record adjustment
-	records := s.App.RecordsKeeper.GetAllDepositRecord(s.Ctx)
+	records := s.App.RecordsKeeper.GetAllDepositRecord(s.Ctx())
 	s.Require().Len(records, 1, "number of deposit records")
 
 	expectedDepositRecordAmount := tc.initialState.depositRecordAmount + stakeAmount.Int64()
@@ -149,13 +149,13 @@ func (s *KeeperTestSuite) TestLiquidStake_DifferentRedemptionRates() {
 		// Update rate in host zone
 		hz := tc.initialState.hostZone
 		hz.RedemptionRate = newRedemptionRate
-		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hz)
+		s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hz)
 
 		// Liquid stake for each balance and confirm stAtom minted
-		startingStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, user.acc, stAtom).Amount.Int64()
-		_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &msg)
+		startingStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), user.acc, stAtom).Amount.Int64()
+		_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &msg)
 		s.Require().NoError(err)
-		endingStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, user.acc, stAtom).Amount.Int64()
+		endingStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), user.acc, stAtom).Amount.Int64()
 		actualStAtomMinted := endingStAtomBalance - startingStAtomBalance
 
 		expectedStAtomMinted := int64(float64(msg.Amount) / redemptionRateFloat)
@@ -171,9 +171,9 @@ func (s *KeeperTestSuite) TestLiquidStake_RateBelowMinThreshold() {
 	// Update rate in host zone to below min threshold
 	hz := tc.initialState.hostZone
 	hz.RedemptionRate = sdk.NewDec(8).Quo(sdk.NewDec(10))
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hz)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hz)
 
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &msg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &msg)
 	s.Require().Error(err)
 }
 
@@ -182,7 +182,7 @@ func (s *KeeperTestSuite) TestLiquidStake_HostZoneNotFound() {
 	// Update message with invalid denom
 	invalidMsg := tc.validMsg
 	invalidMsg.HostDenom = "ufakedenom"
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "no host zone found for denom (ufakedenom): host zone not registered")
 }
@@ -192,8 +192,8 @@ func (s *KeeperTestSuite) TestLiquidStake_IbcCoinParseError() {
 	// Update hostzone with denom that can't be parsed
 	badHostZone := tc.initialState.hostZone
 	badHostZone.IBCDenom = "ibc.0atom"
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, badHostZone)
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), badHostZone)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 
 	badCoin := fmt.Sprintf("%d%s", tc.validMsg.Amount, badHostZone.IBCDenom)
 	s.Require().EqualError(err, fmt.Sprintf("failed to parse coin (%s): invalid decimal coin expression: %s", badCoin, badCoin))
@@ -205,10 +205,10 @@ func (s *KeeperTestSuite) TestLiquidStake_NotIbcDenom() {
 	badDenom := "i/uatom"
 	badHostZone := tc.initialState.hostZone
 	badHostZone.IBCDenom = badDenom
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, badHostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), badHostZone)
 	// Fund the user with the non-ibc denom
 	s.FundAccount(tc.user.acc, sdk.NewInt64Coin(badDenom, 1000000000))
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 
 	s.Require().EqualError(err, fmt.Sprintf("denom is not an IBC token (%s): invalid token denom", badHostZone.IBCDenom))
 }
@@ -219,7 +219,7 @@ func (s *KeeperTestSuite) TestLiquidStake_InsufficientBalance() {
 	invalidMsg := tc.validMsg
 	balance := tc.user.atomBalance.Amount.Int64()
 	invalidMsg.Amount = uint64(balance + 1000)
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	expectedErr := fmt.Sprintf("balance is lower than staking amount. staking amount: %d, balance: %d: insufficient funds", balance+1000, balance)
 	s.Require().EqualError(err, expectedErr)
@@ -228,8 +228,8 @@ func (s *KeeperTestSuite) TestLiquidStake_InsufficientBalance() {
 func (s *KeeperTestSuite) TestLiquidStake_NoEpochTracker() {
 	tc := s.SetupLiquidStake()
 	// Remove epoch tracker
-	s.App.StakeibcKeeper.RemoveEpochTracker(s.Ctx, epochtypes.STRIDE_EPOCH)
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	s.App.StakeibcKeeper.RemoveEpochTracker(s.Ctx(), epochtypes.STRIDE_EPOCH)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 
 	s.Require().EqualError(err, fmt.Sprintf("no epoch number for epoch (%s): not found", epochtypes.STRIDE_EPOCH))
 }
@@ -237,8 +237,8 @@ func (s *KeeperTestSuite) TestLiquidStake_NoEpochTracker() {
 func (s *KeeperTestSuite) TestLiquidStake_NoDepositRecord() {
 	tc := s.SetupLiquidStake()
 	// Remove deposit record
-	s.App.RecordsKeeper.RemoveDepositRecord(s.Ctx, 1)
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	s.App.RecordsKeeper.RemoveDepositRecord(s.Ctx(), 1)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 
 	s.Require().EqualError(err, fmt.Sprintf("no deposit record for epoch (%d): not found", 1))
 }
@@ -249,8 +249,8 @@ func (s *KeeperTestSuite) TestLiquidStake_InvalidHostAddress() {
 	// Update hostzone with invalid address
 	badHostZone := tc.initialState.hostZone
 	badHostZone.Address = "cosmosXXX"
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, badHostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), badHostZone)
 
-	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	_, err := s.msgServer.LiquidStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().EqualError(err, "could not bech32 decode address cosmosXXX of zone with id: GAIA")
 }

--- a/x/stakeibc/keeper/msg_server_redeem_stake_test.go
+++ b/x/stakeibc/keeper/msg_server_redeem_stake_test.go
@@ -74,9 +74,9 @@ func (s *KeeperTestSuite) SetupRedeemStake() RedeemStakeTestCase {
 	}
 	epochUnbondingRecord.HostZoneUnbondings = append(epochUnbondingRecord.HostZoneUnbondings, hostZoneUnbonding)
 
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, epochTrackerDay)
-	s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx(), epochTrackerDay)
+	s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx(), epochUnbondingRecord)
 
 	return RedeemStakeTestCase{
 		user:        user,
@@ -110,23 +110,23 @@ func (s *KeeperTestSuite) TestRedeemStake_Successful() {
 	redeemAmount := sdk.NewInt(amt)
 
 	// get the initial unbonding amount *before* calling liquid stake, so we can use it to calc expected vs actual in diff space
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &msg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &msg)
 	s.Require().NoError(err)
 
 	// User STUATOM balance should have DECREASED by the amount to be redeemed
 	expectedUserStAtomBalance := user.stAtomBalance.SubAmount(redeemAmount)
-	actualUserStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx, user.acc, "stuatom")
+	actualUserStAtomBalance := s.App.BankKeeper.GetBalance(s.Ctx(), user.acc, "stuatom")
 	s.CompareCoins(expectedUserStAtomBalance, actualUserStAtomBalance, "user stuatom balance")
 
 	// Gaia's hostZoneUnbonding NATIVE TOKEN amount should have INCREASED from 0 to the amount redeemed multiplied by the redemption rate
 	// Gaia's hostZoneUnbonding STTOKEN amount should have INCREASED from 0 to be amount redeemed
-	epochTracker, found := s.App.StakeibcKeeper.GetEpochTracker(s.Ctx, "day")
+	epochTracker, found := s.App.StakeibcKeeper.GetEpochTracker(s.Ctx(), "day")
 	s.Require().True(found, "epoch tracker")
-	epochUnbondingRecord, found := s.App.RecordsKeeper.GetEpochUnbondingRecord(s.Ctx, epochTracker.EpochNumber)
+	epochUnbondingRecord, found := s.App.RecordsKeeper.GetEpochUnbondingRecord(s.Ctx(), epochTracker.EpochNumber)
 	s.Require().True(found, "epoch unbonding record")
-	hostZoneUnbonding, found := s.App.RecordsKeeper.GetHostZoneUnbondingByChainId(s.Ctx, epochUnbondingRecord.EpochNumber, chainId)
+	hostZoneUnbonding, found := s.App.RecordsKeeper.GetHostZoneUnbondingByChainId(s.Ctx(), epochUnbondingRecord.EpochNumber, chainId)
 	s.Require().True(found, "host zone unbondings by chain ID")
-	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, msg.HostZone)
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), msg.HostZone)
 	s.Require().True(found, "host zone")
 
 	nativeRedemptionAmount := (redeemAmount.Int64() * hostZone.RedemptionRate.TruncateInt().Int64())
@@ -144,7 +144,7 @@ func (s *KeeperTestSuite) TestRedeemStake_Successful() {
 	userRedemptionRecords := hostZoneUnbonding.UserRedemptionRecords
 	s.Require().Equal(len(userRedemptionRecords), 1)
 	userRedemptionRecordId := userRedemptionRecords[0]
-	userRedemptionRecord, found := s.App.RecordsKeeper.GetUserRedemptionRecord(s.Ctx, userRedemptionRecordId)
+	userRedemptionRecord, found := s.App.RecordsKeeper.GetUserRedemptionRecord(s.Ctx(), userRedemptionRecordId)
 	s.Require().True(found)
 	// check amount
 	s.Require().Equal(expectedHostZoneUnbondingNativeAmount, int64(userRedemptionRecord.Amount), "redemption record amount")
@@ -164,22 +164,22 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidCreatorAddress() {
 
 	// cosmos instead of stride address
 	invalidMsg.Creator = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: invalid Bech32 prefix; expected stride, got cosmos: invalid address", invalidMsg.Creator))
 
 	// invalid stride address
 	invalidMsg.Creator = "stride1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: decoding bech32 failed: invalid checksum (expected 8dpmg9 got yxp8uf): invalid address", invalidMsg.Creator))
 
 	// empty address
 	invalidMsg.Creator = ""
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: empty address string is not allowed: invalid address", invalidMsg.Creator))
 
 	// wrong len address
 	invalidMsg.Creator = "stride1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ufabc"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: decoding bech32 failed: invalid character not part of charset: 98: invalid address", invalidMsg.Creator))
 }
 
@@ -188,7 +188,7 @@ func (s *KeeperTestSuite) TestRedeemStake_HostZoneNotFound() {
 
 	invalidMsg := tc.validMsg
 	invalidMsg.HostZone = "fake_host_zone"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "host zone is invalid: fake_host_zone: host zone not registered")
 }
@@ -198,9 +198,9 @@ func (s *KeeperTestSuite) TestRedeemStake_RateAboveMaxThreshold() {
 
 	hz := tc.hostZone
 	hz.RedemptionRate = sdk.NewDec(100)
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hz)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hz)
 
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().Error(err)
 }
 
@@ -211,22 +211,22 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidReceiverAddress() {
 
 	// stride instead of cosmos address
 	invalidMsg.Receiver = "stride159atdlc3ksl50g0659w5tq42wwer334ajl7xnq"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (invalid Bech32 prefix; expected cosmos, got stride): invalid address")
 
 	// invalid cosmos address
 	invalidMsg.Receiver = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ua"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (decoding bech32 failed: invalid checksum (expected yxp8uf got yxp8ua)): invalid address")
 
 	// empty address
 	invalidMsg.Receiver = ""
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (empty address string is not allowed): invalid address")
 
 	// wrong len address
 	invalidMsg.Receiver = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ufa"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (decoding bech32 failed: invalid checksum (expected xp8ugp got xp8ufa)): invalid address")
 }
 
@@ -235,7 +235,7 @@ func (s *KeeperTestSuite) TestRedeemStake_RedeemMoreThanStaked() {
 
 	invalidMsg := tc.validMsg
 	invalidMsg.Amount = uint64(1_000_000_000_000_000)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, fmt.Sprintf("cannot unstake an amount g.t. staked balance on host zone: %d: invalid amount", invalidMsg.Amount))
 }
@@ -244,8 +244,8 @@ func (s *KeeperTestSuite) TestRedeemStake_NoEpochTrackerDay() {
 	tc := s.SetupRedeemStake()
 
 	invalidMsg := tc.validMsg
-	s.App.RecordsKeeper.RemoveEpochUnbondingRecord(s.Ctx, tc.initialState.epochNumber)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	s.App.RecordsKeeper.RemoveEpochUnbondingRecord(s.Ctx(), tc.initialState.epochNumber)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "latest epoch unbonding record not found: epoch unbonding record not found")
 }
@@ -254,9 +254,9 @@ func (s *KeeperTestSuite) TestRedeemStake_UserAlreadyRedeemedThisEpoch() {
 	tc := s.SetupRedeemStake()
 
 	invalidMsg := tc.validMsg
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().NoError(err)
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("user already redeemed this epoch: GAIA.1.%s: redemption record already exists", s.TestAccs[0]))
 }
 
@@ -275,8 +275,8 @@ func (s *KeeperTestSuite) TestRedeemStake_HostZoneNoUnbondings() {
 	}
 	epochUnbondingRecord.HostZoneUnbondings = append(epochUnbondingRecord.HostZoneUnbondings, hostZoneUnbonding)
 
-	s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &invalidMsg)
+	s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx(), epochUnbondingRecord)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "host zone not found in unbondings: GAIA: host zone not registered")
 }
@@ -285,10 +285,10 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidHostAddress() {
 	tc := s.SetupRedeemStake()
 
 	// Update hostzone with invalid address
-	badHostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.validMsg.HostZone)
+	badHostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.validMsg.HostZone)
 	badHostZone.Address = "cosmosXXX"
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, badHostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), badHostZone)
 
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
+	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().EqualError(err, "could not bech32 decode address cosmosXXX of zone with id: GAIA")
 }

--- a/x/stakeibc/keeper/msg_server_redeem_stake_test.go
+++ b/x/stakeibc/keeper/msg_server_redeem_stake_test.go
@@ -110,7 +110,7 @@ func (s *KeeperTestSuite) TestRedeemStake_Successful() {
 	redeemAmount := sdk.NewInt(amt)
 
 	// get the initial unbonding amount *before* calling liquid stake, so we can use it to calc expected vs actual in diff space
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &msg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &msg)
 	s.Require().NoError(err)
 
 	// User STUATOM balance should have DECREASED by the amount to be redeemed
@@ -164,22 +164,22 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidCreatorAddress() {
 
 	// cosmos instead of stride address
 	invalidMsg.Creator = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: invalid Bech32 prefix; expected stride, got cosmos: invalid address", invalidMsg.Creator))
 
 	// invalid stride address
 	invalidMsg.Creator = "stride1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8uf"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: decoding bech32 failed: invalid checksum (expected 8dpmg9 got yxp8uf): invalid address", invalidMsg.Creator))
 
 	// empty address
 	invalidMsg.Creator = ""
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: empty address string is not allowed: invalid address", invalidMsg.Creator))
 
 	// wrong len address
 	invalidMsg.Creator = "stride1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ufabc"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("creator address is invalid: %s. err: decoding bech32 failed: invalid character not part of charset: 98: invalid address", invalidMsg.Creator))
 }
 
@@ -188,7 +188,7 @@ func (s *KeeperTestSuite) TestRedeemStake_HostZoneNotFound() {
 
 	invalidMsg := tc.validMsg
 	invalidMsg.HostZone = "fake_host_zone"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "host zone is invalid: fake_host_zone: host zone not registered")
 }
@@ -200,7 +200,7 @@ func (s *KeeperTestSuite) TestRedeemStake_RateAboveMaxThreshold() {
 	hz.RedemptionRate = sdk.NewDec(100)
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hz)
 
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().Error(err)
 }
 
@@ -211,22 +211,22 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidReceiverAddress() {
 
 	// stride instead of cosmos address
 	invalidMsg.Receiver = "stride159atdlc3ksl50g0659w5tq42wwer334ajl7xnq"
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (invalid Bech32 prefix; expected cosmos, got stride): invalid address")
 
 	// invalid cosmos address
 	invalidMsg.Receiver = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ua"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (decoding bech32 failed: invalid checksum (expected yxp8uf got yxp8ua)): invalid address")
 
 	// empty address
 	invalidMsg.Receiver = ""
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (empty address string is not allowed): invalid address")
 
 	// wrong len address
 	invalidMsg.Receiver = "cosmos1g6qdx6kdhpf000afvvpte7hp0vnpzapuyxp8ufa"
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, "invalid receiver address (decoding bech32 failed: invalid checksum (expected xp8ugp got xp8ufa)): invalid address")
 }
 
@@ -235,7 +235,7 @@ func (s *KeeperTestSuite) TestRedeemStake_RedeemMoreThanStaked() {
 
 	invalidMsg := tc.validMsg
 	invalidMsg.Amount = uint64(1_000_000_000_000_000)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, fmt.Sprintf("cannot unstake an amount g.t. staked balance on host zone: %d: invalid amount", invalidMsg.Amount))
 }
@@ -245,7 +245,7 @@ func (s *KeeperTestSuite) TestRedeemStake_NoEpochTrackerDay() {
 
 	invalidMsg := tc.validMsg
 	s.App.RecordsKeeper.RemoveEpochUnbondingRecord(s.Ctx(), tc.initialState.epochNumber)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "latest epoch unbonding record not found: epoch unbonding record not found")
 }
@@ -254,9 +254,9 @@ func (s *KeeperTestSuite) TestRedeemStake_UserAlreadyRedeemedThisEpoch() {
 	tc := s.SetupRedeemStake()
 
 	invalidMsg := tc.validMsg
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().NoError(err)
-	_, err = s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err = s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 	s.Require().EqualError(err, fmt.Sprintf("user already redeemed this epoch: GAIA.1.%s: redemption record already exists", s.TestAccs[0]))
 }
 
@@ -276,7 +276,7 @@ func (s *KeeperTestSuite) TestRedeemStake_HostZoneNoUnbondings() {
 	epochUnbondingRecord.HostZoneUnbondings = append(epochUnbondingRecord.HostZoneUnbondings, hostZoneUnbonding)
 
 	s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx(), epochUnbondingRecord)
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &invalidMsg)
 
 	s.Require().EqualError(err, "host zone not found in unbondings: GAIA: host zone not registered")
 }
@@ -289,6 +289,6 @@ func (s *KeeperTestSuite) TestRedeemStake_InvalidHostAddress() {
 	badHostZone.Address = "cosmosXXX"
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), badHostZone)
 
-	_, err := s.msgServer.RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
+	_, err := s.GetMsgServer().RedeemStake(sdk.WrapSDKContext(s.Ctx()), &tc.validMsg)
 	s.Require().EqualError(err, "could not bech32 decode address cosmosXXX of zone with id: GAIA")
 }

--- a/x/stakeibc/keeper/update_redemption_rates_test.go
+++ b/x/stakeibc/keeper/update_redemption_rates_test.go
@@ -34,7 +34,7 @@ func (s *KeeperTestSuite) SetupUpdateRedemptionRates(
 		Amount:     int64(undelegatedBal),
 		Status:     recordtypes.DepositRecord_STAKE,
 	}
-	s.App.RecordsKeeper.AppendDepositRecord(s.Ctx, toBeStakedDepositRecord)
+	s.App.RecordsKeeper.AppendDepositRecord(s.Ctx(), toBeStakedDepositRecord)
 
 	// add a balance to the stakeibc module account (via records)
 	//    to comprise the stakeibc module account balance i.e. "to be transferred"
@@ -43,7 +43,7 @@ func (s *KeeperTestSuite) SetupUpdateRedemptionRates(
 		Amount:     int64(justDepositedBal),
 		Status:     recordtypes.DepositRecord_TRANSFER,
 	}
-	s.App.RecordsKeeper.AppendDepositRecord(s.Ctx, toBeTransferedDepositRecord)
+	s.App.RecordsKeeper.AppendDepositRecord(s.Ctx(), toBeTransferedDepositRecord)
 
 	// set the stSupply by minting to a random user account
 	user := Account{
@@ -59,7 +59,7 @@ func (s *KeeperTestSuite) SetupUpdateRedemptionRates(
 		StakedBal:      stakedBal,
 		RedemptionRate: initialRedemptionRate,
 	}
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
 
 	return UpdateRedemptionRatesTestCase{
 		hostZone:   hostZone,
@@ -81,9 +81,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRatesSuccessful() {
 	s.Require().Equal(initialRedemptionRate, sdk.NewDec(1), "t0 rr")
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -115,9 +115,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRatesRandomized() {
 	s.Require().Equal(initialRedemptionRate, sdk.NewDec(1), "t0 rr")
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -149,9 +149,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateZeroStAssets() {
 	s.Require().Equal(initialRedemptionRate, sdk.NewDec(1), "t0 rr")
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -173,9 +173,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateZeroNativeAssets() {
 	s.Require().Equal(initialRedemptionRate, sdk.NewDec(1), "t0 rr")
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -198,9 +198,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateNoModuleAccountRecords() {
 
 	// filter out the TRANSFER record from the records when updating the redemption rate
 	records := tc.allRecords[1:]
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -223,9 +223,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateNoStakeDepositRecords() {
 
 	// filter out the STAKE record from the records when updating the redemption rate
 	records := tc.allRecords[:1]
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -249,9 +249,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateNoStakedBal() {
 	s.Require().Equal(initialRedemptionRate, sdk.NewDec(1))
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 
@@ -280,9 +280,9 @@ func (s *KeeperTestSuite) TestUpdateRedemptionRateRandominitialRedemptionRate() 
 	tc := s.SetupUpdateRedemptionRates(stakedBal, undelegatedBal, justDepositedBal, stSupply, initialRedemptionRate)
 
 	records := tc.allRecords
-	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx, records)
+	s.App.StakeibcKeeper.UpdateRedemptionRates(s.Ctx(), records)
 
-	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.hostZone.ChainId)
+	hz, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), tc.hostZone.ChainId)
 	s.Require().True(found, "hz found")
 	rrNew := hz.RedemptionRate
 


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change
* Many functions in our code base issue IBC or ICA transactions. With the current unit testing framework, issuing these transactions will cause the test to fail. This PR mocks out the necessary Stride state  (e.g. clients/connections/channels) to allow these transactions to succeed.

## Brief Changelog
- Integrated `ibctesting` to our framework through the `AppTestHelper`
- `AppTestHelper` now contains:
  - `StrideChain`: An instance of our chain casted as an ibctesting `TestChain`
  - `HostChain`: A `SimApp` chain casted as an ibctesting `TestChain`
  - `Coordinator`: A broker between chains - responsible for updating clients and keeping chains in sync
- Added helper functions to create transfer or ICA channels (and the clients and connections that go with them)
- Modified `msg_server_claim_undelegated_tokens_test.go` so that it calls the true public facing function (`ClaimUndelegatedTokens`) - which includes an ICA transaction. Previously, the test would call nested functions so it could stop short of the ICA transfer
- Added additional test cases to the claim undelegated tokens test to demonstrate the additional coverage with this new framework

## Breaking Changes
* The following must be changed in existing unit tests
```
s.Ctx → s.Ctx()
s.msgServer → s.GetMsgServer()
```

## Usage
* If you need IBC transfer functionality, call `s.CreateTransferChannel(hostChainId)` in the test's setup function
* If you need ICA transfer functionality, call `s.CreateICAChannel(owner)` in the test's setup function
  * The first time this is called, it will automatically create a transfer channel
* Multiple channels are supported. If needed, you can mock out all 4 ICA channels at once.
* Keep using `s.App` to access stride/stakeibc keeper functions
* Use `s.HostApp` to access the host chains keeper. However, see "Shortcomings/Future Work" below.

## IBC Testing Terminology
* **Coordinator**: Keeps track of two chains
* **Path**: Represents a channel 
* **Endpoint**: Represents an end of a channel and the associated clients and connections

## Testing and Verifying
- Verified by unit tests and integration tests
- Integration test results
```
gaia_tests.bats
 ✓ [INTEGRATION-BASIC] address names are correct
 ✓ [INTEGRATION-BASIC] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mints stATOM
 ✓ [INTEGRATION-BASIC-GAIA] tokens were transferred to GAIA after liquid staking
 ✓ [INTEGRATION-BASIC-GAIA] tokens on GAIA were staked
 ✓ [INTEGRATION-BASIC-GAIA] redemption works
 ✓ [INTEGRATION-BASIC-GAIA] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being reinvested, exchange rate updating
 ✓ [NOT-IMPLEMENTED] reinvestment and revenue amounts are correct

10 tests, 0 failures

osmo_tests.bats
 ✓ [INTEGRATION-BASIC] address names are correct
 ✓ [INTEGRATION-BASIC] host zones successfully registered
 ✓ [INTEGRATION-BASIC-OSMO] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-OSMO] liquid stake mints stOSMO
 ✓ [INTEGRATION-BASIC-OSMO] tokens were transferred to OSMO after liquid staking
 ✓ [INTEGRATION-BASIC-OSMO] tokens on OSMO were staked
 ✓ [INTEGRATION-BASIC-OSMO] redemption works
 ✓ [INTEGRATION-BASIC-OSMO] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-OSMO] rewards are being reinvested, exchange rate updating
 ✓ [NOT-IMPLEMENTED] reinvestment and revenue amounts are correct

10 tests, 0 failures

juno_tests.bats
 ✓ [INTEGRATION-BASIC] address names are correct
 ✓ [INTEGRATION-BASIC] host zones successfully registered
 ✓ [INTEGRATION-BASIC-JUNO] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-JUNO] liquid stake mints stJUNO
 ✓ [INTEGRATION-BASIC-JUNO] tokens were transferred to JUNO after liquid staking
 ✓ [INTEGRATION-BASIC-JUNO] tokens on JUNO were staked
 ✓ [INTEGRATION-BASIC-JUNO] redemption works
 ✓ [INTEGRATION-BASIC-JUNO] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-JUNO] rewards are being reinvested, exchange rate updating
 ✓ [NOT-IMPLEMENTED] reinvestment and revenue amounts are correct

10 tests, 0 failures
```

## Shortcomings/Future Work
* The focus of this PR is on Stride's state. We can extend this in the future to identify changes on the host chain, but that is out of the scope of this PR.
* I have yet to test the IBC transfer functionality with an actual function from our code base. I've only tested with the raw `SendTx` functions. I'll make sure to test it in the next unit test that I write (in a separate repo)

## Documentation and Release Note
  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no) no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no) no
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  / README.md  /   not documented) N/A
  - Does this pull request update existing proto field values (and require a backend and frontend migration)? (yes / no) no
  - Does this pull request change existing proto field names (and require a frontend migration)? (yes / no) no

