### PR TITLE
Aidan/v10 upgrade handler claim param migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ upgrade-build-old-binary:
 	@DOCKERNET_HOME=$(DOCKERNET_HOME) BUILDDIR=$(BUILDDIR) bash $(DOCKERNET_HOME)/upgrades/build_old_binary.sh
 
 submit-upgrade-immediately:
-	UPGRADE_HEIGHT=100 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh
+	UPGRADE_HEIGHT=150 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh
 
 submit-upgrade-after-tests:
 	UPGRADE_HEIGHT=400 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ upgrade-build-old-binary:
 	@DOCKERNET_HOME=$(DOCKERNET_HOME) BUILDDIR=$(BUILDDIR) bash $(DOCKERNET_HOME)/upgrades/build_old_binary.sh
 
 submit-upgrade-immediately:
-	UPGRADE_HEIGHT=150 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh
+	UPGRADE_HEIGHT=100 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh
 
 submit-upgrade-after-tests:
 	UPGRADE_HEIGHT=400 bash $(DOCKERNET_HOME)/upgrades/submit_upgrade.sh

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -124,6 +124,7 @@ func (app *StrideApp) setupUpgradeHandlers() {
 			app.IcacallbacksKeeper,
 			app.MintKeeper,
 			app.ParamsKeeper,
+			app.ClaimKeeper,
 		),
 	)
 

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -44,6 +44,7 @@ var (
 	CommunityPoolGrowthProportion         = "0.2158"
 	StrategicReserveProportion            = "0.4879"
 	CommunityPoolSecurityBudgetProportion = "0.1358"
+	StrdDenom                             = "ustrd"
 
 	MinInitialDepositRatio = "0.25"
 	// airdrop distributor addresses
@@ -214,8 +215,9 @@ func MigrateCallbackData(ctx sdk.Context, k icacallbackskeeper.Keeper) error {
 }
 
 // Migrate the claim distributor address, change nothing else about the airdrop params
-func MigrateClaimDistributorAddress(ctx sdk.Context, k claimkeeper.Keeper) error {
-	claimParams, err := k.GetParams(ctx)
+func MigrateClaimDistributorAddress(ctx sdk.Context, ck claimkeeper.Keeper) error {
+	// Migrate claim params
+	claimParams, err := ck.GetParams(ctx)
 	if err != nil {
 		return errorsmod.Wrapf(err, "unable to get claim parameters")
 	}
@@ -226,7 +228,7 @@ func MigrateClaimDistributorAddress(ctx sdk.Context, k claimkeeper.Keeper) error
 		updatedAirdrops = append(updatedAirdrops, airdrop)
 	}
 	claimParams.Airdrops = updatedAirdrops
-	return k.SetParams(ctx, claimParams)
+	return ck.SetParams(ctx, claimParams)
 }
 
 // Helper function to deserialize using the deprecated proto types and reserialize using the new proto types

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -156,15 +156,15 @@ func CreateUpgradeHandler(
 			return nil, errorsmod.Wrapf(err, "unable to MigrateClaimDistributorAddress")
 		}
 
-		ctx.Logger().Info("Executing Prop #205...")
-		if err := ExecuteProp205(ctx, bankKeeper); err != nil {
-			return nil, errorsmod.Wrapf(err, "unable to submit transfer for Prop #205")
-		}
+		// ctx.Logger().Info("Executing Prop #205...")
+		// if err := ExecuteProp205(ctx, bankKeeper); err != nil {
+		// 	return nil, errorsmod.Wrapf(err, "unable to submit transfer for Prop #205")
+		// }
 
-		ctx.Logger().Info("Enabling rate limits...")
-		if err := EnableRateLimits(ctx, ratelimitKeeper, channelKeeper, stakeibcKeeper); err != nil {
-			return nil, errorsmod.Wrapf(err, "unable to enable rate limits")
-		}
+		// ctx.Logger().Info("Enabling rate limits...")
+		// if err := EnableRateLimits(ctx, ratelimitKeeper, channelKeeper, stakeibcKeeper); err != nil {
+		// 	return nil, errorsmod.Wrapf(err, "unable to enable rate limits")
+		// }
 
 		ctx.Logger().Info("v10 Upgrade Complete")
 		return vm, err

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -156,15 +156,15 @@ func CreateUpgradeHandler(
 			return nil, errorsmod.Wrapf(err, "unable to MigrateClaimDistributorAddress")
 		}
 
-		// ctx.Logger().Info("Executing Prop #205...")
-		// if err := ExecuteProp205(ctx, bankKeeper); err != nil {
-		// 	return nil, errorsmod.Wrapf(err, "unable to submit transfer for Prop #205")
-		// }
+		ctx.Logger().Info("Executing Prop #205...")
+		if err := ExecuteProp205(ctx, bankKeeper); err != nil {
+			return nil, errorsmod.Wrapf(err, "unable to submit transfer for Prop #205")
+		}
 
-		// ctx.Logger().Info("Enabling rate limits...")
-		// if err := EnableRateLimits(ctx, ratelimitKeeper, channelKeeper, stakeibcKeeper); err != nil {
-		// 	return nil, errorsmod.Wrapf(err, "unable to enable rate limits")
-		// }
+		ctx.Logger().Info("Enabling rate limits...")
+		if err := EnableRateLimits(ctx, ratelimitKeeper, channelKeeper, stakeibcKeeper); err != nil {
+			return nil, errorsmod.Wrapf(err, "unable to enable rate limits")
+		}
 
 		ctx.Logger().Info("v10 Upgrade Complete")
 		return vm, err

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -225,7 +225,8 @@ func MigrateClaimDistributorAddress(ctx sdk.Context, k claimkeeper.Keeper) error
 		airdrop.DistributorAddress = NewDistributorAddresses[airdrop.AirdropIdentifier]
 		updatedAirdrops = append(updatedAirdrops, airdrop)
 	}
-	return nil
+	claimParams.Airdrops = updatedAirdrops
+	return k.SetParams(ctx, claimParams)
 }
 
 // Helper function to deserialize using the deprecated proto types and reserialize using the new proto types

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -56,12 +56,12 @@ var (
 		"evmos":   "stride10dy5pmc2fq7fnmufjfschkfrxaqnpykl6ezy5j",
 	}
 	NewDistributorAddresses = map[string]string{
-		"stride":  "stride1cpvl8yf848karqauyhr5jzw6d9n9lnuuu974ev",
-		"gaia":    "stride1fmh0ysk5nt9y2cj8hddms5ffj2dhys55xkkjwz",
-		"osmosis": "stride1zlu2l3lx5tqvzspvjwsw9u0e907kelhqae3yhk",
-		"juno":    "stride14k9g9zpgaycpey9840nnpa66l4nd6lu7g7t74c",
-		"stars":   "stride12pum4adk5dhp32d90f8g8gfwujm0gwxqnrdlum",
-		"evmos":   "stride10dy5pmc2fq7fnmufjfschkfrxaqnpykl6ezy5j",
+		"stride":  "stride1w02dg74j8s38gqn6mvlr87hkvyv5rgp3cqe9se",
+		"gaia":    "stride1w0w0gr6u796y2mjl9fuqt66jqvk3j59jq3jtpg",
+		"osmosis": "stride1mfg5ck02tlyzdtdpaj70ngtgjs2vuawtkfz7xd",
+		"juno":    "stride1ral4dsqk0nzyqlwtuyxgavfvx8hegml7u0rzx3",
+		"stars":   "stride1rm9nxc5pw3k5r5s6lm85k73mfp734nhnxq570g",
+		"evmos":   "stride1ej4e7x2hanmy6vrzrjh06g6dnfq5kxm73dmgsw",
 	}
 )
 
@@ -78,7 +78,7 @@ func CreateUpgradeHandler(
 	icacallbacksKeeper icacallbackskeeper.Keeper,
 	mintKeeper mintkeeper.Keeper,
 	paramsKeeper paramskeeper.Keeper,
-	claimKeeper claimKeeper.Keeper,
+	claimKeeper claimkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v10...")

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -49,7 +49,6 @@ var (
 	CommunityPoolGrowthProportion         = "0.2158"
 	StrategicReserveProportion            = "0.4879"
 	CommunityPoolSecurityBudgetProportion = "0.1358"
-	StrdDenom                             = "ustrd"
 
 	CommunityPoolGrowthAddress = "stride1lj0m72d70qerts9ksrsphy9nmsd4h0s88ll9gfphmhemh8ewet5qj44jc9"
 	BadKidsCustodian           = "stride17z6yy8vfgklgej9m848jm7rkp270gd9pgaw8zu"

--- a/app/upgrades/v10/upgrades_test.go
+++ b/app/upgrades/v10/upgrades_test.go
@@ -3,6 +3,7 @@ package v10_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
@@ -21,6 +22,8 @@ import (
 
 	cosmosproto "github.com/cosmos/gogoproto/proto"
 	deprecatedproto "github.com/golang/protobuf/proto" //nolint:staticcheck
+
+	claimtypes "github.com/Stride-Labs/stride/v9/x/claim/types"
 )
 
 type UpgradeTestSuite struct {
@@ -202,4 +205,96 @@ func (s *UpgradeTestSuite) TestMigrateCallbackData() {
 			s.Require().Equal(initialTransferCallbackArgs, finalCallbackArgs, "transfer callback")
 		}
 	}
+}
+
+func (s *UpgradeTestSuite) TestMigrateDistributorAddress() {
+	ck := s.App.ClaimKeeper
+
+	// Airdrops
+	strideAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "stride",
+		AirdropStartTime:   time.Date(2022, 11, 22, 14, 53, 52, 0, time.UTC),
+		AutopilotEnabled:   false,
+		ChainId:            "stride-1",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(4143585840),
+		DistributorAddress: "stride1cpvl8yf848karqauyhr5jzw6d9n9lnuuu974ev",
+	}
+
+	gaiaAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "gaia",
+		AirdropStartTime:   time.Date(2022, 11, 22, 14, 53, 52, 0, time.UTC),
+		AutopilotEnabled:   false,
+		ChainId:            "cosmoshub-4",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(191138794312),
+		DistributorAddress: "stride1fmh0ysk5nt9y2cj8hddms5ffj2dhys55xkkjwz",
+	}
+
+	osmosisAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "osmosis",
+		AirdropStartTime:   time.Date(2022, 11, 22, 14, 53, 52, 0, time.UTC),
+		AutopilotEnabled:   false,
+		ChainId:            "osmosis-1",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(72895369704),
+		DistributorAddress: "stride1zlu2l3lx5tqvzspvjwsw9u0e907kelhqae3yhk",
+	}
+
+	junoAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "juno",
+		AirdropStartTime:   time.Date(2022, 11, 22, 14, 53, 52, 0, time.UTC),
+		AutopilotEnabled:   false,
+		ChainId:            "juno-1",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(10967183382),
+		DistributorAddress: "stride14k9g9zpgaycpey9840nnpa66l4nd6lu7g7t74c",
+	}
+
+	starsAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "stars",
+		AirdropStartTime:   time.Date(2022, 11, 22, 14, 53, 52, 0, time.UTC),
+		AutopilotEnabled:   false,
+		ChainId:            "stargaze-1",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(1013798205),
+		DistributorAddress: "stride12pum4adk5dhp32d90f8g8gfwujm0gwxqnrdlum",
+	}
+
+	evmosAirdrop := claimtypes.Airdrop{
+		AirdropIdentifier:  "evmos",
+		AirdropStartTime:   time.Date(2023, 4, 3, 16, 0, 0, 0, time.UTC),
+		AutopilotEnabled:   true,
+		ChainId:            "evmos_9001-2",
+		ClaimDenom:         "ustrd",
+		ClaimedSoFar:       sdk.NewInt(13491005333),
+		DistributorAddress: "stride10dy5pmc2fq7fnmufjfschkfrxaqnpykl6ezy5j",
+	}
+
+	claimParams, err := ck.GetParams(s.Ctx)
+	s.Require().NoError(err, "no error expected when getting claim params")
+
+	// Set the airdrops on the claim params
+	claimParams.Airdrops = []*claimtypes.Airdrop{&strideAirdrop, &gaiaAirdrop, &osmosisAirdrop, &junoAirdrop, &starsAirdrop, &evmosAirdrop}
+	err = ck.SetParams(s.Ctx, claimParams)
+	s.Require().NoError(err, "no error expected when setting claim params")
+
+	// Migrate the airdrop distributor addresses
+	err = v10.MigrateClaimDistributorAddress(s.Ctx, ck)
+	s.Require().NoError(err, "no error expected when migrating distributor addresses")
+
+	// Iterate allAirdrops and make sure the updated airdrops are equivalent, except for the distributor address
+	for _, airdrop := range claimParams.Airdrops {
+		airdropToCompare := ck.GetAirdropByIdentifier(s.Ctx, airdrop.AirdropIdentifier)
+		s.Require().Equal(airdropToCompare.AirdropIdentifier, airdrop.AirdropIdentifier, "airdrop identifier")
+		s.Require().Equal(airdropToCompare.AirdropStartTime, airdrop.AirdropStartTime, "airdrop start time")
+		s.Require().Equal(airdropToCompare.AutopilotEnabled, airdrop.AutopilotEnabled, "airdrop autopilot enabled")
+		s.Require().Equal(airdropToCompare.ChainId, airdrop.ChainId, "airdrop chain id")
+		s.Require().Equal(airdropToCompare.ClaimDenom, airdrop.ClaimDenom, "airdrop claim denom")
+		s.Require().Equal(airdropToCompare.ClaimedSoFar, airdrop.ClaimedSoFar, "airdrop claimed so far")
+
+		newDistributorAddress := v10.NewDistributorAddresses[airdrop.AirdropIdentifier]
+		s.Require().Equal(newDistributorAddress, airdropToCompare.DistributorAddress, "airdrop distributor address updated")
+	}
+
 }

--- a/app/upgrades/v10/upgrades_test.go
+++ b/app/upgrades/v10/upgrades_test.go
@@ -319,12 +319,12 @@ func (s *UpgradeTestSuite) TestMigrateDistributorAddress() {
 	// Iterate allAirdrops and make sure the updated airdrops are equivalent, except for the distributor address
 	for _, airdrop := range claimParams.Airdrops {
 		airdropToCompare := ck.GetAirdropByIdentifier(s.Ctx, airdrop.AirdropIdentifier)
-		s.Require().Equal(airdropToCompare.AirdropIdentifier, airdrop.AirdropIdentifier, "airdrop identifier")
-		s.Require().Equal(airdropToCompare.AirdropStartTime, airdrop.AirdropStartTime, "airdrop start time")
-		s.Require().Equal(airdropToCompare.AutopilotEnabled, airdrop.AutopilotEnabled, "airdrop autopilot enabled")
-		s.Require().Equal(airdropToCompare.ChainId, airdrop.ChainId, "airdrop chain id")
-		s.Require().Equal(airdropToCompare.ClaimDenom, airdrop.ClaimDenom, "airdrop claim denom")
-		s.Require().Equal(airdropToCompare.ClaimedSoFar, airdrop.ClaimedSoFar, "airdrop claimed so far")
+		s.Require().Equal(airdrop.AirdropIdentifier, airdropToCompare.AirdropIdentifier, "airdrop identifier")
+		s.Require().Equal(airdrop.AirdropStartTime, airdropToCompare.AirdropStartTime, "airdrop start time")
+		s.Require().Equal(airdrop.AutopilotEnabled, airdropToCompare.AutopilotEnabled, "airdrop autopilot enabled")
+		s.Require().Equal(airdrop.ChainId, airdropToCompare.ChainId, "airdrop chain id")
+		s.Require().Equal(airdrop.ClaimDenom, airdropToCompare.ClaimDenom, "airdrop claim denom")
+		s.Require().Equal(airdrop.ClaimedSoFar, airdropToCompare.ClaimedSoFar, "airdrop claimed so far")
 
 		newDistributorAddress := v10.NewDistributorAddresses[airdrop.AirdropIdentifier]
 		s.Require().Equal(newDistributorAddress, airdropToCompare.DistributorAddress, "airdrop distributor address updated")

--- a/dockernet/scripts/airdrop/airdrop1_standard.sh
+++ b/dockernet/scripts/airdrop/airdrop1_standard.sh
@@ -54,11 +54,6 @@ sleep 5
 echo -e "\nBalance after claim [1000120000ustrd expected]:" 
 $STRIDE_MAIN_CMD query bank balances stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr --denom ustrd
 
-# bank send to the new gaia address before the upgrade
-$STRIDE_MAIN_CMD tx bank send stride1z835j3j65nqr6ng257q0xkkc9gta72gf48txwl stride1w0w0gr6u796y2mjl9fuqt66jqvk3j59jq3jtpg 480000ustrd --from distributor-test -y | TRIM_TX
-WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
-sleep 15
-
 # Stake, to claim another 20%
 echo -e "\nStaking..."
 $STRIDE_MAIN_CMD tx staking delegate stridevaloper1nnurja9zt97huqvsfuartetyjx63tc5zrj5x9f 100ustrd --from airdrop-test --gas 400000 -y | TRIM_TX

--- a/dockernet/scripts/airdrop/airdrop1_standard.sh
+++ b/dockernet/scripts/airdrop/airdrop1_standard.sh
@@ -54,6 +54,8 @@ sleep 5
 echo -e "\nBalance after claim [1000120000ustrd expected]:" 
 $STRIDE_MAIN_CMD query bank balances stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr --denom ustrd
 
+# bank send to the new gaia address before the upgrade
+$STRIDE_MAIN_CMD tx bank send stride1z835j3j65nqr6ng257q0xkkc9gta72gf48txwl stride1w0w0gr6u796y2mjl9fuqt66jqvk3j59jq3jtpg 480000ustrd --from distributor-test -y | TRIM_TX
 WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
 sleep 15
 

--- a/dockernet/scripts/airdrop/airdrop1_standard.sh
+++ b/dockernet/scripts/airdrop/airdrop1_standard.sh
@@ -55,6 +55,7 @@ echo -e "\nBalance after claim [1000120000ustrd expected]:"
 $STRIDE_MAIN_CMD query bank balances stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr --denom ustrd
 
 WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
+sleep 15
 
 # Stake, to claim another 20%
 echo -e "\nStaking..."

--- a/dockernet/scripts/airdrop/airdrop1_standard.sh
+++ b/dockernet/scripts/airdrop/airdrop1_standard.sh
@@ -42,6 +42,8 @@ sleep 5
 $STRIDE_MAIN_CMD tx claim set-airdrop-allocations gaia stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr 1 --from distributor-test -y | TRIM_TX
 sleep 5
 
+WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
+
 # AIRDROP CLAIMS
 # Check balances before claims
 echo -e "\nInitial balance before claim [1000000000ustrd expected]:"
@@ -65,3 +67,4 @@ $STRIDE_MAIN_CMD tx stakeibc liquid-stake 1000 uatom --from airdrop-test --gas 4
 sleep 5
 echo -e "\nBalance after liquid stake [1000599900ustrd expected]:" 
 $STRIDE_MAIN_CMD query bank balances stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr --denom ustrd
+

--- a/dockernet/scripts/airdrop/airdrop1_standard.sh
+++ b/dockernet/scripts/airdrop/airdrop1_standard.sh
@@ -42,8 +42,6 @@ sleep 5
 $STRIDE_MAIN_CMD tx claim set-airdrop-allocations gaia stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr 1 --from distributor-test -y | TRIM_TX
 sleep 5
 
-WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
-
 # AIRDROP CLAIMS
 # Check balances before claims
 echo -e "\nInitial balance before claim [1000000000ustrd expected]:"
@@ -55,6 +53,9 @@ $STRIDE_MAIN_CMD tx claim claim-free-amount --from airdrop-test --gas 400000 -y 
 sleep 5
 echo -e "\nBalance after claim [1000120000ustrd expected]:" 
 $STRIDE_MAIN_CMD query bank balances stride1nf6v2paty9m22l3ecm7dpakq2c92ueyununayr --denom ustrd
+
+WAIT_FOR_STRING $STRIDE_LOGS "v10 Upgrade Complete"
+
 # Stake, to claim another 20%
 echo -e "\nStaking..."
 $STRIDE_MAIN_CMD tx staking delegate stridevaloper1nnurja9zt97huqvsfuartetyjx63tc5zrj5x9f 100ustrd --from airdrop-test --gas 400000 -y | TRIM_TX


### PR DESCRIPTION
**Summary**
As a safety precaution, migrate claim distributor addresses to a more secure key setup.

**Test plan**
* Unittests 
* Integration tests

For integration tests, I tested the following cases 
* on commit `bdb7a1`
    * setup airdrop
    * upgrade
    * claim
```
Initial balance before claim [1000000000ustrd expected]:
amount: "1000000000"
denom: ustrd

Claiming free amount...
  code: 0
  txhash: DC2A7A05EA95D4731B1E1D71F3E6515653BE1E3ABEB289AADC9C570785DA9CE5

Balance after claim [1000120000ustrd expected]:
amount: "1000120000"
denom: ustrd

Staking...
  code: 0
  txhash: D55B72B659403D26EB6E63A4314AB84D3C2C028B897812F793B5DBFFA8FE11AD

Balance after stake [1000239900ustrd expected]:
amount: "1000239900"
denom: ustrd

Liquid staking...
  code: 0
  txhash: 942E2F298916BB8287A699272995819A3F440A6DD3C5C741E51D47E774533277

Balance after liquid stake [1000599900ustrd expected]:
amount: "1000599900"
denom: ustrd
```


* on commit `1553d4`
    * setup airdrop
    * partially claim from an account
    * upgrade
    * claim the rest from an account
```
Staking...
  code: 0
  txhash: D55B72B659403D26EB6E63A4314AB84D3C2C028B897812F793B5DBFFA8FE11AD

Balance after stake [1000239900ustrd expected]:
amount: "1000239900"
denom: ustrd

Liquid staking...
  code: 0
  txhash: 942E2F298916BB8287A699272995819A3F440A6DD3C5C741E51D47E774533277

Balance after liquid stake [1000599900ustrd expected]:
amount: "1000599900"
denom: ustrd
```

