### PR TITLE
small fixes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -126,7 +126,7 @@ import (
 const (
 	AccountAddressPrefix = "stride"
 	Name                 = "stride"
-	Version              = "0.0.1"
+	Version              = "1.0.0"
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals

--- a/scripts-local/tests/osmo_tests.bats
+++ b/scripts-local/tests/osmo_tests.bats
@@ -217,7 +217,7 @@ setup() {
   WAIT_FOR_BLOCK $STRIDE_LOGS 2
   # wait four days (transfers, stake, move rewards, reinvest rewards)
   epoch_duration=$($STRIDE_CMD q epochs epoch-infos | grep -Fiw -B 2 'stride_epoch' | head -n 1 | grep -o -E '[0-9]+')
-  sleep $(($epoch_duration * 4))
+  sleep $(($epoch_duration * 6))
   # simple check that number of tokens staked increases
   NEW_STAKED_BAL=$($OSMO_CMD q staking delegation $OSMO_DELEGATION_ICA_ADDR $OSMO_DELEGATE_VAL | GETSTAKE)
   EXPECTED_STAKED_BAL=667

--- a/x/stakeibc/keeper/msg_server_redeem_stake.go
+++ b/x/stakeibc/keeper/msg_server_redeem_stake.go
@@ -17,6 +17,7 @@ import (
 
 func (k msgServer) RedeemStake(goCtx context.Context, msg *types.MsgRedeemStake) (*types.MsgRedeemStakeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	k.Logger(ctx).Info(fmt.Sprintf("redeem stake: %s", msg.String()))
 
 	// get our addresses, make sure they're valid
 	sender, err := sdk.AccAddressFromBech32(msg.Creator)
@@ -149,5 +150,6 @@ func (k msgServer) RedeemStake(goCtx context.Context, msg *types.MsgRedeemStake)
 	}
 	k.RecordsKeeper.SetEpochUnbondingRecord(ctx, *updatedEpochUnbondingRecord)
 
+	k.Logger(ctx).Info(fmt.Sprintf("executed redeem stake: %s", msg.String()))
 	return &types.MsgRedeemStakeResponse{}, nil
 }

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -298,7 +298,11 @@ func (k Keeper) SweepAllUnbondedTokensForHostZone(ctx sdk.Context, hostZone type
 		k.Logger(ctx).Info(fmt.Sprintf("\tUnbonding time:  %d blockTime %d, shouldProcess %v", hostZoneUnbonding.UnbondingTime, blockTime, shouldProcess))
 
 		// if the unbonding period has elapsed, then we can send the ICA call to sweep this hostZone's unbondings to the redemption account (in a batch)
-		if (hostZoneUnbonding.UnbondingTime < blockTime) && shouldProcess {
+		// verify
+		// 1. the unbonding time is set (g.t. 0)
+		// 2. the unbonding time is less than the current block time
+		// 3. the host zone is in the UNBONDED state, meaning it's ready to be transferred
+		if (hostZoneUnbonding.UnbondingTime > 0 && hostZoneUnbonding.UnbondingTime < blockTime) && shouldProcess {
 			// we have a match, so we can process this unbonding
 			logMsg := fmt.Sprintf("\t\tAdding %d to amt to batch transfer from delegation acct to rewards acct for host zone %s, epoch %v",
 				hostZoneUnbonding.NativeTokenAmount, hostZone.ChainId, epochUnbondingRecord.EpochNumber)

--- a/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
+++ b/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
@@ -101,11 +101,13 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 					HostZoneId:        HostChainId,
 					NativeTokenAmount: 2_000_000,
 					Status:            recordtypes.HostZoneUnbonding_UNBONDED,
+					UnbondingTime:     unbondingTime,
 				},
 				{
 					HostZoneId:        OsmoChainId,
 					NativeTokenAmount: 2_000_000,
 					Status:            recordtypes.HostZoneUnbonding_UNBONDED,
+					UnbondingTime:     unbondingTime,
 				},
 			},
 		},

--- a/x/stakeibc/types/message_redeem_stake.go
+++ b/x/stakeibc/types/message_redeem_stake.go
@@ -45,10 +45,10 @@ func (msg *MsgRedeemStake) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
-	// check valid receiver address
-	_, err = sdk.AccAddressFromBech32(msg.Receiver)
-	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid receiver address (%s)", err)
+	// validate host zone is not empty
+	// we check validity in the RedeemState function
+	if msg.Receiver == "" {
+		return sdkerrors.Wrapf(ErrRequiredFieldEmpty, "receiver cannot be empty")
 	}
 	// ensure amount is a nonzero positive integer
 	if msg.Amount <= 0 {

--- a/x/stakeibc/types/message_redeem_stake_test.go
+++ b/x/stakeibc/types/message_redeem_stake_test.go
@@ -48,11 +48,10 @@ func TestMsgRedeemStake_ValidateBasic(t *testing.T) {
 			name: "invalid receiver",
 			msg: MsgRedeemStake{
 				Creator:  sample.AccAddress(),
-				Receiver: "invalid_address",
 				HostZone: "GAIA",
 				Amount:   uint64(1),
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: ErrRequiredFieldEmpty,
 		},
 		{
 			name: "amount max int",


### PR DESCRIPTION
We can't check receiver address validity in ValidateBasic because the check is stateful (we need the zone prefix)

We check this in RedeemStake, so this PR simplifies the check

Changes
- bump version
- fix flaky osmo test
- add log lines to RedeemStake
- add additional safety check to SweepAllUnbondedTokensForHostZone and fix associated tests
- fix validate basic check for RedeemStake and fix associated tests