### PR TITLE
[LSM] Query validator exchange rate after adding validator

### DIFF
--- a/x/stakeibc/keeper/msg_server_add_validators.go
+++ b/x/stakeibc/keeper/msg_server_add_validators.go
@@ -15,7 +15,11 @@ func (k msgServer) AddValidators(goCtx context.Context, msg *types.MsgAddValidat
 		if err := k.AddValidatorToHostZone(ctx, msg.HostZone, *validator, false); err != nil {
 			return nil, err
 		}
-		// TODO [LSM]: Submit ICQ for validator exchange rate
+
+		// Query and store the validator's exchange rate
+		if err := k.QueryValidatorExchangeRate(ctx, msg.HostZone, validator.Address); err != nil {
+			return nil, err
+		}
 	}
 
 	return &types.MsgAddValidatorsResponse{}, nil

--- a/x/stakeibc/keeper/msg_server_add_validators_test.go
+++ b/x/stakeibc/keeper/msg_server_add_validators_test.go
@@ -1,41 +1,69 @@
 package keeper_test
 
 import (
+	"fmt"
+
 	sdkmath "cosmossdk.io/math"
 	_ "github.com/stretchr/testify/suite"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	ibctesting "github.com/cosmos/ibc-go/v5/testing"
 
 	"github.com/Stride-Labs/stride/v9/x/stakeibc/types"
-	stakeibctypes "github.com/Stride-Labs/stride/v9/x/stakeibc/types"
 )
 
 type AddValidatorsTestCase struct {
-	hostZone           stakeibctypes.HostZone
-	validMsg           stakeibctypes.MsgAddValidators
-	expectedValidators []*stakeibctypes.Validator
+	hostZone                 types.HostZone
+	validMsg                 types.MsgAddValidators
+	expectedValidators       []*types.Validator
+	validatorQueryDataToName map[string]string
+}
+
+// Helper function to determine the validator's key in the staking store
+// which is used as the request data in the ICQ
+func (s *KeeperTestSuite) getExchangeRateQueryData(validatorAddress string) []byte {
+	_, validatorAddressBz, err := bech32.DecodeAndConvert(validatorAddress)
+	s.Require().NoError(err, "no error expected when decoding validator address")
+	return stakingtypes.GetValidatorKey(validatorAddressBz)
 }
 
 func (s *KeeperTestSuite) SetupAddValidators() AddValidatorsTestCase {
-	hostZone := stakeibctypes.HostZone{
-		ChainId:    "GAIA",
-		Validators: []*stakeibctypes.Validator{},
+	hostZone := types.HostZone{
+		ChainId:      "GAIA",
+		ConnectionId: ibctesting.FirstConnectionID,
+		Validators:   []*types.Validator{},
 	}
 
-	validMsg := stakeibctypes.MsgAddValidators{
+	validatorAddresses := map[string]string{
+		"val1": "stridevaloper1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrgpwsqm",
+		"val2": "stridevaloper17kht2x2ped6qytr2kklevtvmxpw7wq9rcfud5c",
+		"val3": "stridevaloper1nnurja9zt97huqvsfuartetyjx63tc5zrj5x9f",
+	}
+
+	// mapping of query request data to validator name
+	// serves as a reverse lookup to map exchange rate queries to validators
+	validatorQueryDataToName := map[string]string{}
+	for name, address := range validatorAddresses {
+		queryData := s.getExchangeRateQueryData(address)
+		validatorQueryDataToName[string(queryData)] = name
+	}
+
+	validMsg := types.MsgAddValidators{
 		Creator:  "stride_ADMIN",
 		HostZone: "GAIA",
 		Validators: []*types.Validator{
-			{Name: "val1", Address: "stride_VAL1", Weight: 1},
-			{Name: "val2", Address: "stride_VAL2", Weight: 2},
-			{Name: "val3", Address: "stride_VAL3", Weight: 3},
+			{Name: "val1", Address: validatorAddresses["val1"], Weight: 1},
+			{Name: "val2", Address: validatorAddresses["val2"], Weight: 2},
+			{Name: "val3", Address: validatorAddresses["val3"], Weight: 3},
 		},
 	}
 
 	expectedValidators := []*types.Validator{
-		{Name: "val1", Address: "stride_VAL1", Weight: 1},
-		{Name: "val2", Address: "stride_VAL2", Weight: 2},
-		{Name: "val3", Address: "stride_VAL3", Weight: 3},
+		{Name: "val1", Address: validatorAddresses["val1"], Weight: 1},
+		{Name: "val2", Address: validatorAddresses["val2"], Weight: 2},
+		{Name: "val3", Address: validatorAddresses["val3"], Weight: 3},
 	}
 	for _, validator := range expectedValidators {
 		validator.Delegation = sdkmath.ZeroInt()
@@ -46,9 +74,10 @@ func (s *KeeperTestSuite) SetupAddValidators() AddValidatorsTestCase {
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
 
 	return AddValidatorsTestCase{
-		hostZone:           hostZone,
-		validMsg:           validMsg,
-		expectedValidators: expectedValidators,
+		hostZone:                 hostZone,
+		validMsg:                 validMsg,
+		expectedValidators:       expectedValidators,
+		validatorQueryDataToName: validatorQueryDataToName,
 	}
 }
 
@@ -66,6 +95,26 @@ func (s *KeeperTestSuite) TestAddValidators_Successful() {
 	for i := 0; i < 3; i++ {
 		s.Require().Equal(*tc.expectedValidators[i], *hostZone.Validators[i], "validators %d", i)
 	}
+
+	// Confirm ICQs were submitted
+	queries := s.App.InterchainqueryKeeper.AllQueries(s.Ctx)
+	s.Require().Len(queries, 3)
+
+	// Map the query responses to the validator names to get the names of the validators that
+	// were queried
+	queriedValidators := []string{}
+	for i, query := range queries {
+		validator, ok := tc.validatorQueryDataToName[string(query.RequestData)]
+		s.Require().True(ok, "query from response %d does not match any expected requests", i)
+		queriedValidators = append(queriedValidators, validator)
+	}
+
+	// Confirm the list of queried validators matches the full list of validators
+	allValidatorNames := []string{}
+	for _, expected := range tc.expectedValidators {
+		allValidatorNames = append(allValidatorNames, expected.Name)
+	}
+	s.Require().ElementsMatch(allValidatorNames, queriedValidators, "queried validators")
 }
 
 func (s *KeeperTestSuite) TestAddValidators_HostZoneNotFound() {
@@ -83,13 +132,15 @@ func (s *KeeperTestSuite) TestAddValidators_AddressAlreadyExists() {
 
 	// Update host zone so that the name val1 already exists
 	hostZone := tc.hostZone
-	duplicateVal := stakeibctypes.Validator{Name: "new_val", Address: tc.expectedValidators[0].Address}
-	hostZone.Validators = []*stakeibctypes.Validator{&duplicateVal}
+	duplicateAddress := tc.expectedValidators[0].Address
+	duplicateVal := types.Validator{Name: "new_val", Address: duplicateAddress}
+	hostZone.Validators = []*types.Validator{&duplicateVal}
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
 
 	// Change the validator address to val1 so that the message errors
+	expectedError := fmt.Sprintf("Validator address (%s) already exists on Host Zone (GAIA)", duplicateAddress)
 	_, err := s.GetMsgServer().AddValidators(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
-	s.Require().EqualError(err, "Validator address (stride_VAL1) already exists on Host Zone (GAIA): validator already exists")
+	s.Require().ErrorContains(err, expectedError)
 }
 
 func (s *KeeperTestSuite) TestAddValidators_NameAlreadyExists() {
@@ -97,11 +148,13 @@ func (s *KeeperTestSuite) TestAddValidators_NameAlreadyExists() {
 
 	// Update host zone so that val1's address already exists
 	hostZone := tc.hostZone
-	duplicateVal := stakeibctypes.Validator{Name: tc.expectedValidators[0].Name, Address: "new_address"}
-	hostZone.Validators = []*stakeibctypes.Validator{&duplicateVal}
+	duplicateName := tc.expectedValidators[0].Name
+	duplicateVal := types.Validator{Name: duplicateName, Address: "new_address"}
+	hostZone.Validators = []*types.Validator{&duplicateVal}
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
 
 	// Change the validator name to val1 so that the message errors
+	expectedError := fmt.Sprintf("Validator name (%s) already exists on Host Zone (GAIA)", duplicateName)
 	_, err := s.GetMsgServer().AddValidators(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
-	s.Require().EqualError(err, "Validator name (val1) already exists on Host Zone (GAIA): validator already exists")
+	s.Require().ErrorContains(err, expectedError)
 }

--- a/x/stakeibc/keeper/msg_server_update_validator_shares_exch_rate.go
+++ b/x/stakeibc/keeper/msg_server_update_validator_shares_exch_rate.go
@@ -16,5 +16,8 @@ import (
 // 4. DelegatorSharesCallback (CALLBACK)
 func (k msgServer) UpdateValidatorSharesExchRate(goCtx context.Context, msg *types.MsgUpdateValidatorSharesExchRate) (*types.MsgUpdateValidatorSharesExchRateResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	return k.QueryValidatorExchangeRate(ctx, msg)
+	if err := k.QueryValidatorExchangeRate(ctx, msg.ChainId, msg.Valoper); err != nil {
+		return nil, err
+	}
+	return &types.MsgUpdateValidatorSharesExchRateResponse{}, nil
 }


### PR DESCRIPTION
## Context and purpose of the change
We now need to store each validator's exchange rate on the host zone struct. We can easily accomplish this for new validators by querying it as soon as they're added.

## Brief Changelog
* Added step to query validator exchange rate after adding validator
* Added query check in unit test