### PR TITLE
add nhah's 1st invariant from PR #533

### DIFF
--- a/x/stakeibc/keeper/invariants.go
+++ b/x/stakeibc/keeper/invariants.go
@@ -3,11 +3,21 @@ package keeper
 // DONTCOVER
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	// epochtypes "github.com/Stride-Labs/stride/v4/x/epochs/types"
+	"github.com/Stride-Labs/stride/v5/x/stakeibc/types"
+)
+
+const (
+	DelegationsSumToStakedBalName = "delegations-sum-to-stakedbal"
 )
 
 // RegisterInvariants registers all governance invariants.
 func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, DelegationsSumToStakedBalName, k.DelegationsSumToStakedBal())
 }
 
 // AllInvariants runs all invariants of the stakeibc module
@@ -15,6 +25,32 @@ func AllInvariants(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		// msg, broke := RedemptionRateInvariant(k)(ctx)
 		// note: once we have >1 invariant here, follow the pattern from staking module invariants here: https://github.com/cosmos/cosmos-sdk/blob/v0.46.0/x/staking/keeper/invariants.go
+		// return "", false
+		res, stop := k.DelegationsSumToStakedBal()(ctx)
+		if !stop {
+			return res, stop
+		}
 		return "", false
+	}
+}
+
+// DelegationsSumToStakedBal ensure that sum of balances staked to each validator (as recorded on the host_zone struct) sums to the total staked balance of the host zone (as recorded on the host_zone struct)
+// NOTE: this invariant does not query any *actual* staked balances on the host chain, only the staked balances recorded on the host_zone struct
+func (k Keeper) DelegationsSumToStakedBal() sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		listHostZone := k.GetAllHostZone(ctx)
+
+		for _, host := range listHostZone {
+			sumOfDelegations := k.GetTotalValidatorDelegations(host)
+			if !(host.StakedBal).Equal(sumOfDelegations) {
+				return sdk.FormatInvariant(types.ModuleName, "balance-stake-hostzone-invariant", fmt.Sprintf(
+					"\tStakedBal %s (as recorded on the host_zone struct) is not equal to sum of validator's delegations (as recorded on the host_zone struct) \n"+
+						"\tStakedBal: %d\n"+
+						"\t Sum of validator's delegations: %d\n",
+					host.ChainId, host.StakedBal, sumOfDelegations,
+				)), true
+			}
+		}
+		return sdk.FormatInvariant(types.ModuleName, "delegations-sum-to-stakedbal", "sum of balances staked to each validator (as recorded on the host_zone struct) sums to the total staked balance of the host zone (as recorded on the host_zone struct)"), false
 	}
 }

--- a/x/stakeibc/keeper/invariants_test.go
+++ b/x/stakeibc/keeper/invariants_test.go
@@ -1,0 +1,77 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Stride-Labs/stride/v5/x/stakeibc/types"
+)
+
+func (suite *KeeperTestSuite) TestBalanceStakeHostZoneInvariant() {
+	testcases := []struct {
+		name         string
+		hostZone     types.HostZone
+		expectedStop bool
+	}{
+		{
+			name: "unhappy case",
+			hostZone: types.HostZone{
+				ChainId: HostChainId,
+				Validators: []*types.Validator{
+					{
+						Name:           "val1",
+						Address:        "stride_VAL1",
+						CommissionRate: 1,
+						Weight:         100,
+						Status:         types.Validator_ACTIVE,
+						DelegationAmt:  sdk.NewInt(150),
+					},
+					{
+						Name:           "val2",
+						Address:        "stride_VAL2",
+						CommissionRate: 2,
+						Weight:         500,
+						Status:         types.Validator_ACTIVE,
+						DelegationAmt:  sdk.NewInt(500),
+					},
+				},
+				StakedBal: sdk.NewInt(600),
+			},
+			expectedStop: true,
+		},
+		{
+			name: "happy case",
+			hostZone: types.HostZone{
+				ChainId: HostChainId,
+				Validators: []*types.Validator{
+					{
+						Name:           "val1",
+						Address:        "stride_VAL1",
+						CommissionRate: 1,
+						Weight:         100,
+						Status:         types.Validator_ACTIVE,
+						DelegationAmt:  sdk.NewInt(100),
+					},
+					{
+						Name:           "val2",
+						Address:        "stride_VAL2",
+						CommissionRate: 2,
+						Weight:         500,
+						Status:         types.Validator_ACTIVE,
+						DelegationAmt:  sdk.NewInt(500),
+					},
+				},
+				StakedBal: sdk.NewInt(600),
+			},
+			expectedStop: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		suite.Run(tc.name, func() {
+			suite.Setup()
+			suite.App.StakeibcKeeper.SetHostZone(suite.Ctx, tc.hostZone)
+			res, broken := suite.App.StakeibcKeeper.DelegationsSumToStakedBal()(suite.Ctx)
+			suite.Require().Equal(tc.expectedStop, broken, res)
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/Stride-Labs/stride/issues/525

**Context**: Nhah created a [PR that added three invariants](https://github.com/Stride-Labs/stride/pull/533). The first invariant should ship with the v7 upgrade. The second two need some work, they probably will not ship with the v7 upgrade (see the PR for reasoning). I closed that PR and copied over the first invariant to this PR in order to ship it as part of v7.

**What does this invariant do?**: ensures that sum of balances staked to each validator (as recorded on the host_zone struct) sums to the total staked balance of the host zone (as recorded on the host_zone struct).

**What happens if the invariant is violated?**: stride halts (can a reviewer check this please @sampocs) 

**Reviewers:** 
1. check that the invariant won't trigger unexpectedly (note this is our first time using a proper invariant with the framework that core modules use for invariants)
2. check that if the invariant triggers, it will halt stride; also, is that the desired effect? we may instead want it to pause the affected host zone's app logic and ibc-transfers (like we do [here](https://github.com/Stride-Labs/stride/pull/614/files)) 