### PR TITLE
[LSM] Updated Delegation in Detokenize Callback

### DIFF
--- a/x/stakeibc/keeper/host_zone.go
+++ b/x/stakeibc/keeper/host_zone.go
@@ -101,11 +101,12 @@ func (k Keeper) GetAllActiveHostZone(ctx sdk.Context) (list []types.HostZone) {
 	return
 }
 
-// Updates a validator's delegation
-// Note: This updates modifies the original validator struct
+// Updates a validator's individual delegation, and the corresponding total delegation on the host zone
+// Note: This modifies the original host zone struct. The calling function must Set this host zone
+// for changes to persist
 func (k Keeper) AddDelegationToValidator(
 	ctx sdk.Context,
-	hostZone types.HostZone,
+	hostZone *types.HostZone,
 	validatorAddress string,
 	amount sdkmath.Int,
 	callbackId string,
@@ -116,13 +117,22 @@ func (k Keeper) AddDelegationToValidator(
 				"  Validator %s, Current Delegation: %v, Delegation Change: %v", validator.Address, validator.Delegation, amount))
 
 			// If the delegation change is negative, make sure it wont cause the delegation to fall below zero
-			if amount.IsNegative() && amount.Abs().GT(validator.Delegation) {
-				return errorsmod.Wrapf(types.ErrValidatorDelegationChg,
-					"Delegation change (%v) is greater than validator (%s) delegation %v",
-					amount.Abs(), validatorAddress, validator.Delegation)
+			if amount.IsNegative() {
+				if amount.Abs().GT(validator.Delegation) {
+					return errorsmod.Wrapf(types.ErrValidatorDelegationChg,
+						"Delegation change (%v) is greater than validator (%s) delegation %v",
+						amount.Abs(), validatorAddress, validator.Delegation)
+				}
+				if amount.Abs().GT(hostZone.TotalDelegations) {
+					return errorsmod.Wrapf(types.ErrValidatorDelegationChg,
+						"Delegation change (%v) is greater than total delegation amount on host %s (%v)",
+						amount.Abs(), hostZone.ChainId, hostZone.TotalDelegations)
+				}
 			}
 
 			validator.Delegation = validator.Delegation.Add(amount)
+			hostZone.TotalDelegations = hostZone.TotalDelegations.Add(amount)
+
 			return nil
 		}
 	}

--- a/x/stakeibc/keeper/host_zone_test.go
+++ b/x/stakeibc/keeper/host_zone_test.go
@@ -216,3 +216,32 @@ func (s *KeeperTestSuite) TestIncrementValidatorSlashQueryProgress() {
 	err = s.App.StakeibcKeeper.IncrementValidatorSlashQueryProgress(s.Ctx, HostChainId, "fake_val", stakeAmount)
 	s.Require().ErrorContains(err, "validator not found")
 }
+
+func (s *KeeperTestSuite) TestAddDelegationToValidator() {
+	hostZone := types.HostZone{
+		Validators: []*types.Validator{
+			{Address: "other_val", Delegation: sdkmath.NewInt(1000)},
+			{Address: ValAddress, Delegation: sdkmath.NewInt(3000)},
+			{Address: "other_val2", Delegation: sdkmath.NewInt(3000)},
+		},
+	}
+	updatedIndex := 1
+
+	// Add 500 to the validator
+	err := s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(500), "")
+	s.Require().NoError(err, "no error expected when adding delegation to validator")
+	s.Require().Equal(int64(3500), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after addition")
+
+	// Subtract 250 from the validator
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-250), "")
+	s.Require().NoError(err, "no error expected when subtracting delegation from validator")
+	s.Require().Equal(int64(3250), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after subtraction")
+
+	// Attempt to subtract more than the validator has - it should fail
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-4000), "")
+	s.Require().ErrorContains(err, "Delegation change (4000) is greater than validator")
+
+	// Attempt to modify a validator that doesn't exist - it should fail
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, "does_not_exist", sdkmath.NewInt(-4000), "")
+	s.Require().ErrorContains(err, "validator not found")
+}

--- a/x/stakeibc/keeper/host_zone_test.go
+++ b/x/stakeibc/keeper/host_zone_test.go
@@ -220,8 +220,8 @@ func (s *KeeperTestSuite) TestIncrementValidatorSlashQueryProgress() {
 func (s *KeeperTestSuite) TestAddDelegationToValidator() {
 	hostZone := types.HostZone{
 		Validators: []*types.Validator{
-			{Address: "other_val", Delegation: sdkmath.NewInt(1000)},
-			{Address: ValAddress, Delegation: sdkmath.NewInt(3000)},
+			{Address: "other_val1", Delegation: sdkmath.NewInt(1000)},
+			{Address: ValAddress, Delegation: sdkmath.NewInt(2000)},
 			{Address: "other_val2", Delegation: sdkmath.NewInt(3000)},
 		},
 	}
@@ -230,18 +230,22 @@ func (s *KeeperTestSuite) TestAddDelegationToValidator() {
 	// Add 500 to the validator
 	err := s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(500), "")
 	s.Require().NoError(err, "no error expected when adding delegation to validator")
-	s.Require().Equal(int64(3500), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after addition")
+	s.Require().Equal(int64(2500), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after addition")
 
 	// Subtract 250 from the validator
 	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-250), "")
 	s.Require().NoError(err, "no error expected when subtracting delegation from validator")
-	s.Require().Equal(int64(3250), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after subtraction")
+	s.Require().Equal(int64(2250), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after subtraction")
+
+	// Confirm other validators were not modified
+	s.Require().Equal(int64(1000), hostZone.Validators[0].Delegation.Int64(), "validator at index 0 should not have changed")
+	s.Require().Equal(int64(3000), hostZone.Validators[2].Delegation.Int64(), "validator at index 2 should not have changed")
 
 	// Attempt to subtract more than the validator has - it should fail
-	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-4000), "")
-	s.Require().ErrorContains(err, "Delegation change (4000) is greater than validator")
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-3000), "")
+	s.Require().ErrorContains(err, "Delegation change (3000) is greater than validator")
 
 	// Attempt to modify a validator that doesn't exist - it should fail
-	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, "does_not_exist", sdkmath.NewInt(-4000), "")
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, "does_not_exist", sdkmath.NewInt(1000), "")
 	s.Require().ErrorContains(err, "validator not found")
 }

--- a/x/stakeibc/keeper/host_zone_test.go
+++ b/x/stakeibc/keeper/host_zone_test.go
@@ -218,12 +218,13 @@ func (s *KeeperTestSuite) TestIncrementValidatorSlashQueryProgress() {
 }
 
 func (s *KeeperTestSuite) TestAddDelegationToValidator() {
-	hostZone := types.HostZone{
+	hostZone := &types.HostZone{
 		Validators: []*types.Validator{
 			{Address: "other_val1", Delegation: sdkmath.NewInt(1000)},
 			{Address: ValAddress, Delegation: sdkmath.NewInt(2000)},
 			{Address: "other_val2", Delegation: sdkmath.NewInt(3000)},
 		},
+		TotalDelegations: sdkmath.NewInt(6000),
 	}
 	updatedIndex := 1
 
@@ -231,11 +232,13 @@ func (s *KeeperTestSuite) TestAddDelegationToValidator() {
 	err := s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(500), "")
 	s.Require().NoError(err, "no error expected when adding delegation to validator")
 	s.Require().Equal(int64(2500), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after addition")
+	s.Require().Equal(int64(6500), hostZone.TotalDelegations.Int64(), "total delegations after addition")
 
 	// Subtract 250 from the validator
 	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-250), "")
 	s.Require().NoError(err, "no error expected when subtracting delegation from validator")
 	s.Require().Equal(int64(2250), hostZone.Validators[updatedIndex].Delegation.Int64(), "delegation after subtraction")
+	s.Require().Equal(int64(6250), hostZone.TotalDelegations.Int64(), "total delegations after subtraction")
 
 	// Confirm other validators were not modified
 	s.Require().Equal(int64(1000), hostZone.Validators[0].Delegation.Int64(), "validator at index 0 should not have changed")
@@ -248,4 +251,11 @@ func (s *KeeperTestSuite) TestAddDelegationToValidator() {
 	// Attempt to modify a validator that doesn't exist - it should fail
 	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, "does_not_exist", sdkmath.NewInt(1000), "")
 	s.Require().ErrorContains(err, "validator not found")
+
+	// Attempt to subtract more than the total delegations on the host - it should fail
+	// Here, w set the validator's delegation to be much higher than the TotalDelegation
+	//   (which should not be possible in practice)
+	hostZone.Validators[updatedIndex].Delegation = sdkmath.NewInt(10000)
+	err = s.App.StakeibcKeeper.AddDelegationToValidator(s.Ctx, hostZone, ValAddress, sdkmath.NewInt(-7000), "")
+	s.Require().ErrorContains(err, "Delegation change (7000) is greater than total delegation amount on host")
 }

--- a/x/stakeibc/keeper/icacallbacks_delegate.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate.go
@@ -91,8 +91,7 @@ func DelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, ack
 
 	// Update delegations on the host zone
 	for _, splitDelegation := range delegateCallback.SplitDelegations {
-		hostZone.TotalDelegations = hostZone.TotalDelegations.Add(splitDelegation.Amount)
-		err := k.AddDelegationToValidator(ctx, hostZone, splitDelegation.Validator, splitDelegation.Amount, ICACallbackID_Delegate)
+		err := k.AddDelegationToValidator(ctx, &hostZone, splitDelegation.Validator, splitDelegation.Amount, ICACallbackID_Delegate)
 		if err != nil {
 			return errorsmod.Wrapf(err, "Failed to add delegation to validator")
 		}

--- a/x/stakeibc/keeper/icacallbacks_delegate.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate.go
@@ -92,9 +92,9 @@ func DelegateCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, ack
 	// Update delegations on the host zone
 	for _, splitDelegation := range delegateCallback.SplitDelegations {
 		hostZone.TotalDelegations = hostZone.TotalDelegations.Add(splitDelegation.Amount)
-		success := k.AddDelegationToValidator(ctx, hostZone, splitDelegation.Validator, splitDelegation.Amount, ICACallbackID_Delegate)
-		if !success {
-			return errorsmod.Wrapf(types.ErrValidatorDelegationChg, "Failed to add delegation to validator")
+		err := k.AddDelegationToValidator(ctx, hostZone, splitDelegation.Validator, splitDelegation.Amount, ICACallbackID_Delegate)
+		if err != nil {
+			return errorsmod.Wrapf(err, "Failed to add delegation to validator")
 		}
 		k.SetHostZone(ctx, hostZone)
 	}

--- a/x/stakeibc/keeper/icacallbacks_delegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate_test.go
@@ -217,6 +217,6 @@ func (s *KeeperTestSuite) TestDelegateCallback_MissingValidator() {
 	s.Require().NoError(err)
 
 	err = stakeibckeeper.DelegateCallback(s.App.StakeibcKeeper, s.Ctx, tc.validArgs.packet, tc.validArgs.ackResponse, invalidCallbackArgs)
-	s.Require().EqualError(err, "Failed to add delegation to validator: can't change delegation on validator")
+	s.Require().ErrorContains(err, "Could not find validator address_dne on host zone GAIA: validator not found")
 	s.checkDelegateStateIfCallbackFailed(tc)
 }

--- a/x/stakeibc/keeper/icacallbacks_detokenize.go
+++ b/x/stakeibc/keeper/icacallbacks_detokenize.go
@@ -46,12 +46,23 @@ func DetokenizeCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 	k.Logger(ctx).Info(utils.LogICACallbackStatusWithHostZone(chainId, ICACallbackID_Detokenize,
 		icacallbackstypes.AckResponseStatus_SUCCESS, packet))
 
+	// Confirm host zone exists
+	hostZone, found := k.GetHostZone(ctx, chainId)
+	if !found {
+		return errorsmod.Wrapf(types.ErrHostZoneNotFound, "Host zone not found: %s", chainId)
+	}
+
 	// If the ICA succeeded, remove the token deposit
 	deposit := detokenizeCallback.Deposit
 	k.RecordsKeeper.RemoveLSMTokenDeposit(ctx, deposit.ChainId, deposit.Denom)
 
 	// Update delegation on the host zone and validator
-	// TODO [LSM] - Use helper function
+	err := k.AddDelegationToValidator(ctx, hostZone, deposit.ValidatorAddress, deposit.Amount, ICACallbackID_Detokenize)
+	if err != nil {
+		return err
+	}
+	hostZone.TotalDelegations = hostZone.TotalDelegations.Add(deposit.Amount)
+	k.SetHostZone(ctx, hostZone)
 
 	return nil
 }

--- a/x/stakeibc/keeper/icacallbacks_detokenize.go
+++ b/x/stakeibc/keeper/icacallbacks_detokenize.go
@@ -57,11 +57,10 @@ func DetokenizeCallback(k Keeper, ctx sdk.Context, packet channeltypes.Packet, a
 	k.RecordsKeeper.RemoveLSMTokenDeposit(ctx, deposit.ChainId, deposit.Denom)
 
 	// Update delegation on the host zone and validator
-	err := k.AddDelegationToValidator(ctx, hostZone, deposit.ValidatorAddress, deposit.Amount, ICACallbackID_Detokenize)
+	err := k.AddDelegationToValidator(ctx, &hostZone, deposit.ValidatorAddress, deposit.Amount, ICACallbackID_Detokenize)
 	if err != nil {
 		return err
 	}
-	hostZone.TotalDelegations = hostZone.TotalDelegations.Add(deposit.Amount)
 	k.SetHostZone(ctx, hostZone)
 
 	return nil

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -137,9 +137,9 @@ func (k Keeper) UpdateDelegationBalances(ctx sdk.Context, zone types.HostZone, u
 			zone.TotalDelegations = zone.TotalDelegations.Sub(undelegation.Amount)
 		}
 
-		success := k.AddDelegationToValidator(ctx, zone, undelegation.Validator, undelegation.Amount.Neg(), ICACallbackID_Undelegate)
-		if !success {
-			return errorsmod.Wrapf(types.ErrValidatorDelegationChg, "Failed to remove delegation to validator")
+		err := k.AddDelegationToValidator(ctx, zone, undelegation.Validator, undelegation.Amount.Neg(), ICACallbackID_Undelegate)
+		if err != nil {
+			return errorsmod.Wrapf(err, "Failed to remove delegation to validator")
 		}
 	}
 	k.SetHostZone(ctx, zone)


### PR DESCRIPTION
## Context and purpose of the change
In the detokenize callback, we have to increment the delegation on the validator and the total delegation amount for the host zone

## Brief changelog
* Cleaned up AddDelegationToValidator and added unit test
* Updated delegation in detokenize callback and added corresponding case in unit test