### PR TITLE
Deconflict version command (version -> ver)

### DIFF
--- a/cmd/strided/root.go
+++ b/cmd/strided/root.go
@@ -265,7 +265,7 @@ func txCommand() *cobra.Command {
 
 func versionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "version",
+		Use:     "ver",
 		Aliases: []string{"v"},
 		Short:   "Print the Stride version info",
 		Args:    cobra.ExactArgs(0),


### PR DESCRIPTION
## Context and purpose of the change

version --long no longer displays package information important for debugging chain issues


## Brief Changelog

Renamed "version" command to "ver" to allow the existing "version --long" command to work

## Author's Checklist

I have...

- [ ] Run and PASSED locally all GAIA integration tests
- [ ] If the change is contentful, I either:
    - [ ] Added a new unit test OR 
    - [ ] Added test cases to existing unit tests
- [X] OR this change is a trivial rework / code cleanup without any test coverage

If skipped any of the tests above, explain.


works in stride v10.0.0

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [ ] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
