### PR TITLE
add ibc transfer callback unittest

### DIFF
--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -263,7 +265,7 @@ func CopyConnectionAndClientToPath(path *ibctesting.Path, pathToCopy *ibctesting
 	return path
 }
 
-func  (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg) channeltypes.Acknowledgement {
+func (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg) channeltypes.Acknowledgement {
 	txMsgData := &sdk.TxMsgData{
 		Data: make([]*sdk.MsgData, len(msgs)),
 	}
@@ -278,5 +280,16 @@ func  (s *AppTestHelper) ICAPacketAcknowledgement(msgs []sdk.Msg) channeltypes.A
 	marshalledTxMsgData, err := proto.Marshal(txMsgData)
 	s.Require().NoError(err)
 	ack := channeltypes.NewResultAcknowledgement(marshalledTxMsgData)
+	return ack
+}
+
+func (s *AppTestHelper) MarshalledICS20PacketData() sdk.AccAddress {
+	data := ibctransfertypes.FungibleTokenPacketData{}
+	return data.GetBytes()
+}
+
+func (s *AppTestHelper) ICS20PacketAcknowledgement() channeltypes.Acknowledgement {
+	// see: https://github.com/cosmos/ibc-go/blob/8de555db76d0320842dacaa32e5500e1fd55e667/modules/apps/transfer/keeper/relay.go#L151
+	ack := channeltypes.NewResultAcknowledgement(s.MarshalledICS20PacketData())
 	return ack
 }

--- a/x/records/keeper/callback_transfer.go
+++ b/x/records/keeper/callback_transfer.go
@@ -33,6 +33,10 @@ func (k Keeper) UnmarshalTransferCallbackArgs(ctx sdk.Context, delegateCallback 
 
 func TransferCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, ack *channeltypes.Acknowledgement, args []byte) error {
 	k.Logger(ctx).Info("TransferCallback executing", "packet", packet)
+	if ack.GetError() != "" {
+		k.Logger(ctx).Error(fmt.Sprintf("TransferCallback does not handle errors %s", ack.GetError()))
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "TransferCallback does not handle errors: %s", ack.GetError())
+	}
 	if ack == nil {
 		// timeout
 		k.Logger(ctx).Error(fmt.Sprintf("TransferCallback timeout, ack is nil, packet %v", packet))

--- a/x/records/keeper/callback_transfer_test.go
+++ b/x/records/keeper/callback_transfer_test.go
@@ -1,0 +1,126 @@
+package keeper_test
+
+import (
+	"fmt"
+
+	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	_ "github.com/stretchr/testify/suite"
+
+	recordskeeper "github.com/Stride-Labs/stride/x/records/keeper"
+	"github.com/Stride-Labs/stride/x/records/types"
+	recordtypes "github.com/Stride-Labs/stride/x/records/types"
+)
+
+const chainId = "GAIA"
+
+type TransferCallbackState struct {
+	callbackArgs types.TransferCallback
+}
+
+type TransferCallbackArgs struct {
+	packet channeltypes.Packet
+	ack    *channeltypes.Acknowledgement
+	args   []byte
+}
+
+type TransferCallbackTestCase struct {
+	initialState TransferCallbackState
+	validArgs    TransferCallbackArgs
+}
+
+func (s *KeeperTestSuite) SetupTransferCallback() TransferCallbackTestCase {
+	balanceToStake := int64(1_000_000)
+	depositRecord := recordtypes.DepositRecord{
+		Id:                 1,
+		DepositEpochNumber: 1,
+		HostZoneId:         chainId,
+		Amount:             balanceToStake,
+		Status:             recordtypes.DepositRecord_TRANSFER,
+	}
+	s.App.RecordsKeeper.SetDepositRecord(s.Ctx(), depositRecord)
+	packet := channeltypes.Packet{Data: s.MarshalledICS20PacketData()}
+	ack := s.ICS20PacketAcknowledgement()
+	callbackArgs := types.TransferCallback{
+		DepositRecordId: depositRecord.Id,
+	}
+	args, err := s.App.RecordsKeeper.MarshalTransferCallbackArgs(s.Ctx(), callbackArgs)
+	s.Require().NoError(err)
+
+	return TransferCallbackTestCase{
+		initialState: TransferCallbackState{
+			callbackArgs: callbackArgs,
+		},
+		validArgs: TransferCallbackArgs{
+			packet: packet,
+			ack:    &ack,
+			args:   args,
+		},
+	}
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_Successful() {
+	tc := s.SetupTransferCallback()
+	initialState := tc.initialState
+	validArgs := tc.validArgs
+
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), validArgs.packet, validArgs.ack, validArgs.args)
+	s.Require().NoError(err)
+
+	// Confirm deposit record has been updated to STAKE
+	record, found := s.App.RecordsKeeper.GetDepositRecord(s.Ctx(), initialState.callbackArgs.DepositRecordId)
+	s.Require().True(found)
+	s.Require().Equal(record.Status, recordtypes.DepositRecord_STAKE, "deposit record status should be STAKE")
+}
+
+func (s *KeeperTestSuite) checkTransferStateIfCallbackFailed(tc TransferCallbackTestCase) {
+	record, found := s.App.RecordsKeeper.GetDepositRecord(s.Ctx(), tc.initialState.callbackArgs.DepositRecordId)
+	s.Require().True(found)
+	s.Require().Equal(record.Status, recordtypes.DepositRecord_TRANSFER, "deposit record status should be TRANSFER")
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_TransferCallbackTimeout() {
+	tc := s.SetupTransferCallback()
+	invalidArgs := tc.validArgs
+	// a nil ack means the request timed out
+	invalidArgs.ack = nil
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, invalidArgs.args)
+	s.Require().NoError(err)
+	s.checkTransferStateIfCallbackFailed(tc)
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_TransferCallbackErrorOnHost() {
+	tc := s.SetupTransferCallback()
+	invalidArgs := tc.validArgs
+	// an error ack means the tx failed on the host
+	errorAck := channeltypes.Acknowledgement{Response: &channeltypes.Acknowledgement_Error{Error: "error"}}
+
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), invalidArgs.packet, &errorAck, invalidArgs.args)
+	s.Require().EqualError(err, "TransferCallback does not handle errors: error: invalid request")
+	s.checkTransferStateIfCallbackFailed(tc)
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_WrongCallbackArgs() {
+	tc := s.SetupTransferCallback()
+	invalidArgs := tc.validArgs
+
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, []byte("random bytes"))
+	s.Require().EqualError(err, "unexpected EOF")
+	s.checkTransferStateIfCallbackFailed(tc)
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_DepositRecordNotFound() {
+	tc := s.SetupTransferCallback()
+	s.App.RecordsKeeper.RemoveDepositRecord(s.Ctx(), tc.initialState.callbackArgs.DepositRecordId)
+
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), tc.validArgs.packet, tc.validArgs.ack, tc.validArgs.args)
+	s.Require().EqualError(err, fmt.Sprintf("deposit record not found %d: unknown deposit record", tc.initialState.callbackArgs.DepositRecordId))
+}
+
+func (s *KeeperTestSuite) TestTransferCallback_PacketUnmarshallingError() {
+	tc := s.SetupTransferCallback()
+	invalidArgs := tc.validArgs
+	invalidArgs.packet.Data = []byte("random bytes")
+
+	err := recordskeeper.TransferCallback(s.App.RecordsKeeper, s.Ctx(), invalidArgs.packet, invalidArgs.ack, invalidArgs.args)
+	s.Require().EqualError(err, "cannot unmarshal ICS-20 transfer packet data: invalid character 'r' looking for beginning of value: unknown request")
+}

--- a/x/records/keeper/keeper_test.go
+++ b/x/records/keeper/keeper_test.go
@@ -1,0 +1,27 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/app/apptesting"
+	"github.com/Stride-Labs/stride/x/records/keeper"
+	"github.com/Stride-Labs/stride/x/records/types"
+)
+
+type KeeperTestSuite struct {
+	apptesting.AppTestHelper
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func (s *KeeperTestSuite) GetMsgServer() types.MsgServer {
+	return keeper.NewMsgServerImpl(s.App.RecordsKeeper)
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}


### PR DESCRIPTION
## Context and purpose of the change

Add `TransferCallback` unittests


## Brief Changelog

- Add success case test and failure case tests for `TransferCallback`
- Throw error in `TransferCallback` if ack comes back as an error type (these are filtered out in `OnAcknowledgementPacket`)
- add testing setup infra to records module
- add helpers to return ICS20 packet data, acks

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [X] tests
