### PR TITLE
Cache context in hooks and end blocker 

### DIFF
--- a/x/stakeibc/keeper/deposit_records.go
+++ b/x/stakeibc/keeper/deposit_records.go
@@ -155,7 +155,9 @@ func (k Keeper) StakeExistingDepositsOnHostZones(ctx sdk.Context, epochNumber ui
 		k.Logger(ctx).Info(utils.LogWithHostZone(depositRecord.HostZoneId, "Staking %v%s", depositRecord.Amount, hostZone.HostDenom))
 		stakeAmount := sdk.NewCoin(hostZone.HostDenom, depositRecord.Amount)
 
-		err := k.DelegateOnHost(ctx, hostZone, stakeAmount, depositRecord)
+		err := utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			return k.DelegateOnHost(ctx, hostZone, stakeAmount, depositRecord)
+		})
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Did not stake %s on %s | err: %s", stakeAmount.String(), hostZone.ChainId, err.Error()))
 			continue

--- a/x/stakeibc/keeper/deposit_records.go
+++ b/x/stakeibc/keeper/deposit_records.go
@@ -94,7 +94,9 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 		k.Logger(ctx).Info(utils.LogWithHostZone(depositRecord.HostZoneId, "Transfer Msg: %+v", msg))
 
 		// transfer the deposit record and update its status to TRANSFER_IN_PROGRESS
-		err := k.RecordsKeeper.IBCTransferNativeTokens(ctx, msg, depositRecord)
+		err := utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			return k.RecordsKeeper.IBCTransferNativeTokens(ctx, msg, depositRecord)
+		})
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("[TransferExistingDepositsToHostZones] Failed to initiate IBC transfer to host zone, HostZone: %v, Channel: %v, Amount: %v, ModuleAddress: %v, DelegateAddress: %v, Timeout: %v",
 				hostZone.ChainId, hostZone.TransferChannelId, transferCoin, hostZone.DepositAddress, hostZone.DelegationIcaAddress, timeoutTimestamp))

--- a/x/stakeibc/keeper/lsm.go
+++ b/x/stakeibc/keeper/lsm.go
@@ -220,13 +220,16 @@ func (k Keeper) TransferAllLSMDeposits(ctx sdk.Context) {
 
 			// If the IBC transfer fails to get off the ground, flag the deposit as FAILED
 			// This is highly unlikely and would indicate a larger problem
-			if err := k.RecordsKeeper.IBCTransferLSMToken(
-				ctx,
-				deposit,
-				hostZone.TransferChannelId,
-				hostZone.DepositAddress,
-				hostZone.DelegationIcaAddress,
-			); err != nil {
+			err := utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+				return k.RecordsKeeper.IBCTransferLSMToken(
+					ctx,
+					deposit,
+					hostZone.TransferChannelId,
+					hostZone.DepositAddress,
+					hostZone.DelegationIcaAddress,
+				)
+			})
+			if err != nil {
 				k.Logger(ctx).Error(fmt.Sprintf("Unable to submit IBC Transfer of LSMToken for %v%s on %s: %s",
 					deposit.Amount, deposit.Denom, hostZone.ChainId, err.Error()))
 				k.RecordsKeeper.UpdateLSMTokenDepositStatus(ctx, deposit, recordstypes.LSMTokenDeposit_TRANSFER_FAILED)

--- a/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -148,7 +148,7 @@ func (k Keeper) SetWithdrawalAddressOnHost(ctx sdk.Context, hostZone types.HostZ
 }
 
 // Submits an ICQ for the withdrawal account balance
-func (k Keeper) UpdateWithdrawalBalance(ctx sdk.Context, hostZone types.HostZone) error {
+func (k Keeper) SubmitWithdrawalBalanceICQ(ctx sdk.Context, hostZone types.HostZone) error {
 	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Submitting ICQ for withdrawal account balance"))
 
 	// Get the withdrawal account address from the host zone

--- a/x/stakeibc/keeper/reward_allocation.go
+++ b/x/stakeibc/keeper/reward_allocation.go
@@ -8,6 +8,7 @@ import (
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
+	"github.com/Stride-Labs/stride/v9/utils"
 	"github.com/Stride-Labs/stride/v9/x/stakeibc/types"
 )
 
@@ -36,7 +37,10 @@ func (k Keeper) LiquidStakeRewardCollectorBalance(ctx sdk.Context, msgSvr types.
 			k.Logger(ctx).Error(fmt.Sprintf("Liquid stake from reward collector address failed validate basic: %s", err.Error()))
 			continue
 		}
-		_, err = msgSvr.LiquidStake(ctx, msg)
+		err = utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			_, err := msgSvr.LiquidStake(ctx, msg)
+			return err
+		})
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Failed to liquid stake %s for hostzone %s: %s", token.String(), hz.ChainId, err.Error()))
 			continue

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -352,7 +352,10 @@ func (k Keeper) InitiateAllHostZoneUnbondings(ctx sdk.Context, dayNumber uint64)
 		}
 
 		// Get host zone unbonding message by summing up the unbonding records
-		if err := k.UnbondFromHostZone(ctx, hostZone); err != nil {
+		err := utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			return k.UnbondFromHostZone(ctx, hostZone)
+		})
+		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Error initiating host zone unbondings for host zone %s: %s", hostZone.ChainId, err.Error()))
 			continue
 		}

--- a/x/stakeibc/keeper/validator_selection.go
+++ b/x/stakeibc/keeper/validator_selection.go
@@ -43,7 +43,10 @@ func (k Keeper) RebalanceAllHostZones(ctx sdk.Context) {
 			continue
 		}
 
-		if err := k.RebalanceDelegationsForHostZone(ctx, hostZone.ChainId); err != nil {
+		err := utils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			return k.RebalanceDelegationsForHostZone(ctx, hostZone.ChainId)
+		})
+		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to rebalance delegations for %s: %s", hostZone.ChainId, err.Error()))
 			continue
 		}


### PR DESCRIPTION
## Context
The code that runs in the end blocker does not propagate an error, so if an error occurs halfway through a function, there is the potential for partial state changes from the beginning of the function to be persisted. 

The solution is to use a temporary cache context for the function, that allows any partial state changes to be thrown out in the event of an error. The function is available in utils already - this PR just utilizes it for each hook/endblocker function.

**I'd recommend reviewing the redemption sweep refactor commit's separately.**

## Questions for reviewer
* If we fail to submit a detokenization ICA, should we mark the record as failed or leave it be so that it gets retried?

## Changelog
* Added `ApplyFuncIfNoError` wrapper to the following hooks or end blocker functions:

| Hook/EndBlocker Function              | Wrapped Function |
|---------------------------------------|------------------|
| `InitiateAllHostZoneUnbondings`       | `UnbondFromHostZone` |
| `SweepAllUnbondedTokens`              | `SweepUnbondedTokensForHostZone` (previously `SweepAllUnbondedTokensForHostZone`) |
| `SetWithdrawalAddress`                | `SetWithdrawalAddressOnHost` |
| `TransferExistingDepositsToHostZones` | `IBCTransferNativeTokens` |
| `StakeExistingDepositsOnHostZones`    | `DelegateOnHost` |
| `ReinvestRewards`                     | `SubmitWithdrawalBalanceICQ` (previously `UpdateWithdrawalBalance`) |
| `RebalanceAllHostZones`               | `RebalanceDelegationsForHostZone` |
| `AllocateHostZoneReward`              | `LiquidStake` |
| `TransferAllLSMDeposits`              | `IBCTransferLSMToken` |
| `DetokenizeAllLSMDeposits`            | `DetokenizeLSMDeposit` |

* Renamed `UpdateWithdrawalBalance` to `SubmitWithdrawalBalanceICQ` 

