### PR TITLE
[LSM] Removed Unnecessary Overflow Check

### DIFF
--- a/x/interchainquery/keeper/queries.go
+++ b/x/interchainquery/keeper/queries.go
@@ -103,16 +103,7 @@ func (k Keeper) GetQueryUID(ctx sdk.Context) []byte {
 		uidBz = make([]byte, 8)
 		binary.BigEndian.PutUint64(uidBz, 1)
 	}
-
 	uid := binary.BigEndian.Uint64(uidBz)
-
-	// Reset the uid after 1B
-	// In practice, this is not necessary as we'll never hit the limit, but in theory, we could have int overflow
-	if uid > 1_000_000_000 {
-		uid = 1
-		uidBz = make([]byte, 8)
-		binary.BigEndian.PutUint64(uidBz, uid)
-	}
 
 	// Increment and store the next UID
 	nextUidBz := make([]byte, 8)

--- a/x/interchainquery/keeper/queries_test.go
+++ b/x/interchainquery/keeper/queries_test.go
@@ -216,7 +216,7 @@ func (s *KeeperTestSuite) GetQueryUID() {
 	// Grabbing the uid for the first time should return 1
 	s.Require().Equal(1, getUniqueSuffix())
 
-	// Grabbing it a second time shoudl return 2
+	// Grabbing it a second time should return 2
 	s.Require().Equal(2, getUniqueSuffix())
 
 	// call it 1000 more times
@@ -225,16 +225,6 @@ func (s *KeeperTestSuite) GetQueryUID() {
 		suffix = getUniqueSuffix()
 	}
 	s.Require().Equal(1002, suffix)
-
-	// Set the counter to 1B
-	store := s.Ctx.KVStore(s.App.GetKey(types.StoreKey))
-	nextUidBz := make([]byte, 8)
-	binary.BigEndian.PutUint64(nextUidBz, 1_000_000_000)
-	store.Set(types.KeyQueryCounter, nextUidBz)
-	s.Require().Equal(1_000_000_000, getUniqueSuffix())
-
-	// It should have been reset to 1
-	s.Require().Equal(1, getUniqueSuffix())
 }
 
 func TestUnmarshalAmountFromBalanceQuery(t *testing.T) {


### PR DESCRIPTION
This overflow check is a little ridiculous considering it's only incremented each query we send