### PR TITLE
[LSM] Red team small issues

### DIFF
--- a/x/stakeibc/keeper/host_zone.go
+++ b/x/stakeibc/keeper/host_zone.go
@@ -280,9 +280,7 @@ func (k Keeper) RemoveValidatorFromHostZone(ctx sdk.Context, chainId string, val
 	lsmTokenDeposits := k.RecordsKeeper.GetAllLSMTokenDeposit(ctx)
 	for _, lsmTokenDeposit := range lsmTokenDeposits {
 		if lsmTokenDeposit.ValidatorAddress == validatorAddress {
-			errMsg := fmt.Sprintf("Validator (%s) still has an LSMTokenDeposit (%v)", validatorAddress, lsmTokenDeposit)
-			k.Logger(ctx).Error(errMsg)
-			return errors.New(errMsg)
+			return errorsmod.Wrapf(types.ErrUnableToRemoveValidator, "Validator (%s) still has an LSMTokenDeposit (%+v)", validatorAddress, lsmTokenDeposit)
 		}
 	}
 

--- a/x/stakeibc/keeper/host_zone.go
+++ b/x/stakeibc/keeper/host_zone.go
@@ -280,7 +280,7 @@ func (k Keeper) RemoveValidatorFromHostZone(ctx sdk.Context, chainId string, val
 	lsmTokenDeposits := k.RecordsKeeper.GetAllLSMTokenDeposit(ctx)
 	for _, lsmTokenDeposit := range lsmTokenDeposits {
 		if lsmTokenDeposit.ValidatorAddress == validatorAddress {
-			return errorsmod.Wrapf(types.ErrUnableToRemoveValidator, "Validator (%s) still has an LSMTokenDeposit (%+v)", validatorAddress, lsmTokenDeposit)
+			return errorsmod.Wrapf(types.ErrUnableToRemoveValidator, "Validator (%s) still has at least one LSMTokenDeposit (%+v)", validatorAddress, lsmTokenDeposit)
 		}
 	}
 

--- a/x/stakeibc/keeper/icqcallbacks_delegator_shares.go
+++ b/x/stakeibc/keeper/icqcallbacks_delegator_shares.go
@@ -212,6 +212,12 @@ func (k Keeper) SlashValidatorOnHostZone(ctx sdk.Context, hostZone types.HostZon
 	chainId := hostZone.ChainId
 	validator := hostZone.Validators[valIndex]
 
+	// In theory, it should be hard to reach a call to this function if validator.Delegation is ever 0
+	// Throw an explicit panic if this unexpected event ever happens to avoid a division by zero error
+	if validator.Delegation.IsZero() {
+		panic(fmt.Sprintf("Error: Delegation on this validator can never be 0 inside SlashValidatorOnHostZone(), %v", validator))
+	}
+
 	// Get slash percentage
 	slashAmount := validator.Delegation.Sub(delegatedTokens)
 	slashPct := sdk.NewDecFromInt(slashAmount).Quo(sdk.NewDecFromInt(validator.Delegation))

--- a/x/stakeibc/keeper/icqcallbacks_delegator_shares.go
+++ b/x/stakeibc/keeper/icqcallbacks_delegator_shares.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
 	sdkmath "cosmossdk.io/math"
@@ -215,7 +216,8 @@ func (k Keeper) SlashValidatorOnHostZone(ctx sdk.Context, hostZone types.HostZon
 	// In theory, it should be hard to reach a call to this function if validator.Delegation is ever 0
 	// Throw an explicit panic if this unexpected event ever happens to avoid a division by zero error
 	if validator.Delegation.IsZero() {
-		panic(fmt.Sprintf("Error: Delegation on this validator can never be 0 inside SlashValidatorOnHostZone(), %v", validator))
+		errMsg := fmt.Sprintf("Error: Delegation on this validator can never be 0 inside SlashValidatorOnHostZone(), %v", validator)
+		return errors.New(errMsg)
 	}
 
 	// Get slash percentage

--- a/x/stakeibc/keeper/lsm.go
+++ b/x/stakeibc/keeper/lsm.go
@@ -306,6 +306,7 @@ func (k Keeper) DetokenizeAllLSMDeposits(ctx sdk.Context) {
 		delegationICAPortID, err := icatypes.NewControllerPortID(delegationICAOwner)
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to get delegation port ID for %s: %s", hostZone.ChainId, err))
+			continue
 		}
 
 		// If the delegation channel is not open, skip this host zone

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -38,6 +38,14 @@ type ValidatorUnbondCapacity struct {
 // The smaller number means their current delegation is much larger
 // then their fair portion of the current total stake
 func (c *ValidatorUnbondCapacity) GetBalanceRatio() sdk.Dec {
+	// ValidatorUnbondCapaciy structs only exist for validators with positive capacity
+	//   capacity is CurrentDelegation - BalancedDelegation
+	//   positive capacity means CurrentDelegation must be >0
+	// Therefore this code should only be reachable when CurrentDelegation is >0
+	// Throw an explicit panic if this unexpected event ever happens
+	if c.CurrentDelegation.IsZero() {
+		panic(fmt.Sprintf("Error: CurrentDelegation can never be 0 inside GetBalanceRatio(), %v", c))
+	}
 	return sdk.NewDecFromInt(c.BalancedDelegation).Quo(sdk.NewDecFromInt(c.CurrentDelegation))
 }
 

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -43,7 +43,7 @@ func (c *ValidatorUnbondCapacity) GetBalanceRatio() (sdk.Dec, error) {
 	//   capacity is CurrentDelegation - BalancedDelegation
 	//   positive capacity means CurrentDelegation must be >0
 
-	// Therefore the current delegation gere should never be zero
+	// Therefore the current delegation here should never be zero
 	if c.CurrentDelegation.IsZero() {
 		errMsg := fmt.Sprintf("CurrentDelegation should not be 0 inside GetBalanceRatio(), %+v", c)
 		return sdk.ZeroDec(), errors.New(errMsg)

--- a/x/stakeibc/keeper/unbonding_records_get_host_zone_unbondings_msgs_test.go
+++ b/x/stakeibc/keeper/unbonding_records_get_host_zone_unbondings_msgs_test.go
@@ -434,16 +434,15 @@ func (s *KeeperTestSuite) TestGetBalanceRatio() {
 				BalancedDelegation: sdkmath.NewInt(100),
 				CurrentDelegation:  sdkmath.NewInt(0),
 			},
-			expectedRatio: sdk.MustNewDecFromStr("0.0"),
 			errorExpected: true,			
 		},		
 	}
 	for _, tc := range testCases {
 		balanceRatio, err := tc.unbondCapacity.GetBalanceRatio()
-		if err != nil {
-			s.Require().True(tc.errorExpected)
+		if tc.errorExpected {
+			s.Require().Error(err)
 		} else {
-			s.Require().False(tc.errorExpected)
+			s.Require().NoError(err)
 			s.Require().Equal(tc.expectedRatio.String(), balanceRatio.String())
 		}
 	}
@@ -699,8 +698,8 @@ func (s *KeeperTestSuite) TestSortUnbondingCapacityByPriority() {
 	}
 
 	// Sort the list
-	actualSortedCapacities, sortErr := keeper.SortUnbondingCapacityByPriority(inputCapacities)
-	s.Require().True(sortErr == nil)
+	actualSortedCapacities, err := keeper.SortUnbondingCapacityByPriority(inputCapacities)
+	s.Require().NoError(err)
 	s.Require().Len(actualSortedCapacities, len(expectedSortedCapacities), "number of capacities")
 
 	// To make the error easier to understand, we first compare just the list of validator addresses

--- a/x/stakeibc/types/errors.go
+++ b/x/stakeibc/types/errors.go
@@ -52,4 +52,5 @@ var (
 	ErrValidatorWasSlashed               = errorsmod.Register(ModuleName, 1545, "Validator was slash")
 	ErrInvalidValidatorDelegationUpdates = errorsmod.Register(ModuleName, 1546, "Invalid validator delegation updates")
 	ErrLSMLiquidStakeDisabledForHostZone = errorsmod.Register(ModuleName, 1547, "LSM liquid stake is disabled for host zone")
+	ErrUnableToRemoveValidator           = errorsmod.Register(ModuleName, 1548, "Unable to remove validator")
 )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This PR addresses several informational level issues surfaced by the redteam

## Brief Changelog

  -  Added check for zero division with panic message to GetBalanceRatio (issue 3)  
  -  Added check for zero division with panic message to SlashValidatorOnHostZone (issue 4)
  -  Added check for LSMTokenDeposits associated with ValidatorAddress before deleting Validators (issue 5)
  -  Added continue statement in error case of DetokenizeAllLSMDeposits (issue 9)

Issue 1 is already fixed in a branch which will be merged to lsm shortly
Issues 6, 10, and 11 require no code change.
We will address issues 7 and 8 in a more general PR about the cache context for end blockers.

The last remaining issue is 2 which requires further investigation and discussion.

