### PR TITLE
fix `GET_VAL_ADDR` param

### DIFF
--- a/dockernet/tests/integration_tests.bats
+++ b/dockernet/tests/integration_tests.bats
@@ -165,7 +165,7 @@ setup_file() {
   WAIT_FOR_BLOCK $STRIDE_LOGS 2
 
   # check staked tokens
-  NEW_STAKE=$($HOST_MAIN_CMD q staking delegation $(GET_ICA_ADDR $HOST_CHAIN_ID delegation) $(GET_VAL_ADDR $HOST_CHAIN_ID 1) | GETSTAKE)
+  NEW_STAKE=$($HOST_MAIN_CMD q staking delegation $(GET_ICA_ADDR $HOST_CHAIN_ID delegation) $(GET_VAL_ADDR $CHAIN_NAME 1) | GETSTAKE)
   stake_diff=$(($NEW_STAKE > 0))
   assert_equal "$stake_diff" "1"
 }


### PR DESCRIPTION
**Summary**
`GET_VAL_ADDR` requires a `CHAIN_NAME`, not a `HOST_CHAIN_ID`. In many cases, these are the same (so this error went unnoticed) but Evmos has a different chain name / chain id, which causes a failure.

**Test plan**
Ran integration tests on Gaia, Evmos successfully