### PR TITLE
remove unnecessary errs in hooks

### DIFF
--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -7,11 +7,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cast"
 
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	"github.com/Stride-Labs/stride/v6/utils"
 	epochstypes "github.com/Stride-Labs/stride/v6/x/epochs/types"
 	recordstypes "github.com/Stride-Labs/stride/v6/x/records/types"
 	"github.com/Stride-Labs/stride/v6/x/stakeibc/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInfo) {
@@ -75,7 +76,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to allocate host zone reward, err: %s", err.Error()))
 			return
 		}
-		
+
 	}
 }
 
@@ -143,7 +144,8 @@ func (k Keeper) SetWithdrawalAddress(ctx sdk.Context) {
 
 // Updates the redemption rate for each host zone
 // The redemption rate equation is:
-//   (Unbonded Balance + Staked Balance + Module Account Balance) / (stToken Supply)
+//
+//	(Unbonded Balance + Staked Balance + Module Account Balance) / (stToken Supply)
 func (k Keeper) UpdateRedemptionRates(ctx sdk.Context, depositRecords []recordstypes.DepositRecord) {
 	k.Logger(ctx).Info("Updating Redemption Rates...")
 
@@ -156,17 +158,9 @@ func (k Keeper) UpdateRedemptionRates(ctx sdk.Context, depositRecords []recordst
 			k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "No st%s in circulation - redemption rate is unchanged", hostZone.HostDenom))
 			continue
 		}
-		undelegatedBalance, err := k.GetUndelegatedBalance(hostZone, depositRecords)
-		if err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("Could not get undelegated balance for host zone %s: %s", hostZone.ChainId, err.Error()))
-			return
-		}
+		undelegatedBalance := k.GetUndelegatedBalance(hostZone, depositRecords)
 		stakedBalance := hostZone.StakedBal
-		moduleAcctBalance, err := k.GetModuleAccountBalance(hostZone, depositRecords)
-		if err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("Could not get module account balance for host zone %s: %s", hostZone.ChainId, err.Error()))
-			return
-		}
+		moduleAcctBalance := k.GetModuleAccountBalance(hostZone, depositRecords)
 
 		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId,
 			"Redemption Rate Components - Undelegated Balance: %v, Staked Balance: %v, Module Account Balance: %v, stToken Supply: %v",
@@ -183,7 +177,7 @@ func (k Keeper) UpdateRedemptionRates(ctx sdk.Context, depositRecords []recordst
 	}
 }
 
-func (k Keeper) GetUndelegatedBalance(hostZone types.HostZone, depositRecords []recordstypes.DepositRecord) (sdkmath.Int, error) {
+func (k Keeper) GetUndelegatedBalance(hostZone types.HostZone, depositRecords []recordstypes.DepositRecord) sdkmath.Int {
 	// filter to only the deposit records for the host zone with status DELEGATION_QUEUE
 	UndelegatedDepositRecords := utils.FilterDepositRecords(depositRecords, func(record recordstypes.DepositRecord) (condition bool) {
 		return ((record.Status == recordstypes.DepositRecord_DELEGATION_QUEUE || record.Status == recordstypes.DepositRecord_DELEGATION_IN_PROGRESS) && record.HostZoneId == hostZone.ChainId)
@@ -195,10 +189,10 @@ func (k Keeper) GetUndelegatedBalance(hostZone types.HostZone, depositRecords []
 		totalAmount = totalAmount.Add(depositRecord.Amount)
 	}
 
-	return totalAmount, nil
+	return totalAmount
 }
 
-func (k Keeper) GetModuleAccountBalance(hostZone types.HostZone, depositRecords []recordstypes.DepositRecord) (sdkmath.Int, error) {
+func (k Keeper) GetModuleAccountBalance(hostZone types.HostZone, depositRecords []recordstypes.DepositRecord) sdkmath.Int {
 	// filter to only the deposit records for the host zone with status DELEGATION
 	ModuleAccountRecords := utils.FilterDepositRecords(depositRecords, func(record recordstypes.DepositRecord) (condition bool) {
 		return (record.Status == recordstypes.DepositRecord_TRANSFER_QUEUE || record.Status == recordstypes.DepositRecord_TRANSFER_IN_PROGRESS) && record.HostZoneId == hostZone.ChainId
@@ -210,7 +204,7 @@ func (k Keeper) GetModuleAccountBalance(hostZone types.HostZone, depositRecords 
 		totalAmount = totalAmount.Add(depositRecord.Amount)
 	}
 
-	return totalAmount, nil
+	return totalAmount
 }
 
 func (k Keeper) ReinvestRewards(ctx sdk.Context) {
@@ -255,7 +249,7 @@ func (k Keeper) AllocateHostZoneReward(ctx sdk.Context) error {
 		hz, err := k.GetHostZoneFromIBCDenom(ctx, token.Denom)
 		if err != nil {
 			k.Logger(ctx).Info("Can't get host zone from ibc token %s", token.Denom)
-			return err
+			continue
 		}
 
 		// liquid stake all tokens
@@ -263,7 +257,7 @@ func (k Keeper) AllocateHostZoneReward(ctx sdk.Context) error {
 		_, err = msgSvr.LiquidStake(ctx, msg)
 		if err != nil {
 			k.Logger(ctx).Info("Can't liquid stake %s for hostzone %s", token.String(), hz.ChainId)
-			return err
+			continue
 		}
 	}
 	// After liquid stake all tokens, reward collector receive stTokens


### PR DESCRIPTION
## Context and purpose of the change

Hooks.go contains an unnecessary Error, and the Error was handled incorrectly (`return` instead of `continue`). Given that we can't make any atomicity assumptions in `hooks.go`, I removed the extra Error + Return statement. 


## Brief Changelog

Modify error handling in `UpdateRedemptionRates`
