### PR TITLE
Add Function to Update Airdrop Addresses

### DIFF
--- a/x/claim/README.md
+++ b/x/claim/README.md
@@ -54,6 +54,21 @@ type ClaimRecord struct {
 
 ```
 
+## A Note on Address Mappings
+
+When an airdrop is created, we call `LoadAllocationData` to load the airdrop data from the allocations file. 
+This will apply `utils.ConvertAddressToStrideAddress` on each of those addresses, and then store those with the `ClaimRecords`.
+For an airdrop to, say, the Cosmos Hub, this will be the proper Stride address associated with that account. 
+`claim` state will only ever store this Stride address.
+
+However, for zones with a different coin type, _this will be an incorrect Stride address_. This should not cause any issues though,
+as this Stride address will be unusable.
+
+In order to claim that airdrop, the user will have to verify that they own the corresponding Evmos address. When the user tries to verify,
+we call `utils.ConvertAddressToStrideAddress` on that address, and verify it gives the same "incorrect" Stride address from earlier. 
+Through this, we can confirm that the user owns the Evmos address. 
+We then replace the Stride address with a "correct" one that the user verifies they own. 
+
 ## Params
 
 The airdrop logic has 4 parameters:

--- a/x/claim/keeper/hooks.go
+++ b/x/claim/keeper/hooks.go
@@ -48,15 +48,20 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochInfo epochstypes.EpochInfo) 
 	// check if epochInfo.Identifier is an airdrop epoch
 	// if yes, reset claim status for all users
 	// check if epochInfo.Identifier starts with "airdrop"
+	k.Logger(ctx).Info(fmt.Sprintf("[CLAIM] checking if epoch %s is an airdrop epoch", epochInfo.Identifier))
 	if strings.HasPrefix(epochInfo.Identifier, "airdrop-") {
 		airdropIdentifier := strings.TrimPrefix(epochInfo.Identifier, "airdrop-")
+		k.Logger(ctx).Info(fmt.Sprintf("[CLAIM] trimmed airdrop identifier: %s", airdropIdentifier))
 		airdropFound := k.GetAirdropByIdentifier(ctx, airdropIdentifier)
+		k.Logger(ctx).Info(fmt.Sprintf("[CLAIM] airdrop found: %v", airdropFound))
 		if airdropFound == nil {
-			k.Logger(ctx).Info(fmt.Sprintf("resetting claims for airdrop %s", epochInfo.Identifier))
+			k.Logger(ctx).Info(fmt.Sprintf("[CLAIM] resetting claims for airdrop %s", epochInfo.Identifier))
 			err := k.ResetClaimStatus(ctx, airdropIdentifier)
 			if err != nil {
-				k.Logger(ctx).Error(fmt.Sprintf("failed to reset claim status for epoch %s: %s", epochInfo.Identifier, err.Error()))
+				k.Logger(ctx).Error(fmt.Sprintf("[CLAIM] failed to reset claim status for epoch %s: %s", epochInfo.Identifier, err.Error()))
 			}
+		} else {
+			k.Logger(ctx).Info(fmt.Sprintf("[CLAIM] airdrop %s not found, skipping reset", airdropIdentifier))
 		}
 	}
 }

--- a/x/claim/types/errors.go
+++ b/x/claim/types/errors.go
@@ -22,4 +22,10 @@ var (
 		"cannot claim negative tokens")
 	ErrInvalidAccount = errorsmod.Register(ModuleName, 1109,
 		"only BaseAccount and StridePeriodicVestingAccount can claim")
+	ErrAirdropNotFound = errorsmod.Register(ModuleName, 1110,
+		"the airdrop was not found")
+	ErrClaimNotFound = errorsmod.Register(ModuleName, 1111,
+		"the claim record was not found")
+	ErrModifyingClaimRecord = errorsmod.Register(ModuleName, 1112,
+		"failed to modify claim record")
 )


### PR DESCRIPTION
## Context and purpose of the change

This adds a function to `claim` that allows the keeper to update an airdrop address. This will be used to match airdrops on zones that have different cointypes, e.g. Evmos. 
