### PR TITLE
[LSM] Discard partial state changes with failed FinishLSMLiquidStake

### DIFF
--- a/utils/cache_ctx.go
+++ b/utils/cache_ctx.go
@@ -1,0 +1,84 @@
+package utils
+
+// Borrowed from Osmosis
+// https://github.com/osmosis-labs/osmosis/blob/62757d309957fa9e02e6fb0b5dc8caf1ca68e696/osmoutils/cache_ctx.go
+// Wraps the execution of a function with a temporary context so that state changes can be discarded if an error occurs
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// This function lets you run the function f, but if theres an error or panic
+// drop the state machine change and log the error.
+// If there is no error, proceeds as normal (but with some slowdown due to SDK store weirdness)
+// Try to avoid usage of iterators in f.
+//
+// If its an out of gas panic, this function will also panic like in normal tx execution flow.
+// This is still safe for beginblock / endblock code though, as they do not have out of gas panics.
+func ApplyFuncIfNoError(ctx sdk.Context, f func(ctx sdk.Context) error) (err error) {
+	// Add a panic safeguard
+	defer func() {
+		if recoveryError := recover(); recoveryError != nil {
+			if isErr, _ := IsOutOfGasError(recoveryError); isErr {
+				// We panic with the same error, to replicate the normal tx execution flow.
+				panic(recoveryError)
+			} else {
+				PrintPanicRecoveryError(ctx, recoveryError)
+				err = errors.New("panic occurred during execution")
+			}
+		}
+	}()
+	// makes a new cache context, which all state changes get wrapped inside of.
+	cacheCtx, write := ctx.CacheContext()
+	err = f(cacheCtx)
+	if err != nil {
+		ctx.Logger().Error(err.Error())
+	} else {
+		// no error, write the output of f
+		write()
+		ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
+	}
+	return err
+}
+
+// Frustratingly, this has to return the error descriptor, not an actual error itself
+// because the SDK errors here are not actually errors. (They don't implement error interface)
+func IsOutOfGasError(err any) (bool, string) {
+	switch e := err.(type) {
+	case types.ErrorOutOfGas:
+		return true, e.Descriptor
+	case types.ErrorGasOverflow:
+		return true, e.Descriptor
+	default:
+		return false, ""
+	}
+}
+
+// PrintPanicRecoveryError error logs the recoveryError, along with the stacktrace, if it can be parsed.
+// If not emits them to stdout.
+func PrintPanicRecoveryError(ctx sdk.Context, recoveryError interface{}) {
+	errStackTrace := string(debug.Stack())
+	switch e := recoveryError.(type) {
+	case types.ErrorOutOfGas:
+		ctx.Logger().Debug("out of gas error inside panic recovery block: " + e.Descriptor)
+		return
+	case string:
+		ctx.Logger().Error("Recovering from (string) panic: " + e)
+	case runtime.Error:
+		ctx.Logger().Error("recovered (runtime.Error) panic: " + e.Error())
+	case error:
+		ctx.Logger().Error("recovered (error) panic: " + e.Error())
+	default:
+		ctx.Logger().Error("recovered (default) panic. Could not capture logs in ctx, see stdout")
+		fmt.Println("Recovering from panic ", recoveryError)
+		debug.PrintStack()
+		return
+	}
+	ctx.Logger().Error("stack trace: " + errStackTrace)
+}

--- a/utils/cache_ctx_test.go
+++ b/utils/cache_ctx_test.go
@@ -1,0 +1,59 @@
+package utils_test
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/Stride-Labs/stride/v9/utils"
+)
+
+var expectedOutOfGasError = types.ErrorOutOfGas{Descriptor: "my func"}
+
+func consumeGas(ctx sdk.Context, gas uint64, numTimes int) error {
+	for i := 0; i < numTimes; i++ {
+		ctx.GasMeter().ConsumeGas(gas, "my func")
+	}
+	return nil
+}
+
+func (s *UtilsTestSuite) TestCacheCtxConsumeGas() {
+	// every test case adds 1k gas 10 times
+	testcases := map[string]struct {
+		gasLimit       uint64
+		gasUsedPreCtx  uint64
+		gasUsedPostCtx uint64
+		expectPanic    bool
+	}{
+		"no gas limit hit": {
+			gasLimit:       15_000,
+			gasUsedPreCtx:  111,
+			gasUsedPostCtx: 111 + 10_000,
+			expectPanic:    false,
+		},
+		"gas limit hit": {
+			gasLimit:       10_000,
+			gasUsedPreCtx:  111,
+			gasUsedPostCtx: 111 + 10_000,
+			expectPanic:    true,
+		},
+	}
+	for name, tc := range testcases {
+		s.Run(name, func() {
+			ctx := s.Ctx.WithGasMeter(sdk.NewGasMeter(tc.gasLimit))
+			ctx.GasMeter().ConsumeGas(tc.gasUsedPreCtx, "pre ctx")
+			var err error
+			f := func() {
+				utils.ApplyFuncIfNoError(ctx, func(c sdk.Context) error {
+					return consumeGas(c, 1000, 10)
+				})
+			}
+			if tc.expectPanic {
+				s.PanicsWithValue(expectedOutOfGasError, f)
+			} else {
+				f()
+				s.Require().NoError(err)
+			}
+			s.Equal(tc.gasUsedPostCtx, ctx.GasMeter().GasConsumed())
+		})
+	}
+}

--- a/utils/module_account_test.go
+++ b/utils/module_account_test.go
@@ -1,0 +1,69 @@
+package utils_test
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/Stride-Labs/stride/v9/utils"
+)
+
+func (s *UtilsTestSuite) TestCreateModuleAccount() {
+	baseWithAddr := func(addr sdk.AccAddress) authtypes.AccountI {
+		acc := authtypes.ProtoBaseAccount()
+		acc.SetAddress(addr)
+		return acc
+	}
+	userAccViaSeqnum := func(addr sdk.AccAddress) authtypes.AccountI {
+		base := baseWithAddr(addr)
+		base.SetSequence(2)
+		return base
+	}
+	userAccViaPubkey := func(addr sdk.AccAddress) authtypes.AccountI {
+		base := baseWithAddr(addr)
+		base.SetPubKey(secp256k1.GenPrivKey().PubKey())
+		return base
+	}
+	defaultModuleAccAddr := address.Module("dummy module", []byte{1})
+	testcases := map[string]struct {
+		priorAccounts []authtypes.AccountI
+		moduleAccAddr sdk.AccAddress
+		expErr        bool
+	}{
+		"no prior acc": {
+			priorAccounts: []authtypes.AccountI{},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        false,
+		},
+		"prior empty acc at addr": {
+			priorAccounts: []authtypes.AccountI{baseWithAddr(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        false,
+		},
+		"prior user acc at addr (sequence)": {
+			priorAccounts: []authtypes.AccountI{userAccViaSeqnum(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        true,
+		},
+		"prior user acc at addr (pubkey)": {
+			priorAccounts: []authtypes.AccountI{userAccViaPubkey(defaultModuleAccAddr)},
+			moduleAccAddr: defaultModuleAccAddr,
+			expErr:        true,
+		},
+	}
+	for name, tc := range testcases {
+		s.Run(name, func() {
+			s.SetupTest()
+			for _, priorAcc := range tc.priorAccounts {
+				s.App.AccountKeeper.SetAccount(s.Ctx, priorAcc)
+			}
+			err := utils.CreateModuleAccount(s.Ctx, s.App.AccountKeeper, tc.moduleAccAddr)
+			if tc.expErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,21 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/v9/app/apptesting"
+)
+
+type UtilsTestSuite struct {
+	apptesting.AppTestHelper
+}
+
+func (s *UtilsTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func TestUtilsTestSuite(t *testing.T) {
+	suite.Run(t, new(UtilsTestSuite))
+}

--- a/x/stakeibc/keeper/icqcallbacks_validator_exchange_rate_test.go
+++ b/x/stakeibc/keeper/icqcallbacks_validator_exchange_rate_test.go
@@ -25,6 +25,7 @@ type ValidatorICQCallbackState struct {
 	validator        types.Validator
 	delegator        string
 	lsmTokenIBCDenom string
+	stakerBalance    sdkmath.Int
 }
 
 type ValidatorICQCallbackArgs struct {
@@ -98,13 +99,13 @@ func (s *KeeperTestSuite) SetupValidatorICQCallback(validatorSlashed, liquidStak
 	var err error
 	lsmTokenIBCDenom := ""
 	callbackDataBz := []byte{}
+	stakeAmount := sdkmath.NewInt(1_000_000)
 	if liquidStakeCallback {
 		// Need valid IBC denom here to test parsing
 		lsmTokenIBCDenom = s.getLSMTokenIBCDenom()
 
 		// Fund the user's account with the LSM token
 		liquidStaker := s.TestAccs[0]
-		stakeAmount := sdkmath.NewInt(1_000_000)
 		s.FundAccount(liquidStaker, sdk.NewCoin(lsmTokenIBCDenom, stakeAmount))
 
 		// The callback data consists of the LSMTokenDeposit wrapped in additional state context
@@ -133,6 +134,7 @@ func (s *KeeperTestSuite) SetupValidatorICQCallback(validatorSlashed, liquidStak
 			validator:        queriedValidator,
 			delegator:        delegatorAddress,
 			lsmTokenIBCDenom: lsmTokenIBCDenom,
+			stakerBalance:    stakeAmount,
 		},
 		exchangeRateIfSlashed: exchangeRateIfSlashed,
 		validArgs: ValidatorICQCallbackArgs{
@@ -302,6 +304,53 @@ func (s *KeeperTestSuite) TestValidatorExchangeRateCallback_Successful_NoSlash_L
 
 	// Confirm the liquid stake was a success
 	s.checkLSMLiquidStakeSuccess()
+}
+
+// Test case where the callback was successful and this query was from a liquid stake,
+// but the finishing of the liquid stake failed
+// Any state changes from the finish liquid stake should be discarded, including
+// the transfer of LSM tokens to the deposit account
+func (s *KeeperTestSuite) TestValidatorExchangeRateCallback_Successful_NoSlash_LiquidStakeFailed() {
+	validatorSlashed := false
+	lsmCallback := true
+	tc := s.SetupValidatorICQCallback(validatorSlashed, lsmCallback)
+
+	// Remove the host zone's delegation account - this should cause the finishing of the LSM liquid stake to fail
+	var callbackData types.ValidatorExchangeRateQueryCallback
+	err := proto.Unmarshal(tc.validArgs.query.CallbackData, &callbackData)
+	s.Require().NoError(err, "no error expected when unmarshaling query args")
+
+	callbackData.LsmLiquidStake.HostZone.DelegationIcaAddress = ""
+	invalidCallbackData, err := proto.Marshal(&callbackData)
+	s.Require().NoError(err, "no error expected when marshaling query args")
+
+	invalidQuery := tc.validArgs.query
+	invalidQuery.CallbackData = invalidCallbackData
+
+	// When the callback runs, the finishing of the LSM liquid stake should make partial state changes, including
+	// the sending of LSM tokens to the module account
+	// However, that change should be discarded since the liquid stake failed
+	err = stakeibckeeper.ValidatorExchangeRateCallback(s.App.StakeibcKeeper, s.Ctx, tc.validArgs.callbackArgs, invalidQuery)
+	s.Require().NoError(err, "validator exchange rate callback error")
+
+	// Confirm validator's exchange rate DID NOT update
+	expectedExchangeRate := tc.initialState.validator.InternalSharesToTokensRate
+	s.checkValidatorExchangeRate(expectedExchangeRate, tc)
+
+	// Confirm delegator shares query WAS NOT submitted
+	s.checkDelegatorSharesQueryNotSubmitted()
+
+	// Confirm the liquid stake failed
+	// We'll check both that the failed event was emitted, and the success event was not emitted
+	// (to confirm short circuiting)
+	s.checkLSMLiquidStakeFailed()
+	successEmitted := s.checkLSMLiquidStakeEventEmitted(types.EventTypeLSMLiquidStakeRequest)
+	s.Require().False(successEmitted, "expected to not see a successful LSM liquid stake event")
+
+	// Confirm the tokens were not sent to the module account since the state changes were discarded
+	stakerBalance := s.App.BankKeeper.GetBalance(s.Ctx, s.TestAccs[0], tc.initialState.lsmTokenIBCDenom)
+	s.Require().Equal(tc.initialState.stakerBalance.Int64(), stakerBalance.Amount.Int64(),
+		"staker balance after failed liquid stake")
 }
 
 // Test case where the callback was successful, there was a slash, and this query was from a liquid stake


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
In the event of an asynchronous LSMLiquidStake, the second half of the transaction (`FinishLSMLiquidStake`) is executed in the query callback. In this case, there's the potential that FinishLSMLiquidStake can fail part way through.

If an error is thrown from FinishLSMLiquidStake, there were previously two options: propagate the error or swallow the error:
 * Propagating the error would cause the entire MsgSubmitQueryResponse tx to fail, which would revert all state changes and prevent the Query object from being deleted from the store. 
 * Swallowing the error would allow the state changes to persist (and would remove the Query object from the store), however, this would include unintended partial state changes. For instance, if an error was thrown from FinishLSMLiquidStake after the LSM Tokens were sent to Stride, they would never be sent back to the user.

Fortunately there's a third solution that combines these two! We can call FinsihLSMLiquidStake with a temporary context that gets discarded in the event of an error - reverting state changes in the process. This way, we can swallow the error (allowing the Query object to get deleted), while discarding any of the partial state changes that may have occurred at the start of FinishLSMLiquidStake.

The osmo dev's have already written a helper util function to use this strategy and wrap the function execution with a temporary context. This PR adds their helper function and implements it in the query callback.

## Brief Changelog
* Added `ApplyFuncIfNoError` from osmo
* Wrapped `FinsihLSMLiquidStake` with `ApplyFuncIfNoError` in query callback
* Added unit test to confirm partial state is discarded
* Added unit tests for `ApplyFuncIfNoError` and `module_account.go` (taken from osmo and adapted to our test framework)
  * The module account test is outside of the scope of this PR but should have been added awhile back