### PR TITLE
Reset TTL Upon Duplicate Query Submission

### DIFF
--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -105,8 +105,8 @@ func (k *Keeper) MakeRequest(ctx sdk.Context, connection_id string, chain_id str
 		k.SetQuery(ctx, *newQuery)
 
 	} else {
-		// a re-request of an existing query triggers resetting of height to trigger immediately.
-		existingQuery.LastHeight = sdk.ZeroInt()
+		// a re-request of an existing query should reset the TTL
+		existingQuery.Ttl = ttl
 		k.SetQuery(ctx, existingQuery)
 	}
 	return nil

--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -108,6 +108,7 @@ func (k *Keeper) MakeRequest(ctx sdk.Context, connectionId string, chainId strin
 		// Otherwise, if the same query is re-requested - reset the TTL
 		k.Logger(ctx).Info("Query already exists - resetting TTL")
 		query.Ttl = ttl
+		query.LastHeight = sdk.ZeroInt() // allows query to be emitted again
 	}
 
 	// Save the query to the store

--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -61,18 +61,26 @@ func (k *Keeper) MakeRequest(ctx sdk.Context, connectionId string, chainId strin
 
 	// Only 0 height queries are currently supported
 	if height != 0 {
-		k.Logger(ctx).Error("[ICQ Validation Check] Failed! height for interchainquery must be 0 (we exclusively query at the latest height on the host zone)")
+		errMsg := "[ICQ Validation Check] Failed! height for interchainquery must be 0 (we exclusively query at the latest height on the host zone)"
+		k.Logger(ctx).Error(errMsg)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, errMsg)
 	}
 
 	// Confirm the connectionId and chainId are valid
 	if connectionId == "" {
-		k.Logger(ctx).Error("[ICQ Validation Check] Failed! connection id cannot be empty")
+		errMsg := "[ICQ Validation Check] Failed! connection id cannot be empty"
+		k.Logger(ctx).Error(errMsg)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, errMsg)
 	}
 	if !strings.HasPrefix(connectionId, "connection") {
-		k.Logger(ctx).Error("[ICQ Validation Check] Failed! connection id must begin with 'connection'")
+		errMsg := "[ICQ Validation Check] Failed! connection id must begin with 'connection'"
+		k.Logger(ctx).Error(errMsg)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, errMsg)
 	}
 	if chainId == "" {
-		k.Logger(ctx).Error("[ICQ Validation Check] Failed! chain_id cannot be empty")
+		errMsg := "[ICQ Validation Check] Failed! chain_id cannot be empty"
+		k.Logger(ctx).Error(errMsg)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, errMsg)
 	}
 
 	// Check to see if the query already exists

--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -90,7 +90,7 @@ func (k *Keeper) MakeRequest(ctx sdk.Context, connectionId string, chainId strin
 			k.Logger(ctx).Error(err.Error())
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "no callback handler registered for module")
 		}
-		if exists := k.callbacks[module].Has(callbackId); !exists {
+		if exists := k.callbacks[module].HasICQCallback(callbackId); !exists {
 			err := fmt.Errorf("no callback %s registered for module %s", callbackId, module)
 			k.Logger(ctx).Error(err.Error())
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "no callback handler registered for module")

--- a/x/interchainquery/keeper/msg_server.go
+++ b/x/interchainquery/keeper/msg_server.go
@@ -185,7 +185,7 @@ func (k msgServer) SubmitQueryResponse(goCtx context.Context, msg *types.MsgSubm
 		return nil, err
 	}
 	if ttlExceeded {
-		k.Logger(ctx).Info(fmt.Sprintf("[ICQ Resp] %s's ttl exceeded: %d < %d.", msg.QueryId, q.Ttl, ctx.BlockHeader().Time.UnixNano()))
+		k.Logger(ctx).Info(fmt.Sprintf("[ICQ Resp] %s's ttl exceeded: %d < %d.", msg.QueryId, q.Ttl, ctx.BlockHeader().Time.UnixNano()))
 		return &types.MsgSubmitQueryResponseResponse{}, nil
 	}
 

--- a/x/interchainquery/keeper/queries.go
+++ b/x/interchainquery/keeper/queries.go
@@ -11,22 +11,20 @@ import (
 	"github.com/Stride-Labs/stride/x/interchainquery/types"
 )
 
-func GenerateQueryHash(connection_id string, chain_id string, query_type string, request []byte, module string, height int64) string {
-	return fmt.Sprintf("%x", crypto.Sha256(append([]byte(module+connection_id+chain_id+query_type+strconv.FormatInt(height, 10)), request...)))
+func GenerateQueryHash(connectionId string, chainId string, queryType string, request []byte, module string, height int64) string {
+	return fmt.Sprintf("%x", crypto.Sha256(append([]byte(module+connectionId+chainId+queryType+strconv.FormatInt(height, 10)), request...)))
 }
 
-// ----------------------------------------------------------------
-
-func (k Keeper) NewQuery(ctx sdk.Context, module string, connection_id string, chain_id string, query_type string, request []byte, period sdk.Int, callback_id string, ttl uint64, height int64) *types.Query {
+func (k Keeper) NewQuery(ctx sdk.Context, module string, connectionId string, chainId string, queryType string, request []byte, period sdk.Int, callbackId string, ttl uint64, height int64) *types.Query {
 	return &types.Query{
-		Id:           GenerateQueryHash(connection_id, chain_id, query_type, request, module, height),
-		ConnectionId: connection_id,
-		ChainId:      chain_id,
-		QueryType:    query_type,
+		Id:           GenerateQueryHash(connectionId, chainId, queryType, request, module, height),
+		ConnectionId: connectionId,
+		ChainId:      chainId,
+		QueryType:    queryType,
 		Request:      request,
 		Period:       period,
 		LastHeight:   sdk.ZeroInt(),
-		CallbackId:   callback_id,
+		CallbackId:   callbackId,
 		Ttl:          ttl,
 		Height:       height,
 	}

--- a/x/stakeibc/keeper/update_validator_shares_exch_rate_test.go
+++ b/x/stakeibc/keeper/update_validator_shares_exch_rate_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"fmt"
 
+	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	_ "github.com/stretchr/testify/suite"
 
 	epochtypes "github.com/Stride-Labs/stride/x/epochs/types"
@@ -29,6 +30,7 @@ func (s *KeeperTestSuite) SetupQueryValidatorExchangeRate() QueryValidatorExchan
 
 	hostZone := types.HostZone{
 		ChainId:      HostChainId,
+		ConnectionId: ibctesting.FirstConnectionID,
 		HostDenom:    Atom,
 		IBCDenom:     IbcAtom,
 		Bech32Prefix: Bech32Prefix,
@@ -129,6 +131,17 @@ func (s *KeeperTestSuite) TestQueryValidatorExchangeRate_BadValoperAddress() {
 	s.Require().Nil(resp, "response should be nil")
 }
 
+func (s *KeeperTestSuite) TestQueryValidatorExchangeRate_MissingConnectionId() {
+	tc := s.SetupQueryValidatorExchangeRate()
+
+	tc.hostZone.ConnectionId = ""
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), tc.hostZone)
+
+	resp, err := s.App.StakeibcKeeper.QueryValidatorExchangeRate(s.Ctx(), &tc.msg)
+	s.Require().ErrorContains(err, "connection id cannot be empty")
+	s.Require().Nil(resp, "response should be nil")
+}
+
 // ================================== 2: QueryDelegationsIcq ==========================================
 
 type QueryDelegationsIcqTestCase struct {
@@ -151,6 +164,7 @@ func (s *KeeperTestSuite) SetupQueryDelegationsIcq() QueryDelegationsIcqTestCase
 
 	hostZone := types.HostZone{
 		ChainId:           HostChainId,
+		ConnectionId:      ibctesting.FirstConnectionID,
 		HostDenom:         Atom,
 		IBCDenom:          IbcAtom,
 		Bech32Prefix:      Bech32Prefix,
@@ -233,4 +247,14 @@ func (s *KeeperTestSuite) TestQueryDelegationsIcq_MissingDelegationAddress() {
 
 	err := s.App.StakeibcKeeper.QueryDelegationsIcq(s.Ctx(), tc.hostZone, tc.valoperAddr)
 	s.Require().ErrorContains(err, "missing a delegation address")
+}
+
+func (s *KeeperTestSuite) TestQueryDelegationsIcq_MissingConnectionId() {
+	tc := s.SetupQueryDelegationsIcq()
+
+	tc.hostZone.ConnectionId = ""
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx(), tc.hostZone)
+
+	err := s.App.StakeibcKeeper.QueryDelegationsIcq(s.Ctx(), tc.hostZone, tc.valoperAddr)
+	s.Require().ErrorContains(err, "connection id cannot be empty")
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
* Psuedo code of current setup with description below...
```
def makeQueryRequest():
    queryId = hashOf(chainId, queryType) // this ID will always be the same across each epoch 
    callbackData = {ConnectionId, chainId, queryType, address, ..., ttl} // TTL is the only thing different across epochs

    if queryId not already in state:                   // we go down this branch during the first epoch
        k.SetValue(key=queryID, value=callbackData)   
    else:                                              // we'll go down this branch every epoch after that until we handle a response
        do nothing

def handleQueryResponse():
    callbackData = k.GetValue(key=queryId)
    if currentTime > callbackData.ttl:
        query has expired!
    else:
        handle response

    k.DeleteValue(key=queryId)
```
For a given host zone, each query type will share the same queryID (e.g. all delegation account balance queries for cosmoshub have the same query Id - regardless of the epoch that they're submitted from). However, the ttl field which is stored in the query object, is different across epochs. This introduces an edge case where if the same query is re-requested multiple times before any of them are handled, the query object is never updated. Which means that once one of the queries is finally handled, it will use the old TTL field and be marked as expired.
In other words, if a query wasn't handled after a given epoch, we'd have to wait an extra epoch before it was handled properly...
* Epoch 1) query (1) is requested but response is never relayed. Query TTL is defined in the store as roughly 2 hours before epoch 2.
* Epoch 2) - query (2) requested and response is relayed, but it has the same ID as query (1). This means it grabs the old query object from the store and marks this query as expired since it’s using the old TTL. The query is then deleted from the store
* Epoch 3) - query (3) is requested and response is relayed successfully

## Brief Changelog
* Added check to reset the TTL when a duplicate request is submitted
* Returned errors for a few edge cases where only errors were logged but the function continued
* Cleaned up the MakeRequest function in general

## Author's Checklist

I have...

- [ ] Run and PASSED locally all GAIA integration tests
- [ ] If the change is contentful, I either:
    - [ ] Added a new unit test OR 
    - [ ] Added test cases to existing unit tests
- [ ] OR this change is a trivial rework / code cleanup without any test coverage

If skipped any of the tests above, explain.
<!-- *(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...* -->

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [ ] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
