### PR TITLE
test for sei testnet (liquid staking with ica disabled)

### DIFF
--- a/dockernet/config.sh
+++ b/dockernet/config.sh
@@ -28,7 +28,7 @@ HOST_CHAINS=()
 #  - STARS
 #  - HOST (Stride chain enabled as a host zone)
 if [[ "${ALL_HOST_CHAINS:-false}" == "true" ]]; then 
-  HOST_CHAINS=(GAIA OSMO HOST)
+  HOST_CHAINS=(GAIA OSMO) # OSMO HOST)
 elif [[ "${#HOST_CHAINS[@]}" == "0" ]]; then 
   HOST_CHAINS=(GAIA)
 fi

--- a/dockernet/config/ica_off.json
+++ b/dockernet/config/ica_off.json
@@ -1,0 +1,20 @@
+{
+    "interchainaccounts": {
+        "controller_genesis_state": {
+            "active_channels": [],
+            "interchain_accounts": [],
+            "ports": [],
+            "params": {
+                "controller_enabled": true
+            }
+        },
+        "host_genesis_state": {
+            "active_channels": [],
+            "interchain_accounts": [],
+            "port": "icahost",
+            "params": {
+                "host_enabled": false
+            }
+        }
+    }
+}

--- a/dockernet/scripts/test_sei_case.sh
+++ b/dockernet/scripts/test_sei_case.sh
@@ -1,0 +1,12 @@
+### IBC TRANSFER
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/../config.sh
+
+## IBC ATOM from OSMO to STRIDE
+$OSMO_MAIN_CMD tx ibc-transfer transfer transfer channel-0 $(STRIDE_ADDRESS) 1000000uosmo --from ${OSMO_VAL_PREFIX}1 -y 
+sleep 3
+## LIQUID STAKE IT
+$STRIDE_MAIN_CMD tx stakeibc liquid-stake 10000 $OSMO_DENOM --from sval1_test -y --keyring-backend os
+sleep 3
+## CHECK WE GOT stOSMO
+$STRIDE_MAIN_CMD q bank balances stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7

--- a/dockernet/scripts/test_sei_case.sh
+++ b/dockernet/scripts/test_sei_case.sh
@@ -6,7 +6,7 @@ source ${SCRIPT_DIR}/../config.sh
 $OSMO_MAIN_CMD tx ibc-transfer transfer transfer channel-0 $(STRIDE_ADDRESS) 1000000uosmo --from ${OSMO_VAL_PREFIX}1 -y 
 sleep 3
 ## LIQUID STAKE IT
-$STRIDE_MAIN_CMD tx stakeibc liquid-stake 10000 $OSMO_DENOM --from sval1_test -y --keyring-backend os
+$STRIDE_MAIN_CMD tx stakeibc liquid-stake 50000 $OSMO_DENOM --from sval1_test -y --keyring-backend os
 sleep 3
 ## CHECK WE GOT stOSMO
 $STRIDE_MAIN_CMD q bank balances stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7

--- a/dockernet/src/init_chain.sh
+++ b/dockernet/src/init_chain.sh
@@ -48,7 +48,16 @@ set_host_genesis() {
 
     # Add interchain accounts to the genesis set
     jq "del(.app_state.interchain_accounts)" $genesis_config > json.tmp && mv json.tmp $genesis_config
-    interchain_accts=$(cat $DOCKERNET_HOME/config/ica.json)
+    echo "moose"
+    echo $genesis_config
+    # if genesis_config contains substring "gaia" then
+    if [[ "$genesis_config" == *"gaia"* ]]; then
+        echo "It's there."
+        interchain_accts=$(cat $DOCKERNET_HOME/config/ica.json)
+    else
+        echo "It's not there."
+        interchain_accts=$(cat $DOCKERNET_HOME/config/ica_off.json)
+    fi
     jq ".app_state += $interchain_accts" $genesis_config > json.tmp && mv json.tmp $genesis_config
 
     # Slightly harshen slashing parameters (if 5 blocks are missed, the validator will be slashed)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Sei's testnet will upgrade to enable ICA soon, but in the meantime we'd like to connect and allow users to liquid stake.

Simple tests
- [x] we can register the zone despite ICA being turned off (`"host_enabled": false`)
- [x] we pass integration tests on ICA enabled hosts from the same stride controller with a ICA-disabled host
- [ ] we can liquid stake to the ICA-disabled zone without breaking any assumptions

Involved tests
- [ ] when the ICA-disabled host upgrades to add ICA, the pending stakes process properly and the integration tests pass

---

Setup: 
* In dockernet, gaia is the ICA-enabled host, osmo is the ICA-disabled host (see setup in `init_chain.sh:54`)

Testing:
- Run `make test-integration-docker`
```
base ❯ make test-integration-docker
bash ./dockernet/tests/run_all_tests.sh
integration_tests.bats
 ✓ [INTEGRATION-BASIC-GAIA] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mint and transfer
 - [INTEGRATION-BASIC-GAIA] packet forwarding automatically liquid stakes (skipped: DefaultActive set to false, skip test)
 ✓ [INTEGRATION-BASIC-GAIA] tokens on GAIA were staked
 ✓ [INTEGRATION-BASIC-GAIA] redemption works
 ✓ [INTEGRATION-BASIC-GAIA] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being reinvested, exchange rate updating
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being distributed to stakers

9 tests, 0 failures, 1 skipped

integration_tests.bats
 ✗ [INTEGRATION-BASIC-OSMO] host zones successfully registered
   (from function `refute_line' in file dockernet/tests/bats/bats-assert/src/refute_line.bash, line 265,
    in test file dockernet/tests/integration_tests.bats, line 83)
     `refute_line '  delegation_account: null'' failed
... MORE ERRORS 
```
Notice that OSMO was not registered. The delegation account is null. 

Querying the OSMO zone gives this
```
base ❯ build/strided --home scripts/state/stride1 q stakeibc show-host-zone OSMO
host_zone:
  address: stride1hrzg27xh9zc25uufl8lm84z595zv8efsxl6cfr76kvg5xafzd8asx6lnz2
  bech32prefix: osmo
  blacklisted_validators: []
  chain_id: OSMO
  connection_id: connection-1
  delegation_account: null
  fee_account: null
  halted: false
  host_denom: uosmo
  ibc_denom: ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B
  last_redemption_rate: "1.000000000000000000"
  max_redemption_rate: "1.500000000000000000"
  min_redemption_rate: "0.900000000000000000"
  redemption_account: null
  redemption_rate: "1.000000000000000000"
  staked_bal: "0"
  transfer_channel_id: channel-1
  unbonding_frequency: "1"
  validators:
  - address: osmovaloper1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhr6n3re8
    commission_rate: "10"
    delegation_amt: "0"
    internal_exchange_rate: null
    name: oval1
    status: ACTIVE
    weight: "10"
  withdrawal_account: null
```
Run the provided test to make sure we can liquid stake to this zone
```
base ❯ sh ./dockernet/scripts/test_sei_case.sh 
code: 0
codespace: ""
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: '[]'
timestamp: ""
tx: null
txhash: D5035C85D1DA0AA7EE69DABC46E4E9200C6CA8D3E5AC083746EE947AED9A15E7
code: 0
codespace: ""
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: '[]'
timestamp: ""
tx: null
txhash: BD253D11D68360996B440F0E8025CD11A48DBD2C64B7E8494D1036E6AE3DEF49
balances:
- amount: "950000"
  denom: ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B
- amount: "50000"
  denom: stuosmo
- amount: "4995000000000"
  denom: ustrd
pagination:
  next_key: null
  total: "0"
```
Notice there's stOSMO in the account!