### PR TITLE
add undelegate callback unittest

### DIFF
--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -2,9 +2,6 @@ package apptesting
 
 import (
 	"strings"
-	"time"
-
-	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -274,7 +271,6 @@ func (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg, msgResponse *pr
 	for i, msg := range msgs {
 		var data []byte
 		var err error
-		msgResponse = &stakingTypes.MsgUndelegateResponse{CompletionTime: time.Now()}.(proto.Message)
 		if msgResponse != nil {
 			// see: https://github.com/cosmos/cosmos-sdk/blob/1dee068932d32ba2a87ba67fc399ae96203ec76d/types/result.go#L246
 			data, err = proto.Marshal(*msgResponse)

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -2,6 +2,9 @@ package apptesting
 
 import (
 	"strings"
+	"time"
+
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -264,15 +267,24 @@ func CopyConnectionAndClientToPath(path *ibctesting.Path, pathToCopy *ibctesting
 	return path
 }
 
-func (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg) channeltypes.Acknowledgement {
+func (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg, msgResponse *proto.Message) channeltypes.Acknowledgement {
 	txMsgData := &sdk.TxMsgData{
 		Data: make([]*sdk.MsgData, len(msgs)),
 	}
 	for i, msg := range msgs {
-		msgResponse := []byte("msg_response")
+		var data []byte
+		var err error
+		msgResponse = &stakingTypes.MsgUndelegateResponse{CompletionTime: time.Now()}.(proto.Message)
+		if msgResponse != nil {
+			// see: https://github.com/cosmos/cosmos-sdk/blob/1dee068932d32ba2a87ba67fc399ae96203ec76d/types/result.go#L246
+			data, err = proto.Marshal(*msgResponse)
+			s.Require().NoError(err, "marshal error")
+		} else {
+			data = []byte("msg_response")
+		}
 		txMsgData.Data[i] = &sdk.MsgData{
 			MsgType: sdk.MsgTypeURL(msg),
-			Data:    msgResponse,
+			Data:    data,
 		}
 
 	}

--- a/x/stakeibc/keeper/icacallbacks_claim_test.go
+++ b/x/stakeibc/keeper/icacallbacks_claim_test.go
@@ -42,7 +42,7 @@ func (s *KeeperTestSuite) SetupClaimCallback() ClaimCallbackTestCase {
 	packet := channeltypes.Packet{}
 	var msgs []sdk.Msg
 	msgs = append(msgs, &banktypes.MsgSend{})
-	ack := s.ICAPacketAcknowledgement(msgs)
+	ack := s.ICAPacketAcknowledgement(msgs, nil)
 	callbackArgs := types.ClaimCallback{
 		UserRedemptionRecordId: recordId,
 	}

--- a/x/stakeibc/keeper/icacallbacks_delegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate_test.go
@@ -75,7 +75,7 @@ func (s *KeeperTestSuite) SetupDelegateCallback() DelegateCallbackTestCase {
 	packet := channeltypes.Packet{}
 	var msgs []sdk.Msg
 	msgs = append(msgs, &stakingTypes.MsgDelegate{}, &stakingTypes.MsgDelegate{})
-	ack := s.ICAPacketAcknowledgement(msgs)
+	ack := s.ICAPacketAcknowledgement(msgs, nil)
 	val1SplitDelegation := types.SplitDelegation{
 		Validator: val1.Address,
 		Amount:    uint64(val1RelAmt),

--- a/x/stakeibc/keeper/icacallbacks_redemption_test.go
+++ b/x/stakeibc/keeper/icacallbacks_redemption_test.go
@@ -72,7 +72,7 @@ func (s *KeeperTestSuite) SetupRedemptionCallback() RedemptionCallbackTestCase {
 	packet := channeltypes.Packet{}
 	var msgs []sdk.Msg
 	msgs = append(msgs, &banktypes.MsgSend{})
-	ack := s.ICAPacketAcknowledgement(msgs)
+	ack := s.ICAPacketAcknowledgement(msgs, nil)
 	callbackArgs := types.RedemptionCallback{
 		HostZoneId:              HostChainId,
 		EpochUnbondingRecordIds: []uint64{epochNumber},

--- a/x/stakeibc/keeper/icacallbacks_reinvest_test.go
+++ b/x/stakeibc/keeper/icacallbacks_reinvest_test.go
@@ -58,7 +58,7 @@ func (s *KeeperTestSuite) SetupReinvestCallback() ReinvestCallbackTestCase {
 	packet := channeltypes.Packet{}
 	var msgs []sdk.Msg
 	msgs = append(msgs, &banktypes.MsgSend{}, &banktypes.MsgSend{})
-	ack := s.ICAPacketAcknowledgement(msgs)
+	ack := s.ICAPacketAcknowledgement(msgs, nil)
 	callbackArgs := types.ReinvestCallback{
 		HostZoneId:     HostChainId,
 		ReinvestAmount: sdk.NewCoin(Atom, sdk.NewInt(reinvestAmt)),

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -161,7 +161,7 @@ func (k Keeper) UpdateHostZoneUnbondings(
 		}
 		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, zone.ChainId)
 		if !found {
-			errMsg := fmt.Sprintf("Host zone not found (%s) in epoch unbonding record: %d", zone.ChainId, epochNumber)
+			errMsg := fmt.Sprintf("Host zone unbonding not found (%s) in epoch unbonding record: %d", zone.ChainId, epochNumber)
 			k.Logger(ctx).Error(errMsg)
 			return 0, sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, errMsg)
 		}

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -143,7 +143,12 @@ func (k Keeper) GetLatestCompletionTime(ctx sdk.Context, txMsgData *sdk.TxMsgDat
 	return &latestCompletionTime, nil
 }
 
-func (k Keeper) UpdateHostZoneUnbondings(ctx sdk.Context, latestCompletionTime time.Time, zone types.HostZone, undelegateCallback types.UndelegateCallback) (stTokenBurnAmount int64, err error) {
+func (k Keeper) UpdateHostZoneUnbondings(
+	ctx sdk.Context,
+	latestCompletionTime time.Time,
+	zone types.HostZone,
+	undelegateCallback types.UndelegateCallback,
+) (stTokenBurnAmount int64, err error) {
 	// Update the status and time of each hostZoneUnbonding on each epochUnbondingRecord and grab the number of stTokens that need to be burned
 	for _, epochNumber := range undelegateCallback.EpochUnbondingRecordIds {
 		epochUnbondingRecord, found := k.RecordsKeeper.GetEpochUnbondingRecord(ctx, epochNumber)

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -149,7 +149,9 @@ func (k Keeper) UpdateHostZoneUnbondings(
 	zone types.HostZone,
 	undelegateCallback types.UndelegateCallback,
 ) (stTokenBurnAmount int64, err error) {
-	// Update the status and time of each hostZoneUnbonding on each epochUnbondingRecord and grab the number of stTokens that need to be burned
+	// UpdateHostZoneUnbondings does two things:
+	// 		1. Update the status and time of each hostZoneUnbonding on each epochUnbondingRecord
+	// 		2. Return the number of stTokens that need to be burned
 	for _, epochNumber := range undelegateCallback.EpochUnbondingRecordIds {
 		epochUnbondingRecord, found := k.RecordsKeeper.GetEpochUnbondingRecord(ctx, epochNumber)
 		if !found {

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -40,25 +40,25 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 	logMsg := fmt.Sprintf("UndelegateCallback executing packet: %d, source: %s %s, dest: %s %s",
 		packet.Sequence, packet.SourceChannel, packet.SourcePort, packet.DestinationChannel, packet.DestinationPort)
 	k.Logger(ctx).Info(logMsg)
+
+	// handle transaction failure cases
 	if ack == nil {
 		// handle timeout
 		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback timeout, txMsgData is nil, packet %v", packet))
 		return nil
 	}
-
 	txMsgData, err := icacallbacks.GetTxMsgData(ctx, *ack, k.Logger(ctx))
 	if err != nil {
 		k.Logger(ctx).Error(fmt.Sprintf("failed to fetch txMsgData, packet %v", packet))
 		return sdkerrors.Wrap(icacallbackstypes.ErrTxMsgData, err.Error())
 	}
-
 	if len(txMsgData.Data) == 0 {
 		// handle tx failure
 		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback tx failed, txMsgData is empty, ack error, packet %v", packet))
 		return nil
 	}
 
-	// unmarshal the callback args and get the host zone
+	// fetch relevant state
 	undelegateCallback, err := k.UnmarshalUndelegateCallbackArgs(ctx, args)
 	if err != nil {
 		errMsg := fmt.Sprintf("Unable to unmarshal undelegate callback args | %s", err.Error())
@@ -66,13 +66,38 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 		return sdkerrors.Wrapf(types.ErrUnmarshalFailure, errMsg)
 	}
 	k.Logger(ctx).Info(fmt.Sprintf("UndelegateCallback, HostZone: %s", undelegateCallback.HostZoneId))
-
-	hostZone, found := k.GetHostZone(ctx, undelegateCallback.HostZoneId)
+	zone, found := k.GetHostZone(ctx, undelegateCallback.HostZoneId)
 	if !found {
 		return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, "Host zone not found: %s", undelegateCallback.HostZoneId)
 	}
 
-	// Redelegate to each validator and updated host zone staked balance if successful
+	// core callback logic
+	err = k.updateDelegationBalances(ctx, zone, undelegateCallback)
+	if err != nil {
+		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback | %s", err.Error()))
+		return err
+	}
+	latestCompletionTime, err := k.getLatestCompletionTime(ctx, txMsgData)
+	if err != nil {
+		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback | %s", err.Error()))
+		return err
+	}
+	stTokenBurnAmount, err := k.updateHostZoneUnbondings(ctx, *latestCompletionTime, zone, undelegateCallback)
+	if err != nil {
+		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback | %s", err.Error()))
+		return err
+	}
+	err = k.burnTokens(ctx, zone, stTokenBurnAmount)
+	if err != nil {
+		k.Logger(ctx).Error(fmt.Sprintf("UndelegateCallback | %s", err.Error()))
+		return err
+	}
+
+	return nil
+}
+
+func (k Keeper) updateDelegationBalances(ctx sdk.Context, zone types.HostZone, undelegateCallback types.UndelegateCallback) error {
+	// Undelegate from each validator and update host zone staked balance, if successful
 	for _, undelegation := range undelegateCallback.SplitDelegations {
 		undelegateAmt, err := cast.ToInt64E(undelegation.Amount)
 		k.Logger(ctx).Info(fmt.Sprintf("UndelegateCallback, Undelegation: %d, validator: %s", undelegateAmt, undelegation.Validator))
@@ -82,14 +107,17 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 			return sdkerrors.Wrapf(types.ErrIntCast, errMsg)
 		}
 		undelegateVal := undelegation.Validator
-		success := k.AddDelegationToValidator(ctx, hostZone, undelegateVal, -undelegateAmt)
+		success := k.AddDelegationToValidator(ctx, zone, undelegateVal, -undelegateAmt)
 		if !success {
 			return sdkerrors.Wrapf(types.ErrValidatorDelegationChg, "Failed to remove delegation to validator")
 		}
-		hostZone.StakedBal -= undelegation.Amount
+		zone.StakedBal -= undelegation.Amount
 	}
-	k.SetHostZone(ctx, hostZone)
+	k.SetHostZone(ctx, zone)
+	return nil
+}
 
+func (k Keeper) getLatestCompletionTime(ctx sdk.Context, txMsgData *sdk.TxMsgData) (*time.Time, error) {
 	// Update the completion time using the latest completion time across each message within the transaction
 	latestCompletionTime := time.Time{}
 	for _, msgResponseBytes := range txMsgData.Data {
@@ -98,7 +126,7 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 		if err != nil {
 			errMsg := fmt.Sprintf("Unable to unmarshal undelegation tx response | %s", err)
 			k.Logger(ctx).Error(errMsg)
-			return sdkerrors.Wrapf(types.ErrUnmarshalFailure, errMsg)
+			return nil, sdkerrors.Wrapf(types.ErrUnmarshalFailure, errMsg)
 		}
 		if undelegateResponse.CompletionTime.After(latestCompletionTime) {
 			latestCompletionTime = undelegateResponse.CompletionTime
@@ -107,23 +135,25 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 	if latestCompletionTime.IsZero() {
 		errMsg := fmt.Sprintf("Invalid completion time (%s) from txMsg", latestCompletionTime.String())
 		k.Logger(ctx).Error(errMsg)
-		return types.ErrInvalidPacketCompletionTime
+		return nil, types.ErrInvalidPacketCompletionTime
 	}
+	return &latestCompletionTime, nil
+}
 
-	// Update the status and time of each unbonding record and grab the number of stTokens that need to be burned
-	stAmountToBurn := int64(0)
+func (k Keeper) updateHostZoneUnbondings(ctx sdk.Context, latestCompletionTime time.Time, zone types.HostZone, undelegateCallback types.UndelegateCallback) (stTokenBurnAmount int64, err error) {
+	// Update the status and time of each epoch unbonding record and grab the number of stTokens that need to be burned
 	for _, epochNumber := range undelegateCallback.EpochUnbondingRecordIds {
 		epochUnbondingRecord, found := k.RecordsKeeper.GetEpochUnbondingRecord(ctx, epochNumber)
 		if !found {
 			errMsg := fmt.Sprintf("Unable to find epoch unbonding record for epoch: %d", epochNumber)
 			k.Logger(ctx).Error(errMsg)
-			return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, errMsg)
+			return 0, sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, errMsg)
 		}
-		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, hostZone.ChainId)
+		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, zone.ChainId)
 		if !found {
-			errMsg := fmt.Sprintf("Host zone not found (%s) in epoch unbonding record: %d", hostZone.ChainId, epochNumber)
+			errMsg := fmt.Sprintf("Host zone not found (%s) in epoch unbonding record: %d", zone.ChainId, epochNumber)
 			k.Logger(ctx).Error(errMsg)
-			return sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, errMsg)
+			return 0, sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, errMsg)
 		}
 
 		// Keep track of the stTokens that need to be burned
@@ -131,46 +161,47 @@ func UndelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 		if err != nil {
 			errMsg := fmt.Sprintf("Could not convert stTokenAmount to int64 in redeem stake | %s", err.Error())
 			k.Logger(ctx).Error(errMsg)
-			return sdkerrors.Wrapf(types.ErrIntCast, errMsg)
+			return 0, sdkerrors.Wrapf(types.ErrIntCast, errMsg)
 		}
-		stAmountToBurn += stTokenAmount
+		stTokenBurnAmount += stTokenAmount
 
 		// Update the bonded status and time
 		hostZoneUnbonding.Status = recordstypes.HostZoneUnbonding_UNBONDED
 		hostZoneUnbonding.UnbondingTime = cast.ToUint64(latestCompletionTime.UnixNano())
-		updatedEpochUnbondingRecord, success := k.RecordsKeeper.AddHostZoneToEpochUnbondingRecord(ctx, epochUnbondingRecord.EpochNumber, hostZone.ChainId, hostZoneUnbonding)
+		updatedEpochUnbondingRecord, success := k.RecordsKeeper.AddHostZoneToEpochUnbondingRecord(ctx, epochUnbondingRecord.EpochNumber, zone.ChainId, hostZoneUnbonding)
 		if !success {
-			k.Logger(ctx).Error(fmt.Sprintf("Failed to set host zone epoch unbonding record: epochNumber %d, chainId %s, hostZoneUnbonding %v", epochUnbondingRecord.EpochNumber, hostZone.ChainId, hostZoneUnbonding))
-			return sdkerrors.Wrapf(types.ErrEpochNotFound, "couldn't set host zone epoch unbonding record. err: %s", err.Error())
+			k.Logger(ctx).Error(fmt.Sprintf("Failed to set host zone epoch unbonding record: epochNumber %d, chainId %s, hostZoneUnbonding %v", epochUnbondingRecord.EpochNumber, zone.ChainId, hostZoneUnbonding))
+			return 0, sdkerrors.Wrapf(types.ErrEpochNotFound, "couldn't set host zone epoch unbonding record. err: %s", err.Error())
 		}
 		k.RecordsKeeper.SetEpochUnbondingRecord(ctx, *updatedEpochUnbondingRecord)
 
 		logMsg := fmt.Sprintf("Set unbonding time to %s for host zone %s's unbonding record: %d",
-			latestCompletionTime.String(), hostZone.ChainId, epochNumber)
+			latestCompletionTime.String(), zone.ChainId, epochNumber)
 		k.Logger(ctx).Info(logMsg)
 	}
+	return stTokenBurnAmount, nil
+}
 
-	// Burn stTokens
-	stCoinDenom := types.StAssetDenomFromHostZoneDenom(hostZone.HostDenom)
-	stCoinString := sdk.NewDec(stAmountToBurn).String() + stCoinDenom
+func (k Keeper) burnTokens(ctx sdk.Context, zone types.HostZone, stTokenBurnAmount int64) error {
+	stCoinDenom := types.StAssetDenomFromHostZoneDenom(zone.HostDenom)
+	stCoinString := sdk.NewDec(stTokenBurnAmount).String() + stCoinDenom
 	stCoin, err := sdk.ParseCoinNormalized(stCoinString)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "could not parse burnCoin: %s. err: %s", stCoinString, err.Error())
 	}
-	bech32ZoneAddress, err := sdk.AccAddressFromBech32(hostZone.Address)
+	bech32ZoneAddress, err := sdk.AccAddressFromBech32(zone.Address)
 	if err != nil {
-		return fmt.Errorf("could not bech32 decode address %s of zone with id: %s", hostZone.Address, hostZone.ChainId)
+		return fmt.Errorf("could not bech32 decode address %s of zone with id: %s", zone.Address, zone.ChainId)
 	}
 	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, bech32ZoneAddress, types.ModuleName, sdk.NewCoins(stCoin))
 	if err != nil {
-		return fmt.Errorf("could not send coins from account %s to module %s. err: %s", hostZone.Address, types.ModuleName, err.Error())
+		return fmt.Errorf("could not send coins from account %s to module %s. err: %s", zone.Address, types.ModuleName, err.Error())
 	}
 	err = k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(stCoin))
 	if err != nil {
 		k.Logger(ctx).Error(fmt.Sprintf("Failed to burn stAssets upon successful unbonding %s", err.Error()))
-		return sdkerrors.Wrapf(types.ErrInsufficientFunds, "couldn't burn %d %s tokens in module account. err: %s", stAmountToBurn, stCoinDenom, err.Error())
+		return sdkerrors.Wrapf(types.ErrInsufficientFunds, "couldn't burn %d %s tokens in module account. err: %s", stTokenBurnAmount, stCoinDenom, err.Error())
 	}
-
 	k.Logger(ctx).Info(fmt.Sprintf("Total supply %s", k.bankKeeper.GetSupply(ctx, stCoinDenom)))
 	return nil
 }

--- a/x/stakeibc/keeper/icacallbacks_undelegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate_test.go
@@ -218,3 +218,16 @@ func (s *KeeperTestSuite) TestUndelegateCallback_WrongCallbackArgs() {
 	s.Require().EqualError(err, "Unable to unmarshal undelegate callback args | unexpected EOF: unable to unmarshal data structure")
 	s.checkStateIfUndelegateCallbackFailed(tc)
 }
+
+func (s *KeeperTestSuite) TestUndelegateCallback_HostNotFound() {
+	tc := s.SetupUndelegateCallback()
+	valid := tc.validArgs
+	s.App.StakeibcKeeper.RemoveHostZone(s.Ctx(), chainId)
+	err := stakeibckeeper.UndelegateCallback(s.App.StakeibcKeeper, s.Ctx(), valid.packet, valid.ack, valid.args)
+	s.Require().EqualError(err, "Host zone not found: GAIA: key not found")
+}
+
+// Test updateDelegationBalances
+// Test getLatestCompletionTime
+// Test updateHostZoneUnbondings
+// Test burnTokens

--- a/x/stakeibc/keeper/icacallbacks_undelegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate_test.go
@@ -163,29 +163,29 @@ func (s *KeeperTestSuite) TestUndelegateCallback_Successful() {
 }
 
 func (s *KeeperTestSuite) checkStateIfUndelegateCallbackFailed(tc UndelegateCallbackTestCase) {
-	// initialState := tc.initialState
+	initialState := tc.initialState
 
-	// // Check that stakedBal has NOT decreased on the host zone
-	// hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), chainId)
-	// s.Require().True(found)
-	// s.Require().Equal(int64(hostZone.StakedBal), initialState.stakedBal)
+	// Check that stakedBal has NOT decreased on the host zone
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), chainId)
+	s.Require().True(found)
+	s.Require().Equal(int64(hostZone.StakedBal), int64(initialState.stakedBal))
 
-	// // Check that Delegations on validators have NOT decreased
-	// s.Require().True(len(hostZone.Validators) == 2, "Expected 2 validators")
-	// val1 := hostZone.Validators[0]
-	// s.Require().Equal(int64(val1.DelegationAmt), int64(initialState.val1Bal))
-	// val2 := hostZone.Validators[1]
-	// s.Require().Equal(int64(val2.DelegationAmt), int64(initialState.val2Bal))
+	// Check that Delegations on validators have NOT decreased
+	s.Require().True(len(hostZone.Validators) == 2, "Expected 2 validators")
+	val1 := hostZone.Validators[0]
+	s.Require().Equal(int64(val1.DelegationAmt), int64(initialState.val1Bal))
+	val2 := hostZone.Validators[1]
+	s.Require().Equal(int64(val2.DelegationAmt), int64(initialState.val2Bal))
 
-	// epochUnbondingRecord, found := s.App.RecordsKeeper.GetEpochUnbondingRecord(s.Ctx(), initialState.epochNumber)
-	// s.Require().True(found)
-	// s.Require().Equal(len(epochUnbondingRecord.HostZoneUnbondings), 1)
-	// hzu := epochUnbondingRecord.HostZoneUnbondings[0]
-	// s.Require().Equal(int64(hzu.UnbondingTime), 0, "completion time is NOT set on the hzu")
-	// s.Require().Equal(hzu.Status, recordtypes.HostZoneUnbonding_BONDED, "hzu status is set to BONDED")
-	// zoneAccount, err := sdk.AccAddressFromBech32(hostZone.Address)
-	// s.Require().NoError(err)
-	// s.Require().Equal(s.App.BankKeeper.GetBalance(s.Ctx(), zoneAccount, stAtom).Amount.Int64(), initialState.balanceToUnstake, "tokens are NOT burned")
+	epochUnbondingRecord, found := s.App.RecordsKeeper.GetEpochUnbondingRecord(s.Ctx(), initialState.epochNumber)
+	s.Require().True(found)
+	s.Require().Equal(len(epochUnbondingRecord.HostZoneUnbondings), 1)
+	hzu := epochUnbondingRecord.HostZoneUnbondings[0]
+	s.Require().Equal(int64(hzu.UnbondingTime), int64(0), "completion time is NOT set on the hzu")
+	s.Require().Equal(hzu.Status, recordtypes.HostZoneUnbonding_BONDED, "hzu status is set to BONDED")
+	zoneAccount, err := sdk.AccAddressFromBech32(hostZone.Address)
+	s.Require().NoError(err)
+	s.Require().Equal(s.App.BankKeeper.GetBalance(s.Ctx(), zoneAccount, stAtom).Amount.Int64(), initialState.balanceToUnstake+int64(10), "tokens are NOT burned")
 }
 
 func (s *KeeperTestSuite) TestUndelegateCallback_UndelegateCallbackTimeout() {

--- a/x/stakeibc/keeper/icacallbacks_undelegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate_test.go
@@ -1,8 +1,6 @@
 package keeper_test
 
 import (
-	"time"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
@@ -81,8 +79,8 @@ func (s *KeeperTestSuite) SetupUndelegateCallback() UndelegateCallbackTestCase {
 	var msgs []sdk.Msg
 	msgs = append(msgs, &stakingTypes.MsgUndelegate{}, &stakingTypes.MsgUndelegate{})
 	// TODO add an unbonding time to the response
-	msgUndelegateResponse := &stakingTypes.MsgUndelegateResponse{CompletionTime: time.Now()}
-	ack := s.ICAPacketAcknowledgement(msgs, &msgUndelegateResponse)
+	// msgUndelegateResponse := &stakingTypes.MsgUndelegateResponse{CompletionTime: time.Now()}
+	ack := s.ICAPacketAcknowledgement(msgs, nil)
 	val1SplitDelegation := types.SplitDelegation{
 		Validator: val1.Address,
 		Amount:    uint64(val1RelAmt),

--- a/x/stakeibc/keeper/icacallbacks_undelegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate_test.go
@@ -1,0 +1,164 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	_ "github.com/stretchr/testify/suite"
+
+	recordtypes "github.com/Stride-Labs/stride/x/records/types"
+	stakeibckeeper "github.com/Stride-Labs/stride/x/stakeibc/keeper"
+	"github.com/Stride-Labs/stride/x/stakeibc/types"
+	stakeibc "github.com/Stride-Labs/stride/x/stakeibc/types"
+)
+
+type UndelegateCallbackState struct {
+	callbackArgs types.UndelegateCallback
+}
+
+type UndelegateCallbackArgs struct {
+	packet channeltypes.Packet
+	ack    *channeltypes.Acknowledgement
+	args   []byte
+}
+
+type UndelegateCallbackTestCase struct {
+	initialState UndelegateCallbackState
+	validArgs    UndelegateCallbackArgs
+}
+
+func (s *KeeperTestSuite) SetupUndelegateCallback() UndelegateCallbackTestCase {
+	stakedBal := uint64(1_000_000)
+	val1Bal := uint64(400_000)
+	val2Bal := uint64(stakedBal) - val1Bal
+	balanceToStake := int64(300_000)
+	val1RelAmt := int64(120_000)
+	val2RelAmt := int64(180_000)
+
+	// STATE
+	// host zone
+	// Validators (2)
+	// EpochUnbondingRecord (1)
+	// HZU (1)
+	// Account with tokens
+
+	val1 := types.Validator{
+		Name:          "val1",
+		Address:       "val1_address",
+		DelegationAmt: val1Bal,
+	}
+	val2 := types.Validator{
+		Name:          "val2",
+		Address:       "val2_address",
+		DelegationAmt: val2Bal,
+	}
+	hostZone := stakeibc.HostZone{
+		ChainId:        chainId,
+		HostDenom:      atom,
+		IBCDenom:       ibcAtom,
+		RedemptionRate: sdk.NewDec(1.0),
+		Validators:     []*types.Validator{&val1, &val2},
+		StakedBal:      stakedBal,
+	}
+	depositRecord := recordtypes.DepositRecord{
+		Id:                 1,
+		DepositEpochNumber: 1,
+		HostZoneId:         chainId,
+		Amount:             balanceToStake,
+		Status:             recordtypes.DepositRecord_STAKE,
+	}
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), hostZone)
+	s.App.RecordsKeeper.SetDepositRecord(s.Ctx(), depositRecord)
+
+	packet := channeltypes.Packet{}
+	var msgs []sdk.Msg
+	// add
+	msgs = append(msgs, &stakingTypes.MsgUndelegate{}, &stakingTypes.MsgUndelegate{})
+	ack := s.ICAPacketAcknowledgement(msgs)
+	val1SplitDelegation := types.SplitDelegation{
+		Validator: val1.Address,
+		Amount:    uint64(val1RelAmt),
+	}
+	val2SplitDelegation := types.SplitDelegation{
+		Validator: val2.Address,
+		Amount:    uint64(val2RelAmt),
+	}
+	callbackArgs := types.UndelegateCallback{
+		HostZoneId:              chainId,
+		SplitDelegations:        []*types.SplitDelegation{&val1SplitDelegation, &val2SplitDelegation},
+		EpochUnbondingRecordIds: []uint64{1, 2},
+	}
+	args, err := s.App.StakeibcKeeper.MarshalUndelegateCallbackArgs(s.Ctx(), callbackArgs)
+	s.Require().NoError(err)
+
+	return UndelegateCallbackTestCase{
+		initialState: UndelegateCallbackState{
+			callbackArgs: callbackArgs,
+		},
+		validArgs: UndelegateCallbackArgs{
+			packet: packet,
+			ack:    &ack,
+			args:   args,
+		},
+	}
+}
+
+func (s *KeeperTestSuite) TestUndelegateCallback_Successful() {
+	tc := s.SetupUndelegateCallback()
+	initialState := tc.initialState
+	validArgs := tc.validArgs
+
+	err := stakeibckeeper.UndelegateCallback(s.App.StakeibcKeeper, s.Ctx(), validArgs.packet, validArgs.ack, validArgs.args)
+	s.Require().NoError(err)
+
+	// Check that stakedBal has decreased
+	// Check that Delegations on validators have decreased
+	// Check that hzu are updated correctly
+	// -- Check that the completion time is set on the hzu
+	// -- Check that the hzu status is set to UNBONDED
+	// Check that tokens are burned
+}
+
+func (s *KeeperTestSuite) checkStateIfUndelegateCallbackFailed(tc UndelegateCallbackTestCase) {
+	// Confirm stakedBal has not increased
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx(), chainId)
+	s.Require().True(found)
+	s.Require().Equal(int64(tc.initialState.stakedBal), int64(hostZone.StakedBal), "stakedBal should not have increased")
+
+	// Confirm deposit record has NOT been removed
+	records := s.App.RecordsKeeper.GetAllDepositRecord(s.Ctx())
+	s.Require().Len(records, 1, "number of deposit records")
+	record := records[0]
+	s.Require().Equal(recordtypes.DepositRecord_STAKE, record.Status, "deposit record status should not have changed")
+}
+
+func (s *KeeperTestSuite) TestUndelegateCallback_UndelegateCallbackTimeout() {
+	tc := s.SetupUndelegateCallback()
+	invalidArgs := tc.validArgs
+	// a nil ack means the request timed out
+	invalidArgs.ack = nil
+	err := stakeibckeeper.UndelegateCallback(s.App.StakeibcKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, invalidArgs.args)
+	s.Require().NoError(err)
+	s.checkStateIfUndelegateCallbackFailed(tc)
+}
+
+func (s *KeeperTestSuite) TestUndelegateCallback_UndelegateCallbackErrorOnHost() {
+	tc := s.SetupUndelegateCallback()
+	invalidArgs := tc.validArgs
+	// an error ack means the tx failed on the host
+	fullAck := channeltypes.Acknowledgement{Response: &channeltypes.Acknowledgement_Error{Error: "error"}}
+	invalidArgs.ack = &fullAck
+
+	err := stakeibckeeper.UndelegateCallback(s.App.StakeibcKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, invalidArgs.args)
+	s.Require().NoError(err)
+	s.checkStateIfUndelegateCallbackFailed(tc)
+}
+
+func (s *KeeperTestSuite) TestUndelegateCallback_WrongCallbackArgs() {
+	tc := s.SetupUndelegateCallback()
+	invalidArgs := tc.validArgs
+
+	err := stakeibckeeper.UndelegateCallback(s.App.StakeibcKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, []byte("random bytes"))
+	s.Require().EqualError(err, "unexpected EOF")
+	s.checkStateIfUndelegateCallbackFailed(tc)
+}

--- a/x/stakeibc/keeper/icacallbacks_undelegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate_test.go
@@ -227,7 +227,23 @@ func (s *KeeperTestSuite) TestUndelegateCallback_HostNotFound() {
 	s.Require().EqualError(err, "Host zone not found: GAIA: key not found")
 }
 
-// Test updateDelegationBalances
-// Test getLatestCompletionTime
-// Test updateHostZoneUnbondings
-// Test burnTokens
+// Test UpdateDelegationBalances
+// Test success case - validator amounts decrease
+// Test failure case - amount is too big
+
+// Test GetLatestCompletionTime
+// Test success case - given a list of completion times, pick the latest
+// Test failure case - latest completion time is zero
+
+// Test UpdateHostZoneUnbondings
+// Test success case - update unbonding records and get tokens to burn
+// Test failure case - epoch unbonding record DNE
+// Test failure case - HostZoneUnbonding DNE
+// Test failure case - Amount too big
+
+// Test BurnTokens
+// Test success case - tokens are burned
+// Test failure case - could not parse coin
+// Test failure case - could not decode address
+// Test failure case - could not send coins from account to module
+// Test failure case, could not burn coins (too few coins to burn)

--- a/x/stakeibc/types/errors.go
+++ b/x/stakeibc/types/errors.go
@@ -35,4 +35,5 @@ var (
 	ErrIntCast                           = sdkerrors.Register(ModuleName, 1525, "unable to cast to safe cast int")
 	ErrFeeAccountNotRegistered           = sdkerrors.Register(ModuleName, 1526, "fee account is not registered")
 	ErrRedemptionRateOutsideSafetyBounds = sdkerrors.Register(ModuleName, 1527, "redemption rate outside safety bounds")
+	ErrTxMsgDataInvalid                  = sdkerrors.Register(ModuleName, 1528, "TxMsgData invalid")
 )


### PR DESCRIPTION
## Context and purpose of the change

Add `UndelegateCallback` unittests. This also breaks up `UndelegateCallback` into smaller functions and adds some unittest helpers.

NOTE: I'm still writing tests for `UpdateHostZoneUnbondings`, but wanted to open this up for review because everything else is done

## Brief Changelog

- Add success case test and failure case tests for `UndelegateCallback`
- Break up `UndelegateCallback` into four sub-functions
    - `UpdateDelegationBalances`
    - `GetLatestCompletionTime`
    - `UpdateHostZoneUnbondings`
    - `BurnTokens`
- Add `msgResponse` argument to `ICAPacketAcknowledgement` so that we can return mocked response types in `TxMsgData` (required to to get the unbonding time)

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [X] tests
