### PR TITLE
Automated version increment [Part 1]

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,43 +15,47 @@ jobs:
     steps:
       - name: Get versions
         run: |
-          echo "old_version=${{ github.event.inputs.old_version }}" >> $GITHUB_ENV
-          echo "new_version=${{ github.event.inputs.new_version }}" >> $GITHUB_ENV
-          echo new_major_version=v$(echo "${{ github.event.inputs.new_version }}" | cut -d '.' -f 1)
-          echo "branch_name=update-stride-version-$new_major_version" >> $GITHUB_ENV
+          old_version=${{ github.event.inputs.old_version }}
+          new_version=${{ github.event.inputs.new_version }}
+          new_major_version=v$(echo $new_version | cut -d '.' -f 1)
+          branch_name=update-stride-version-${new_major_version}
+
+          echo "old_version=$old_version" >> $GITHUB_ENV
+          echo "new_version=$new_version" >> $GITHUB_ENV
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
 
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 
       - name: Create branch
         run: git checkout -b update-stride-version-${{ env.new_major_version }}
 
-      - name: Update versions
+      - name: Update versions in files
         run: |
           OLD_VERSION=${{ env.old_version }} NEW_VERSION=${{ env.new_version }} bash scripts/version.sh
 
-      - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          branch: ${{ env.branch_name }}
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@v0.6.0
+      #   with:
+      #     branch: ${{ env.branch_name }}
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.branch_name }}
-          base: main
-          title: Update Stride Version to ${{ env.new_version }}
-          body: |
-            This is an automatically generated pull request.
-            Please review and merge the changes.
+      # - name: Create Pull Request
+      #   uses: peter-evans/create-pull-request@v3
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     branch: ${{ env.branch_name }}
+      #     base: main
+      #     title: Update Stride Version to ${{ env.new_version }}
+      #     body: |
+      #       This is an automatically generated pull request.
+      #       Please review and merge the changes.
 
-            ## Context
-            Increments Stride version for the ${{ env.new_major_version }} upgrade
+      #       ## Context
+      #       Increments Stride version for the ${{ env.new_major_version }} upgrade
 
-            ## Brief Changelog
-            * Increments Stride version in cmd/strided/config/config.go and app/app.go
-            * Updates module name to ${{ env.new_major_version }}
-            * Re-generates protos
+      #       ## Brief Changelog
+      #       * Increments Stride version in cmd/strided/config/config.go and app/app.go
+      #       * Updates module name to ${{ env.new_major_version }}
+      #       * Re-generates protos

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,26 +36,26 @@ jobs:
         run: |
           OLD_VERSION=${{ env.old_version }} NEW_VERSION=${{ env.new_version }} bash scripts/version.sh
 
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@v0.6.0
-      #   with:
-      #     branch: ${{ env.branch_name }}
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          branch: ${{ env.branch_name }}
 
-      # - name: Create Pull Request
-      #   uses: peter-evans/create-pull-request@v3
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: ${{ env.branch_name }}
-      #     base: main
-      #     title: Update Stride Version to ${{ env.new_version }}
-      #     body: |
-      #       This is an automatically generated pull request.
-      #       Please review and merge the changes.
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.branch_name }}
+          base: main
+          title: Update Stride Version to ${{ env.new_version }}
+          body: |
+            This is an automatically generated pull request.
+            Please review and merge the changes.
 
-      #       ## Context
-      #       Increments Stride version for the ${{ env.new_major_version }} upgrade
+            ## Context
+            Increments Stride version for the ${{ env.new_major_version }} upgrade
 
-      #       ## Brief Changelog
-      #       * Increments Stride version in cmd/strided/config/config.go and app/app.go
-      #       * Updates module name to ${{ env.new_major_version }}
-      #       * Re-generates protos
+            ## Brief Changelog
+            * Increments Stride version in cmd/strided/config/config.go and app/app.go
+            * Updates module name to ${{ env.new_major_version }}
+            * Re-generates protos

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,57 @@
+name: Update Stride Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      old_version:
+        description: "Specify the old version (e.g. 8.0.0)"
+      new_version:
+        description: "Specify the new version (e.g. 9.0.0)"
+
+jobs:
+  increment-stride-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get versions
+        run: |
+          echo "old_version=${{ github.event.inputs.old_version }}" >> $GITHUB_ENV
+          echo "new_version=${{ github.event.inputs.new_version }}" >> $GITHUB_ENV
+          echo new_major_version=v$(echo "${{ github.event.inputs.new_version }}" | cut -d '.' -f 1)
+          echo "branch_name=update-stride-version-$new_major_version" >> $GITHUB_ENV
+
+      - name: Checkout main
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Create branch
+        run: git checkout -b update-stride-version-${{ env.new_major_version }}
+
+      - name: Update versions
+        run: |
+          OLD_VERSION=${{ env.old_version }} NEW_VERSION=${{ env.new_version }} bash scripts/version.sh
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          branch: ${{ env.branch_name }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.branch_name }}
+          base: main
+          title: Update Stride Version to ${{ env.new_version }}
+          body: |
+            This is an automatically generated pull request.
+            Please review and merge the changes.
+
+            ## Context
+            Increments Stride version for the ${{ env.new_major_version }} upgrade
+
+            ## Brief Changelog
+            * Increments Stride version in cmd/strided/config/config.go and app/app.go
+            * Updates module name to ${{ env.new_major_version }}
+            * Re-generates protos

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+VERSION_REGEX='[0-9]{1,2}\.[0-9]{1}\.[0-9]{1}$'
+
+# Validate script parameters
+if [ -z "$OLD_VERSION" ]; then
+    echo "OLD_VERSION must be set (e.g. 8.0.0). Exiting..."
+    exit 1
+fi
+
+if [ -z "$NEW_VERSION" ]; then
+    echo "NEW_VERSION must be set (e.g. 8.0.0). Exiting..."
+    exit 1
+fi
+
+if ! echo $OLD_VERSION | grep -Eq $VERSION_REGEX; then 
+    echo "OLD_VERSION must be of form {major}.{minor}.{patch} (e.g. 8.0.0). Exiting..."
+fi 
+
+if ! echo $NEW_VERSION | grep -Eq $VERSION_REGEX; then 
+    echo "NEW_VERSION must be of form {major}.{minor}.{patch} (e.g. 8.0.0). Exiting..."
+fi 
+
+if [ "$(basename "$PWD")" != "stride" ]; then
+    echo "The script must be run from the project home directory. Exiting..."
+fi
+
+# Update version 
+CONFIG_FILE=cmd/strided/config/config.go
+APP_FILE=app/app.go
+
+sed -i '' "s/$OLD_VERSION/$NEW_VERSION/g" $CONFIG_FILE
+sed -i '' "s/$OLD_VERSION/$NEW_VERSION/g" $APP_FILE
+
+git add $CONFIG_FILE $APP_FILE
+git commit -m "updated version from $OLD_VERSION to $NEW_VERSION"
+
+
+# Update package name
+OLD_MAJOR_VERSION=v$(echo "$OLD_VERSION" | cut -d '.' -f 1)
+NEW_MAJOR_VERSION=v$(echo "$NEW_VERSION" | cut -d '.' -f 1)
+
+for parent_directory in "app" "cmd" "proto" "testutil" "third_party" "utils" "x"; do
+    for file in $(find $parent_directory -type f \( -name "*.go" -o -name "*.proto" \)); do 
+        echo "Updating version in $file"
+        sed -i '' "s|github.com/Stride-Labs/stride/$OLD_MAJOR_VERSION|github.com/Stride-Labs/stride/$NEW_MAJOR_VERSION|g" $file
+    done
+done
+
+sed -i '' "s|github.com/Stride-Labs/stride/$OLD_MAJOR_VERSION|github.com/Stride-Labs/stride/$NEW_MAJOR_VERSION|g" go.mod
+
+git add .
+git commit -m "updated package from $OLD_MAJOR_VERSION -> $NEW_MAJOR_VERSION"
+
+
+# Re-generate protos
+make proto-all
+
+git add .
+git commit -m 'generated protos'
+

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 VERSION_REGEX='[0-9]{1,2}\.[0-9]{1}\.[0-9]{1}$'
 
 # Validate script parameters


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
Each upgrade, we need to increment Stride's version in all the import statements and in different `Version` variables. This process could easily be automated.
This PR introduces a github action that does the sed replacements and opens a new pull request with the changes. The action must be invoked manually.

**Note**: This will have to be merged to main before it can be fully tested since you can't run GH workflows that haven't been merged. Once this is merged, I can continue debugging in a side branch

## Brief Changelog
* Added version.sh script to sed replace the module name, all import paths, and the version references
* Added GH action that:
  * Accepts user input for the version definitions
  * Creates a new branch 
  * Updates the version
  * Commits and pushes the changes 
  * Opens a pull request