### PR TITLE
Added long version to version command

### DIFF
--- a/cmd/strided/root.go
+++ b/cmd/strided/root.go
@@ -1,17 +1,21 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/snapshots"
+	"gopkg.in/yaml.v2"
 
 	"github.com/Stride-Labs/stride/v10/utils"
 
 	cometbftdb "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/cli"
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/spf13/cast"
@@ -47,6 +51,8 @@ import (
 )
 
 var ChainID string
+
+var flagLong = "long"
 
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
@@ -270,11 +276,38 @@ func versionCommand() *cobra.Command {
 		Short:   "Print the Stride version info",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("version:", version.Version)
-			fmt.Println("commit:", version.Commit)
+			long, _ := cmd.Flags().GetBool(flagLong)
+			output, _ := cmd.Flags().GetString(cli.OutputFlag)
+
+			if !long {
+				fmt.Println("version:", version.Version)
+				fmt.Println("commit:", version.Commit)
+				return nil
+			}
+
+			verInfo := version.NewInfo()
+			var bz []byte
+			var err error
+
+			switch strings.ToLower(output) {
+			case "json":
+				bz, err = json.Marshal(verInfo)
+
+			default:
+				bz, err = yaml.Marshal(&verInfo)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			cmd.Println(string(bz))
 			return nil
 		},
 	}
+
+	cmd.Flags().Bool(flagLong, false, "Print long version information")
+	cmd.Flags().StringP(cli.OutputFlag, "o", "text", "Output format (text|json)")
 
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
version --long no longer displays package information important for debugging chain issues


## Brief Changelog
Added `--long` option to version command

## Testing
```bash
>>> strided version
version: v10.0.0-1-g6719a44b
commit: 6719a44bc2366f675a96d4df3c82a73ab475c314


>>> strided version --long
name: stride
server_name: strided
version: v10.0.0-1-g6719a44b
commit: 6719a44bc2366f675a96d4df3c82a73ab475c314
build_tags: netgo,ledger
go: go version go1.20.3 darwin/arm64
build_deps:
- cloud.google.com/go/compute/metadata@v0.2.3
...
- sigs.k8s.io/yaml@v1.3.0
cosmos_sdk_version: v0.47.3


>>> strided version --long -o json
{
    "name": "stride",
    "server_name": "strided",
    "version": "v10.0.0-1-g6719a44b",
    "commit": "6719a44bc2366f675a96d4df3c82a73ab475c314",
    "build_tags": "netgo,ledger",
    "go": "go version go1.20.3 darwin/arm64",
    "build_deps": [
        "cloud.google.com/go@v0.110.0",
          ...
        "sigs.k8s.io/yaml@v1.3.0"
    ],
    "cosmos_sdk_version": "v0.47.3"
}
```
