### PR TITLE
Withdrawal Balance Callback Empty Query Response

### DIFF
--- a/x/stakeibc/keeper/callbacks.go
+++ b/x/stakeibc/keeper/callbacks.go
@@ -79,7 +79,7 @@ func WithdrawalBalanceCallback(k Keeper, ctx sdk.Context, args []byte, query icq
 		return sdkerrors.Wrapf(types.ErrMarshalFailure, errMsg)
 	}
 
-	// Confirm the coin is not nil (which would indicate the account never had a balance)
+	// Check if the coin is nil (which would indicate the account never had a balance)
 	if withdrawalBalanceCoin.IsNil() || withdrawalBalanceCoin.Amount.IsNil() {
 		k.Logger(ctx).Info(fmt.Sprintf("WithdrawalBalanceCallback: balance query returned a nil coin for address %s on %s, meaning the account has never had a balance on the host",
 			hostZone.WithdrawalAccount.Address, hostZone.ChainId))

--- a/x/stakeibc/keeper/callbacks.go
+++ b/x/stakeibc/keeper/callbacks.go
@@ -91,7 +91,7 @@ func WithdrawalBalanceCallback(k Keeper, ctx sdk.Context, args []byte, query icq
 	}
 
 	// sanity check, do not transfer if we have 0 balance!
-	if withdrawalBalanceCoin.Amount.Int64() <= 0 {
+	if withdrawalBalanceCoin.Amount.IsNil() || withdrawalBalanceCoin.Amount.Int64() <= 0 {
 		k.Logger(ctx).Info(fmt.Sprintf("WithdrawalBalanceCallback: no balance to transfer for zone: %s, accAddr: %v, coin: %v",
 			hostZone.ChainId, queriedAddress.String(), withdrawalBalanceCoin.String()))
 		return nil

--- a/x/stakeibc/keeper/callbacks.go
+++ b/x/stakeibc/keeper/callbacks.go
@@ -70,30 +70,26 @@ func WithdrawalBalanceCallback(k Keeper, ctx sdk.Context, args []byte, query icq
 		return sdkerrors.Wrapf(types.ErrHostZoneNotFound, errMsg)
 	}
 
-	// Query request is a byte array of the form:
-	// [ {balancesPrefix} {address} {denom} ]
-	// {balancePrefix} is only a single byte - and it must be removed before calling AddressFromBalancesStore
-	balancesStoreKey := query.Request[1:]
-	queriedAddress, err := banktypes.AddressFromBalancesStore(balancesStoreKey)
-	if err != nil {
-		errMsg := "unable to derive queried address from request byte array"
-		k.Logger(ctx).Error(errMsg)
-		return sdkerrors.Wrapf(err, errMsg)
-	}
-
 	// Unmarshal the CB args into a coin type
 	withdrawalBalanceCoin := sdk.Coin{}
-	err = k.cdc.Unmarshal(args, &withdrawalBalanceCoin)
+	err := k.cdc.Unmarshal(args, &withdrawalBalanceCoin)
 	if err != nil {
 		errMsg := fmt.Sprintf("unable to unmarshal balance in callback args for zone: %s, err: %s", hostZone.ChainId, err.Error())
 		k.Logger(ctx).Error(errMsg)
 		return sdkerrors.Wrapf(types.ErrMarshalFailure, errMsg)
 	}
 
-	// sanity check, do not transfer if we have 0 balance!
-	if withdrawalBalanceCoin.Amount.IsNil() || withdrawalBalanceCoin.Amount.Int64() <= 0 {
+	// Confirm the coin is not nil (which would indicate the account never had a balance)
+	if withdrawalBalanceCoin.IsNil() || withdrawalBalanceCoin.Amount.IsNil() {
+		k.Logger(ctx).Info(fmt.Sprintf("WithdrawalBalanceCallback: balance query returned a nil coin for address %s on %s, meaning the account has never had a balance on the host",
+			hostZone.WithdrawalAccount.Address, hostZone.ChainId))
+		return nil
+	}
+
+	// Confirm the balance is greater than zero
+	if withdrawalBalanceCoin.Amount.Int64() <= 0 {
 		k.Logger(ctx).Info(fmt.Sprintf("WithdrawalBalanceCallback: no balance to transfer for zone: %s, accAddr: %v, coin: %v",
-			hostZone.ChainId, queriedAddress.String(), withdrawalBalanceCoin.String()))
+			hostZone.ChainId, hostZone.WithdrawalAccount.Address, withdrawalBalanceCoin.String()))
 		return nil
 	}
 


### PR DESCRIPTION
Closes: #XXX

## Context and purpose of the change
This PR makes some small changes to the WithdrawalBalanceCallback, described below...


## Brief Changelog
- If a withdrawal address has not been created yet, an empty byte array is passed back (which someone is able to be unmarshalled as a nil Coin object). An added check for a nil coin has been added along with a unit test
- In the callback, the address was deserialized from the query request, but it was only used for logging. Additionally, the log printed the incorrect address because the sdk config is set to interpret addresses as having a stride prefix, rather than their host prefix (which would cause a stride address to be logged). As a result, I've removed the address deserialization and corresponding unit test.


## Author's Checklist

I have...

- [x] Run and PASSED locally all GAIA integration tests
- [x] If the change is contentful, I either:
    - [ ] Added a new unit test OR 
    - [x] Added test cases to existing unit tests
- [ ] OR this change is a trivial rework / code cleanup without any test coverage

If skipped any of the tests above, explain.
<!-- *(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...* -->

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [ ] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
