### PR TITLE
ICQ events for cosmos/relayer

### DIFF
--- a/x/interchainquery/keeper/abci.go
+++ b/x/interchainquery/keeper/abci.go
@@ -35,7 +35,7 @@ func (k Keeper) EndBlocker(ctx sdk.Context) {
 
 			events = append(events, event)
 
-			event.Type = "query_response"
+			event.Type = "query_request"
 			events = append(events, event)
 
 			queryInfo.LastHeight = sdk.NewInt(ctx.BlockHeight())

--- a/x/interchainquery/keeper/abci.go
+++ b/x/interchainquery/keeper/abci.go
@@ -34,6 +34,10 @@ func (k Keeper) EndBlocker(ctx sdk.Context) {
 			)
 
 			events = append(events, event)
+
+			event.Type = "query_response"
+			events = append(events, event)
+
 			queryInfo.LastHeight = sdk.NewInt(ctx.BlockHeight())
 			k.SetQuery(ctx, queryInfo)
 

--- a/x/interchainquery/keeper/msg_server.go
+++ b/x/interchainquery/keeper/msg_server.go
@@ -168,6 +168,7 @@ func (k msgServer) SubmitQueryResponse(goCtx context.Context, msg *types.MsgSubm
 			"query_response",
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(types.AttributeKeyQueryId, q.Id),
+			sdk.NewAttribute(types.AttributeKeyChainId, q.ChainId),
 		),
 	})
 

--- a/x/interchainquery/keeper/msg_server.go
+++ b/x/interchainquery/keeper/msg_server.go
@@ -175,7 +175,6 @@ func (k msgServer) SubmitQueryResponse(goCtx context.Context, msg *types.MsgSubm
 	// 1. verify the response's proof, if one exists
 	err := k.VerifyKeyProof(ctx, msg, q)
 	if err != nil {
-		k.Logger(ctx).Error("[ICQ Resp] error verifying key proof: %v", err)
 		return nil, err
 	}
 	// 2. immediately delete the query so it cannot process again
@@ -184,7 +183,6 @@ func (k msgServer) SubmitQueryResponse(goCtx context.Context, msg *types.MsgSubm
 	// 3. verify the query's ttl is unexpired
 	ttlExceeded, err := k.HasQueryExceededTtl(ctx, msg, q)
 	if err != nil {
-		k.Logger(ctx).Error("[ICQ Resp] error checking ttl exceeded: %v", err)
 		return nil, err
 	}
 	if ttlExceeded {
@@ -201,10 +199,8 @@ func (k msgServer) SubmitQueryResponse(goCtx context.Context, msg *types.MsgSubm
 	// 5. call the query's associated callback function
 	err = k.InvokeCallback(ctx, msg, q)
 	if err != nil {
-		k.Logger(ctx).Error("[ICQ Resp] error invoking callback: %v", err)
 		return nil, err
 	}
 
-	k.Logger(ctx).Info("[ICQ Resp] successful query")
 	return &types.MsgSubmitQueryResponseResponse{}, nil
 }


### PR DESCRIPTION
## Context and purpose of the change

Simplifies event correlation for cosmos go relayer by emitting extra events with specific types.

## Brief Changelog

- Adds `query_request` event in the end block events, in addition to the existing `message` event, to avoid breaking changes
- Adds `query_response` event in the tx events for `MsgSubmitQueryResponse`
- Emits events in `MsgSubmitQueryResponse` for every case where the query ID exists to close the query

## Author's Checklist

I have...

- Tested in cosmos/relayer https://github.com/cosmos/relayer/pull/954
- `ibctest` suite integration test https://github.com/strangelove-ventures/ibctest/pull/273

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

Not documented because only relevant to cosmos relayer. No breaking changes.
