### PR TITLE
Add Commit SHA to Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 BUILDDIR ?= $(CURDIR)/build
 build=s
 cache=false
+COMMIT := $(shell git log -1 --format='%H')
 
 # process build tags
 


### PR DESCRIPTION
Adds commit sha to the version when running `make build` 