### PR TITLE
Check if binaries exist during dockernet startup

### DIFF
--- a/dockernet/start_network.sh
+++ b/dockernet/start_network.sh
@@ -4,6 +4,18 @@ set -eu
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/config.sh
 
+# Confirm binaries are present
+for chain in STRIDE ${HOST_CHAINS[@]}; do
+    binary_path=$(GET_VAR_VALUE ${chain}_BINARY)
+    binary_path=$(realpath "$binary_path")
+    if [[ ! -e "$binary_path" ]]; then
+        echo "ERROR: Binary for $chain does not exist"
+        echo "It should be present at $binary_path"
+        echo "To build the binary, ensure submodules are updated and pass the host chain flag as a build argument (e.g. 'make start-docker build=g')"
+        exit 1
+    fi
+done
+
 # cleanup any stale state
 make stop-docker
 rm -rf $STATE $LOGS 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
One of the most common issues people have with starting up dockernet is forgetting to build the binary for a host zone. This PR adds a check during the dockernet startup to alert the user if the binary does not exist. 

