### PR TITLE
Fix bug in ICA SendTx

### DIFF
--- a/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -26,8 +26,6 @@ import (
 	icqtypes "github.com/Stride-Labs/stride/v9/x/interchainquery/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	icacontrollerkeeper "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/keeper"
-	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 )
 
@@ -288,16 +286,13 @@ func (k Keeper) SubmitTxs(
 		Data: data,
 	}
 
-	msg := icacontrollertypes.NewMsgSendTx(owner, connectionId, timeoutTimestamp, packetData)
-
-	msgServer := icacontrollerkeeper.NewMsgServerImpl(&k.ICAControllerKeeper)
-
-	res, err := msgServer.SendTx(ctx, msg)
+	// TODO: SendTx is deprecated and MsgServer should used going forward
+	// IMPORTANT: When updating to MsgServer, the timestamp passed to NewMsgSendTx is the relative timeout offset,
+	// not the unix time (e.g. "30 minutes in nanoseconds" instead "current unix nano + 30 minutes in nanoseconds")
+	sequence, err := k.ICAControllerKeeper.SendTx(ctx, nil, connectionId, portID, packetData, timeoutTimestamp) // nolint:staticcheck
 	if err != nil {
 		return 0, err
 	}
-
-	sequence := res.Sequence
 
 	// Store the callback data
 	if callbackId != "" && callbackArgs != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context
### The Problem
With ibc-go v7, the keeper function SendTx was deprecated in favor of the msg_server function...
```go
// from 
k.ICAControllerKeeper.SendTx(...) 

// to
msg := icacontrollertypes.NewMsgSendTx(...)
msgServer.SendTx(ctx, msg)
```
However, whereas the timestamp in the keeper function was an _absolute_ timestamp (i.e. the timeout in unix nano), the timestamp that should be passed into `NewMsgSendTx` is a _relative_ timestamp (i.e. the offset in nano seconds between the current time and the timeout timestamp).

As the code lives on main, the absolute timestamp is being passed into `NewMsgSendTx`, which is causing the end timestamp to be essentially doubled:
```
Current Time: 1000
Desired Timeout: 1010
NewMsgSendTx(1010) → Returns absolute timestamp of 2010
```

### The Solution
There are two solutions here:
  a. Continue to use the new msg server API and adjust all invocations of SubmitTxs to pass the relative timestamp instead of the absolute timestamp
  b. Revert back to the legacy API
Considering option (a) would involve a big refactor, I think it makes sense to move forward with option (b) in the short term.

## Brief Changelog
* Reverted ICA SendTx call to legacy api

