### PR TITLE
Refactored redemption sweep and added more test coverage

### DIFF
--- a/x/stakeibc/keeper/events.go
+++ b/x/stakeibc/keeper/events.go
@@ -116,3 +116,16 @@ func EmitUndelegationEvent(ctx sdk.Context, hostZone types.HostZone, totalUnbond
 		),
 	)
 }
+
+// Emits an event if an redemption sweep ICA was submitted for a host zone
+func EmitRedemptionSweepEvent(ctx sdk.Context, hostZone types.HostZone, sweptAmount sdkmath.Int) {
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeUndelegation,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+			sdk.NewAttribute(types.AttributeKeyHostZone, hostZone.ChainId),
+			sdk.NewAttribute(types.AttributeKeyNativeBaseDenom, hostZone.HostDenom),
+			sdk.NewAttribute(types.AttributeKeySweptAmount, sweptAmount.String()),
+		),
+	)
+}

--- a/x/stakeibc/keeper/events.go
+++ b/x/stakeibc/keeper/events.go
@@ -121,7 +121,7 @@ func EmitUndelegationEvent(ctx sdk.Context, hostZone types.HostZone, totalUnbond
 func EmitRedemptionSweepEvent(ctx sdk.Context, hostZone types.HostZone, sweptAmount sdkmath.Int) {
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
-			types.EventTypeUndelegation,
+			types.EventTypeRedemptionSweep,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 			sdk.NewAttribute(types.AttributeKeyHostZone, hostZone.ChainId),
 			sdk.NewAttribute(types.AttributeKeyNativeBaseDenom, hostZone.HostDenom),

--- a/x/stakeibc/keeper/get_light_client_safely_test.go
+++ b/x/stakeibc/keeper/get_light_client_safely_test.go
@@ -53,10 +53,10 @@ func (s *KeeperTestSuite) TestGetLightClientSafely_InvalidConnection() {
 	tc.connectionId = "connection-invalid"
 
 	_, err := s.App.StakeibcKeeper.GetLightClientTimeSafely(s.Ctx, tc.connectionId)
-	s.Require().ErrorContains(err, "invalid connection id", "get lc time: error complains about invalid connection id")
+	s.Require().ErrorContains(err, "connection-id: connection-invalid: connection not found")
 
 	_, err = s.App.StakeibcKeeper.GetLightClientHeightSafely(s.Ctx, tc.connectionId)
-	s.Require().ErrorContains(err, "invalid connection id", "get lc height: error complains about invalid connection id")
+	s.Require().ErrorContains(err, "connection-id: connection-invalid: connection not found")
 }
 
 func (s *KeeperTestSuite) TestGetLightClientHeightSafely_Successful() {

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -28,7 +28,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 		// Initiate unbondings from any hostZone where it's appropriate
 		k.InitiateAllHostZoneUnbondings(ctx, epochNumber)
 		// Check previous epochs to see if unbondings finished, and sweep the tokens if so
-		k.SweepAllUnbondedTokens(ctx)
+		k.SweepUnbondedTokensAllHostZones(ctx)
 		// Cleanup any records that are no longer needed
 		k.CleanupEpochUnbondingRecords(ctx, epochNumber)
 		// Create an empty unbonding record for this epoch

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -389,15 +389,14 @@ func (k Keeper) CleanupEpochUnbondingRecords(ctx sdk.Context, epochNumber uint64
 	return true
 }
 
-// Batch transfers any unbonded tokens from the delegation account to the redemption account
-func (k Keeper) SweepAllUnbondedTokensForHostZone(ctx sdk.Context, hostZone types.HostZone, epochUnbondingRecords []recordstypes.EpochUnbondingRecord) (success bool, sweepAmount sdkmath.Int) {
-	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Sweeping unbonded tokens"))
-
-	// Sum up all host zone unbonding records that have finished unbonding
-	totalAmtTransferToRedemptionAcct := sdkmath.ZeroInt()
-	epochUnbondingRecordIds := []uint64{}
-	for _, epochUnbondingRecord := range epochUnbondingRecords {
-
+// Gets the total unbonded amount for the host zone that has finished unbonding
+func (k Keeper) GetRedemptionSweepAmountAndRecordIds(
+	ctx sdk.Context,
+	hostZone types.HostZone,
+) (totalSweepAmount sdkmath.Int, unbondingRecordIds []uint64) {
+	// Sum the total unbonded amount for each unbonding record
+	totalSweepAmount = sdkmath.ZeroInt()
+	for _, epochUnbondingRecord := range k.RecordsKeeper.GetAllEpochUnbondingRecord(ctx) {
 		// Get all the unbondings associated with the epoch + host zone pair
 		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, hostZone.ChainId)
 		if !found {
@@ -430,30 +429,38 @@ func (k Keeper) SweepAllUnbondedTokensForHostZone(ctx sdk.Context, hostZone type
 				k.Logger(ctx).Error(errMsg)
 				continue
 			}
-			totalAmtTransferToRedemptionAcct = totalAmtTransferToRedemptionAcct.Add(hostZoneUnbonding.NativeTokenAmount)
-			epochUnbondingRecordIds = append(epochUnbondingRecordIds, epochUnbondingRecord.EpochNumber)
+			totalSweepAmount = totalSweepAmount.Add(hostZoneUnbonding.NativeTokenAmount)
+			unbondingRecordIds = append(unbondingRecordIds, epochUnbondingRecord.EpochNumber)
 		}
 	}
 
-	// If we have any amount to sweep, then we can send the ICA call to sweep them
-	if totalAmtTransferToRedemptionAcct.LTE(sdkmath.ZeroInt()) {
-		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "No tokens ready for sweep"))
-		return true, totalAmtTransferToRedemptionAcct
-	}
-	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Batch transferring %v to host zone", totalAmtTransferToRedemptionAcct))
+	return totalSweepAmount, unbondingRecordIds
+}
 
-	// Get the delegation account and redemption account
+// Batch transfers any unbonded tokens from the delegation account to the redemption account
+func (k Keeper) SweepAllUnbondedTokensForHostZone(ctx sdk.Context, hostZone types.HostZone) error {
+	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Sweeping unbonded tokens"))
+
+	// Confirm the delegation (destination) and redemption (source) accounts are registered
 	if hostZone.DelegationIcaAddress == "" {
-		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a delegation address!", hostZone.ChainId))
-		return false, sdkmath.ZeroInt()
+		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no delegation account found for %s", hostZone.ChainId)
 	}
 	if hostZone.RedemptionIcaAddress == "" {
-		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a redemption address!", hostZone.ChainId))
-		return false, sdkmath.ZeroInt()
+		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no redemption account found for %s", hostZone.ChainId)
 	}
 
+	// Determine the total unbonded amount that has finished unbonding
+	totalSweepAmount, epochUnbondingRecordIds := k.GetRedemptionSweepAmountAndRecordIds(ctx, hostZone)
+
+	// If we have any amount to sweep, then we can send the ICA call to sweep them
+	if totalSweepAmount.LTE(sdkmath.ZeroInt()) {
+		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "No tokens ready for sweep"))
+		return nil
+	}
+	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Batch transferring %v to host zone", totalSweepAmount))
+
 	// Build transfer message to transfer from the delegation account to redemption account
-	sweepCoin := sdk.NewCoin(hostZone.HostDenom, totalAmtTransferToRedemptionAcct)
+	sweepCoin := sdk.NewCoin(hostZone.HostDenom, totalSweepAmount)
 	msgs := []sdk.Msg{
 		&banktypes.MsgSend{
 			FromAddress: hostZone.DelegationIcaAddress,
@@ -470,26 +477,25 @@ func (k Keeper) SweepAllUnbondedTokensForHostZone(ctx sdk.Context, hostZone type
 	}
 	marshalledCallbackArgs, err := k.MarshalRedemptionCallbackArgs(ctx, redemptionCallback)
 	if err != nil {
-		k.Logger(ctx).Error(err.Error())
-		return false, sdkmath.ZeroInt()
+		return err
 	}
 
-	// Send the transfer ICA
+	// Send the bank send ICA
 	_, err = k.SubmitTxsDayEpoch(ctx, hostZone.ConnectionId, msgs, types.ICAAccountType_DELEGATION, ICACallbackID_Redemption, marshalledCallbackArgs)
 	if err != nil {
-		k.Logger(ctx).Error(fmt.Sprintf("Failed to SubmitTxs, transfer to redemption account on %s", hostZone.ChainId))
-		return false, sdkmath.ZeroInt()
+		return errorsmod.Wrapf(err, "unable to submit redemption ICA for %s", hostZone.ChainId)
 	}
 	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "ICA MsgSend Successfully Sent"))
 
 	// Update the host zone unbonding records to status IN_PROGRESS
 	err = k.RecordsKeeper.SetHostZoneUnbondings(ctx, hostZone.ChainId, epochUnbondingRecordIds, recordstypes.HostZoneUnbonding_EXIT_TRANSFER_IN_PROGRESS)
 	if err != nil {
-		k.Logger(ctx).Error(err.Error())
-		return false, sdkmath.ZeroInt()
+		return err
 	}
 
-	return true, totalAmtTransferToRedemptionAcct
+	EmitRedemptionSweepEvent(ctx, hostZone, totalSweepAmount)
+
+	return nil
 }
 
 // Sends all unbonded tokens to the redemption account

--- a/x/stakeibc/keeper/unbonding_records.go
+++ b/x/stakeibc/keeper/unbonding_records.go
@@ -390,28 +390,23 @@ func (k Keeper) CleanupEpochUnbondingRecords(ctx sdk.Context, epochNumber uint64
 }
 
 // Gets the total unbonded amount for the host zone that has finished unbonding
-func (k Keeper) GetRedemptionSweepAmountAndRecordIds(
+func (k Keeper) GetTotalRedemptionSweepAmountAndRecordIds(
 	ctx sdk.Context,
-	hostZone types.HostZone,
+	chainId string,
+	hostBlockTime uint64,
 ) (totalSweepAmount sdkmath.Int, unbondingRecordIds []uint64) {
 	// Sum the total unbonded amount for each unbonding record
 	totalSweepAmount = sdkmath.ZeroInt()
 	for _, epochUnbondingRecord := range k.RecordsKeeper.GetAllEpochUnbondingRecord(ctx) {
 		// Get all the unbondings associated with the epoch + host zone pair
-		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, hostZone.ChainId)
+		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochUnbondingRecord.EpochNumber, chainId)
 		if !found {
 			continue
 		}
 
-		// Get latest blockTime from light client
-		blockTime, err := k.GetLightClientTimeSafely(ctx, hostZone.ConnectionId)
-		if err != nil {
-			k.Logger(ctx).Error(fmt.Sprintf("\tCould not find blockTime for host zone %s", hostZone.ChainId))
-			continue
-		}
-
-		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Epoch %d - Status: %s, Amount: %v, Unbonding Time: %d, Block Time: %d",
-			epochUnbondingRecord.EpochNumber, hostZoneUnbonding.Status.String(), hostZoneUnbonding.NativeTokenAmount, hostZoneUnbonding.UnbondingTime, blockTime))
+		k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "Epoch %d - Status: %s, Amount: %v, Unbonding Time: %d, Block Time: %d",
+			epochUnbondingRecord.EpochNumber, hostZoneUnbonding.Status.String(),
+			hostZoneUnbonding.NativeTokenAmount, hostZoneUnbonding.UnbondingTime, hostBlockTime))
 
 		// If the unbonding period has elapsed, then we can send the ICA call to sweep this
 		//   hostZone's unbondings to the redemption account (in a batch).
@@ -420,15 +415,11 @@ func (k Keeper) GetRedemptionSweepAmountAndRecordIds(
 		//      2. the unbonding time is less than the current block time
 		//      3. the host zone is in the EXIT_TRANSFER_QUEUE state, meaning it's ready to be transferred
 		inTransferQueue := hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE
-		validUnbondingTime := hostZoneUnbonding.UnbondingTime > 0 && hostZoneUnbonding.UnbondingTime < blockTime
+		validUnbondingTime := hostZoneUnbonding.UnbondingTime > 0 && hostZoneUnbonding.UnbondingTime < hostBlockTime
 		if inTransferQueue && validUnbondingTime {
-			k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "  %v%s included in sweep", hostZoneUnbonding.NativeTokenAmount, hostZoneUnbonding.Denom))
+			k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "  %v%s included in sweep",
+				hostZoneUnbonding.NativeTokenAmount, hostZoneUnbonding.Denom))
 
-			if err != nil {
-				errMsg := fmt.Sprintf("Could not convert native token amount to int64 | %s", err.Error())
-				k.Logger(ctx).Error(errMsg)
-				continue
-			}
 			totalSweepAmount = totalSweepAmount.Add(hostZoneUnbonding.NativeTokenAmount)
 			unbondingRecordIds = append(unbondingRecordIds, epochUnbondingRecord.EpochNumber)
 		}
@@ -439,25 +430,32 @@ func (k Keeper) GetRedemptionSweepAmountAndRecordIds(
 
 // Batch transfers any unbonded tokens from the delegation account to the redemption account
 func (k Keeper) SweepUnbondedTokensForHostZone(ctx sdk.Context, hostZone types.HostZone) error {
-	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Sweeping unbonded tokens"))
+	chainId := hostZone.ChainId
+	k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "Sweeping unbonded tokens"))
 
 	// Confirm the delegation (destination) and redemption (source) accounts are registered
 	if hostZone.DelegationIcaAddress == "" {
-		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no delegation account found for %s", hostZone.ChainId)
+		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no delegation account found for %s", chainId)
 	}
 	if hostZone.RedemptionIcaAddress == "" {
-		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no redemption account found for %s", hostZone.ChainId)
+		return errorsmod.Wrapf(types.ErrICAAccountNotFound, "no redemption account found for %s", chainId)
+	}
+
+	// Get latest blockTime from light client
+	hostBlockTime, err := k.GetLightClientTimeSafely(ctx, hostZone.ConnectionId)
+	if err != nil {
+		return errorsmod.Wrapf(err, "could not get light client block time for host zone")
 	}
 
 	// Determine the total unbonded amount that has finished unbonding
-	totalSweepAmount, epochUnbondingRecordIds := k.GetRedemptionSweepAmountAndRecordIds(ctx, hostZone)
+	totalSweepAmount, epochUnbondingRecordIds := k.GetTotalRedemptionSweepAmountAndRecordIds(ctx, chainId, hostBlockTime)
 
 	// If we have any amount to sweep, then we can send the ICA call to sweep them
 	if totalSweepAmount.LTE(sdkmath.ZeroInt()) {
-		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "No tokens ready for sweep"))
+		k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "No tokens ready for sweep"))
 		return nil
 	}
-	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Batch transferring %v to host zone", totalSweepAmount))
+	k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "Batch transferring %v to host zone", totalSweepAmount))
 
 	// Build transfer message to transfer from the delegation account to redemption account
 	sweepCoin := sdk.NewCoin(hostZone.HostDenom, totalSweepAmount)
@@ -468,11 +466,11 @@ func (k Keeper) SweepUnbondedTokensForHostZone(ctx sdk.Context, hostZone types.H
 			Amount:      sdk.NewCoins(sweepCoin),
 		},
 	}
-	k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Preparing MsgSend from Delegation Account to Redemption Account"))
+	k.Logger(ctx).Info(utils.LogWithHostZone(chainId, "Preparing MsgSend from Delegation Account to Redemption Account"))
 
 	// Store the epoch numbers in the callback to identify the epoch unbonding records
 	redemptionCallback := types.RedemptionCallback{
-		HostZoneId:              hostZone.ChainId,
+		HostZoneId:              chainId,
 		EpochUnbondingRecordIds: epochUnbondingRecordIds,
 	}
 	marshalledCallbackArgs, err := k.MarshalRedemptionCallbackArgs(ctx, redemptionCallback)

--- a/x/stakeibc/keeper/unbonding_records_initiate_all_unbondings_test.go
+++ b/x/stakeibc/keeper/unbonding_records_initiate_all_unbondings_test.go
@@ -168,5 +168,4 @@ func (s *KeeperTestSuite) TestInitiateAllHostZoneUnbondings_Failed() {
 	// An event should only be emitted for Osmo
 	s.CheckEventValueNotEmitted(types.EventTypeUndelegation, types.AttributeKeyHostZone, HostChainId)
 	s.CheckEventValueEmitted(types.EventTypeUndelegation, types.AttributeKeyHostZone, OsmoChainId)
-
 }

--- a/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
+++ b/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
@@ -10,90 +10,57 @@ import (
 	recordtypes "github.com/Stride-Labs/stride/v9/x/records/types"
 
 	epochtypes "github.com/Stride-Labs/stride/v9/x/epochs/types"
-	stakeibc "github.com/Stride-Labs/stride/v9/x/stakeibc/types"
+	"github.com/Stride-Labs/stride/v9/x/stakeibc/types"
 )
 
 type SweepUnbondedTokensTestCase struct {
 	epochUnbondingRecords []recordtypes.EpochUnbondingRecord
-	hostZones             []stakeibc.HostZone
-	lightClientTime       uint64
+	hostZones             []types.HostZone
+	delegationChannelID   string
+	delegationPortID      string
+	channelStartSequence  uint64
 }
 
 func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase {
-	s.CreateICAChannel("GAIA.DELEGATION")
-	//  define the host zone with TotalDelegations and validators with staked amounts
-	gaiaValidators := []*stakeibc.Validator{
-		{
-			Address:    "cosmos_VALIDATOR",
-			Delegation: sdkmath.NewInt(5_000_000),
-			Weight:     uint64(10),
-		},
-	}
-	osmoValidators := []*stakeibc.Validator{
-		{
-			Address:    "osmo_VALIDATOR",
-			Delegation: sdkmath.NewInt(5_000_000),
-			Weight:     uint64(10),
-		},
-	}
-	hostZones := []stakeibc.HostZone{
+	delegationChannelId, delegationPortId := s.CreateICAChannel("GAIA.DELEGATION")
+
+	hostZones := []types.HostZone{
 		{
 			ChainId:              HostChainId,
 			HostDenom:            Atom,
-			Bech32Prefix:         GaiaPrefix,
 			UnbondingPeriod:      14,
-			Validators:           gaiaValidators,
 			DelegationIcaAddress: "cosmos_DELEGATION",
 			RedemptionIcaAddress: "cosmos_REDEMPTION",
-			TotalDelegations:     sdkmath.NewInt(5_000_000),
 			ConnectionId:         ibctesting.FirstConnectionID,
 		},
 		{
 			ChainId:              OsmoChainId,
 			HostDenom:            Osmo,
-			Bech32Prefix:         OsmoPrefix,
 			UnbondingPeriod:      21,
-			Validators:           osmoValidators,
 			DelegationIcaAddress: "osmo_DELEGATION",
 			RedemptionIcaAddress: "osmo_REDEMPTION",
-			TotalDelegations:     sdkmath.NewInt(5_000_000),
-			ConnectionId:         ibctesting.FirstConnectionID,
+			ConnectionId:         "connection-2",
 		},
 	}
-	dayEpochTracker := stakeibc.EpochTracker{
+	for _, hostZone := range hostZones {
+		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	}
+
+	dayEpochTracker := types.EpochTracker{
 		EpochIdentifier:    epochtypes.DAY_EPOCH,
 		EpochNumber:        1,
 		NextEpochStartTime: uint64(s.Coordinator.CurrentTime.UnixNano() + 30_000_000_000), // dictates timeouts
 	}
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, dayEpochTracker)
 
-	// 2022-08-12T19:51, a random time in the past
-	unbondingTime := uint64(10)
-	lightClientTime := unbondingTime + 1
-	// list of epoch unbonding records
+	unbondingTime := uint64(s.Ctx.BlockTime().Add(-1 * time.Minute).UnixNano())
 	epochUnbondingRecords := []recordtypes.EpochUnbondingRecord{
-		{
-			EpochNumber: 0,
-			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
-				{
-					HostZoneId:        HostChainId,
-					NativeTokenAmount: sdkmath.NewInt(1_000_000),
-					Status:            recordtypes.HostZoneUnbonding_UNBONDING_QUEUE,
-					UnbondingTime:     unbondingTime,
-				},
-				{
-					HostZoneId:        OsmoChainId,
-					NativeTokenAmount: sdkmath.NewInt(1_000_000),
-					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
-					UnbondingTime:     unbondingTime,
-				},
-			},
-		},
 		{
 			EpochNumber: 1,
 			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
 				{
 					HostZoneId:        HostChainId,
-					NativeTokenAmount: sdkmath.NewInt(2_000_000),
+					NativeTokenAmount: sdkmath.NewInt(1_000_000),
 					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
 					UnbondingTime:     unbondingTime,
 				},
@@ -110,13 +77,15 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
 				{
 					HostZoneId:        HostChainId,
-					NativeTokenAmount: sdkmath.NewInt(5_000_000),
-					Status:            recordtypes.HostZoneUnbonding_CLAIMABLE,
+					NativeTokenAmount: sdkmath.NewInt(3_000_000),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     unbondingTime,
 				},
 				{
 					HostZoneId:        OsmoChainId,
-					NativeTokenAmount: sdkmath.NewInt(5_000_000),
-					Status:            recordtypes.HostZoneUnbonding_UNBONDING_QUEUE,
+					NativeTokenAmount: sdkmath.NewInt(4_000_000),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     unbondingTime,
 				},
 			},
 		},
@@ -125,15 +94,16 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 		s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
 	}
 
-	for _, hostZone := range hostZones {
-		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	}
-	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, dayEpochTracker)
+	// Get the sequence number before sweep ICAs are sent to confirm it increments after the ICA
+	startSequence, found := s.App.IBCKeeper.ChannelKeeper.GetNextSequenceSend(s.Ctx, delegationPortId, delegationChannelId)
+	s.Require().True(found, "sequence number not found before transfer")
 
 	return SweepUnbondedTokensTestCase{
 		epochUnbondingRecords: epochUnbondingRecords,
 		hostZones:             hostZones,
-		lightClientTime:       lightClientTime,
+		delegationChannelID:   delegationChannelId,
+		delegationPortID:      delegationPortId,
+		channelStartSequence:  startSequence,
 	}
 }
 
@@ -193,6 +163,79 @@ func (s *KeeperTestSuite) TestSweepUnbondedTokens_DelegationAccountAddressMissin
 	s.Require().Len(failedSweeps, 1, "sweep all tokens fails for 1 host zone")
 	s.Require().Equal("OSMO", failedSweeps[0], "sweep all tokens fails for osmo")
 	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(2_000_000)}, sweepAmounts, "correct amount of tokens swept for each host zone")
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_Successful() {
+	tc := s.SetupSweepUnbondedTokens()
+	hostZone := tc.hostZones[0]
+
+	// Call redemption sweep
+	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
+	s.Require().NoError(err, "no error expected when sweeping")
+
+	// Confirm ICA was submitted (by checking sequence number was incremented)
+	endSequence, found := s.App.IBCKeeper.ChannelKeeper.GetNextSequenceSend(s.Ctx, tc.delegationPortID, tc.delegationChannelID)
+	s.Require().True(found, "sequence number not found after after redemption ICA")
+	s.Require().Equal(tc.channelStartSequence+1, endSequence, "tx sequence number after redemption ICA")
+
+	// Confirm callback data was stored
+	allCallbackData := s.App.IcacallbacksKeeper.GetAllCallbackData(s.Ctx)
+	s.Require().Len(allCallbackData, 1, "length of callback data")
+
+	redemptionCallback, err := s.App.StakeibcKeeper.UnmarshalRedemptionCallbackArgs(s.Ctx, allCallbackData[0].CallbackArgs)
+	s.Require().NoError(err, "no error expected when unmarshaling redemption callback")
+
+	s.Require().Equal(HostChainId, redemptionCallback.HostZoneId, "callback chain ID")
+	s.Require().Equal([]uint64{1, 2}, redemptionCallback.EpochUnbondingRecordIds, "callback epoch unbonding IDs")
+
+	// Confirm epoch unbonding record status was updated
+	epochUnbondingRecords := s.App.RecordsKeeper.GetAllEpochUnbondingRecord(s.Ctx)
+	for _, epochUnbondingRecord := range epochUnbondingRecords {
+		for _, hostZoneUnbondingRecord := range epochUnbondingRecord.HostZoneUnbondings {
+			expectedStatus := recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE.String()
+			if hostZoneUnbondingRecord.HostZoneId == HostChainId {
+				expectedStatus = recordtypes.HostZoneUnbonding_EXIT_TRANSFER_IN_PROGRESS.String()
+			}
+			s.Require().Equal(expectedStatus, hostZoneUnbondingRecord.Status.String(),
+				"epoch unbonding record status for record %d and host zone %s",
+				epochUnbondingRecord.EpochNumber, hostZoneUnbondingRecord.HostZoneId)
+		}
+	}
+
+	// Confirm sweep amount was correct
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, HostChainId)
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeySweptAmount, "4000000")
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_MissingDelegationAccount() {
+	tc := s.SetupSweepUnbondedTokens()
+	hostZone := tc.hostZones[0]
+
+	// Remove the delegation account from the host chain, it should cause the redemption to fail
+	hostZone.DelegationIcaAddress = ""
+	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
+	s.Require().ErrorContains(err, "no delegation account found")
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_MissingRedemptionAccount() {
+	tc := s.SetupSweepUnbondedTokens()
+	hostZone := tc.hostZones[0]
+
+	// Remove the redemption account from the host chain, it should cause the redemption to fail
+	hostZone.DelegationIcaAddress = ""
+	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
+	s.Require().ErrorContains(err, "no redemption account found")
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_FailedToGetLightClientTime() {
+	tc := s.SetupSweepUnbondedTokens()
+	hostZone := tc.hostZones[0]
+
+	// Change the connection ID on the host zone so that the light client time cannot be found
+	// It should cause the redemption to fail
+	hostZone.ConnectionId = "invalid-connection-id"
+	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
+	s.Require().ErrorContains(err, "could not get light client block time for host zone")
 }
 
 func (s *KeeperTestSuite) TestGetTotalRedemptionSweepAmountAndRecordsIds() {

--- a/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
+++ b/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
@@ -24,28 +24,30 @@ type SweepUnbondedTokensTestCase struct {
 func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase {
 	delegationChannelId, delegationPortId := s.CreateICAChannel("GAIA.DELEGATION")
 
+	// Add gaia and osmo host zones
 	hostZones := []types.HostZone{
 		{
 			ChainId:              HostChainId,
 			HostDenom:            Atom,
-			UnbondingPeriod:      14,
 			DelegationIcaAddress: "cosmos_DELEGATION",
 			RedemptionIcaAddress: "cosmos_REDEMPTION",
 			ConnectionId:         ibctesting.FirstConnectionID,
 		},
 		{
+			// the same connection is used for osmo so we don't have to
+			// mock out a separate channel
 			ChainId:              OsmoChainId,
 			HostDenom:            Osmo,
-			UnbondingPeriod:      21,
 			DelegationIcaAddress: "osmo_DELEGATION",
 			RedemptionIcaAddress: "osmo_REDEMPTION",
-			ConnectionId:         "connection-2",
+			ConnectionId:         ibctesting.FirstConnectionID,
 		},
 	}
 	for _, hostZone := range hostZones {
 		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
 	}
 
+	// Add epoch tracker to determine ICA timeout
 	dayEpochTracker := types.EpochTracker{
 		EpochIdentifier:    epochtypes.DAY_EPOCH,
 		EpochNumber:        1,
@@ -53,6 +55,7 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 	}
 	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, dayEpochTracker)
 
+	// Add epoch unbonding records that finished unbonding 1 minute ago
 	unbondingTime := uint64(s.Ctx.BlockTime().Add(-1 * time.Minute).UnixNano())
 	epochUnbondingRecords := []recordtypes.EpochUnbondingRecord{
 		{
@@ -105,64 +108,6 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 		delegationPortID:      delegationPortId,
 		channelStartSequence:  startSequence,
 	}
-}
-
-func (s *KeeperTestSuite) TestSweepUnbondedTokens_Successful() {
-	s.SetupSweepUnbondedTokens()
-	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.Swee(s.Ctx)
-	s.Require().True(success, "sweep all tokens succeeds")
-	s.Require().Len(successfulSweeps, 2, "sweep all tokens succeeds for 2 host zones")
-	s.Require().Len(sweepAmounts, 2, "sweep all tokens succeeds for 2 host zones")
-	s.Require().Len(failedSweeps, 0, "sweep all tokens fails for no host zone")
-	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(2_000_000), sdkmath.NewInt(3_000_000)}, sweepAmounts, "correct amount of tokens swept for each host zone")
-}
-
-func (s *KeeperTestSuite) TestSweepUnbondedTokens_HostZoneUnbondingMissing() {
-	// If Osmo is missing, make sure that the function still succeeds
-	s.SetupSweepUnbondedTokens()
-	epochUnbondingRecords := s.App.RecordsKeeper.GetAllEpochUnbondingRecord(s.Ctx)
-	for _, epochUnbonding := range epochUnbondingRecords {
-		epochUnbonding.HostZoneUnbondings = []*recordtypes.HostZoneUnbonding{
-			epochUnbonding.HostZoneUnbondings[0],
-		}
-		s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbonding)
-	}
-	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.SweepAllUnbondedTokens(s.Ctx)
-	s.Require().True(success, "sweep all tokens succeeded if osmo missing")
-	s.Require().Len(successfulSweeps, 2, "sweep all tokens succeeds for 2 host zones")
-	s.Require().Len(sweepAmounts, 2, "sweep all tokens succeeds for 2 host zone")
-	s.Require().Len(failedSweeps, 0, "sweep all tokens fails for 0 host zone")
-	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(2_000_000), sdkmath.ZeroInt()}, sweepAmounts, "correct amount of tokens swept for each host zone")
-}
-
-func (s *KeeperTestSuite) TestSweepUnbondedTokens_RedemptionAccountMissing() {
-	s.SetupSweepUnbondedTokens()
-	hostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, "GAIA")
-	hostZone.RedemptionIcaAddress = ""
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.SweepAllUnbondedTokens(s.Ctx)
-	s.Require().Equal(success, false, "sweep all tokens failed if osmo missing")
-	s.Require().Len(successfulSweeps, 1, "sweep all tokens succeeds for 1 host zone")
-	s.Require().Equal("OSMO", successfulSweeps[0], "sweep all tokens succeeds for osmo")
-	s.Require().Len(sweepAmounts, 1, "sweep all tokens succeeds for 1 host zone")
-	s.Require().Len(failedSweeps, 1, "sweep all tokens fails for 1 host zone")
-	s.Require().Equal("GAIA", failedSweeps[0], "sweep all tokens fails for gaia")
-	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(3_000_000)}, sweepAmounts, "correct amount of tokens swept for each host zone")
-}
-
-func (s *KeeperTestSuite) TestSweepUnbondedTokens_DelegationAccountAddressMissing() {
-	s.SetupSweepUnbondedTokens()
-	hostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, "OSMO")
-	hostZone.DelegationIcaAddress = ""
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.SweepAllUnbondedTokens(s.Ctx)
-	s.Require().False(success, "sweep all tokens failed if gaia missing")
-	s.Require().Len(successfulSweeps, 1, "sweep all tokens succeeds for 1 host zone")
-	s.Require().Equal("GAIA", successfulSweeps[0], "sweep all tokens succeeds for gaia")
-	s.Require().Len(sweepAmounts, 1, "sweep all tokens succeeds for 1 host zone")
-	s.Require().Len(failedSweeps, 1, "sweep all tokens fails for 1 host zone")
-	s.Require().Equal("OSMO", failedSweeps[0], "sweep all tokens fails for osmo")
-	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(2_000_000)}, sweepAmounts, "correct amount of tokens swept for each host zone")
 }
 
 func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_Successful() {
@@ -222,7 +167,7 @@ func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_MissingRedemptionAc
 	hostZone := tc.hostZones[0]
 
 	// Remove the redemption account from the host chain, it should cause the redemption to fail
-	hostZone.DelegationIcaAddress = ""
+	hostZone.RedemptionIcaAddress = ""
 	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
 	s.Require().ErrorContains(err, "no redemption account found")
 }
@@ -236,6 +181,72 @@ func (s *KeeperTestSuite) TestSweepUnbondedTokensForHostZone_FailedToGetLightCli
 	hostZone.ConnectionId = "invalid-connection-id"
 	err := s.App.StakeibcKeeper.SweepUnbondedTokensForHostZone(s.Ctx, hostZone)
 	s.Require().ErrorContains(err, "could not get light client block time for host zone")
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensAllHostZones_Successful() {
+	// tests a successful sweep to both gaia and osmo
+	s.SetupSweepUnbondedTokens()
+
+	// Sweep for both hosts
+	s.App.StakeibcKeeper.SweepUnbondedTokensAllHostZones(s.Ctx)
+
+	// An event should be emitted for each if they were successful
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, HostChainId)
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, OsmoChainId)
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensAllHostZones_GaiaSuccessful() {
+	s.SetupSweepUnbondedTokens()
+
+	// Remove the osmo epoch unbonding records so that there is nothing to sweep
+	for _, epochUnbondingRecord := range s.App.RecordsKeeper.GetAllEpochUnbondingRecord(s.Ctx) {
+		for _, hostZoneUnbondingRecord := range epochUnbondingRecord.HostZoneUnbondings {
+			if hostZoneUnbondingRecord.HostZoneId == OsmoChainId {
+				hostZoneUnbondingRecord.NativeTokenAmount = sdkmath.ZeroInt()
+			}
+		}
+		s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
+	}
+
+	// Sweep for both hosts (only gaia should submit an ICA)
+	s.App.StakeibcKeeper.SweepUnbondedTokensAllHostZones(s.Ctx)
+
+	// An event should only be emitted for Gaia
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, HostChainId)
+	s.CheckEventValueNotEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, OsmoChainId)
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensAllHostZones_GaiaFailed() {
+	s.SetupSweepUnbondedTokens()
+
+	// Remove the gaia epoch unbonding records so that there is nothing to sweep
+	for _, epochUnbondingRecord := range s.App.RecordsKeeper.GetAllEpochUnbondingRecord(s.Ctx) {
+		for _, hostZoneUnbondingRecord := range epochUnbondingRecord.HostZoneUnbondings {
+			if hostZoneUnbondingRecord.HostZoneId == HostChainId {
+				hostZoneUnbondingRecord.NativeTokenAmount = sdkmath.ZeroInt()
+			}
+		}
+		s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
+	}
+
+	// Sweep for both hosts (only osmo should submit an ICA)
+	s.App.StakeibcKeeper.SweepUnbondedTokensAllHostZones(s.Ctx)
+
+	// An event should only be emitted for Osmo
+	s.CheckEventValueNotEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, HostChainId)
+	s.CheckEventValueEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, OsmoChainId)
+}
+
+func (s *KeeperTestSuite) TestSweepUnbondedTokensAllHostZones_NoneSuccessful() {
+	s.SetupSweepUnbondedTokens()
+
+	// Remove all epoch unbonding records so no ICAs are submitted
+	s.App.RecordsKeeper.RemoveEpochUnbondingRecord(s.Ctx, 1)
+	s.App.RecordsKeeper.RemoveEpochUnbondingRecord(s.Ctx, 2)
+
+	// No event should be emitted for either host
+	s.CheckEventValueNotEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, HostChainId)
+	s.CheckEventValueNotEmitted(types.EventTypeRedemptionSweep, types.AttributeKeyHostZone, OsmoChainId)
 }
 
 func (s *KeeperTestSuite) TestGetTotalRedemptionSweepAmountAndRecordsIds() {

--- a/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
+++ b/x/stakeibc/keeper/unbonding_records_sweep_unbonded_tokens_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	sdkmath "cosmossdk.io/math"
 	ibctesting "github.com/cosmos/ibc-go/v5/testing"
 	_ "github.com/stretchr/testify/suite"
@@ -137,7 +139,7 @@ func (s *KeeperTestSuite) SetupSweepUnbondedTokens() SweepUnbondedTokensTestCase
 
 func (s *KeeperTestSuite) TestSweepUnbondedTokens_Successful() {
 	s.SetupSweepUnbondedTokens()
-	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.SweepAllUnbondedTokens(s.Ctx)
+	success, successfulSweeps, sweepAmounts, failedSweeps := s.App.StakeibcKeeper.Swee(s.Ctx)
 	s.Require().True(success, "sweep all tokens succeeds")
 	s.Require().Len(successfulSweeps, 2, "sweep all tokens succeeds for 2 host zones")
 	s.Require().Len(sweepAmounts, 2, "sweep all tokens succeeds for 2 host zones")
@@ -191,4 +193,110 @@ func (s *KeeperTestSuite) TestSweepUnbondedTokens_DelegationAccountAddressMissin
 	s.Require().Len(failedSweeps, 1, "sweep all tokens fails for 1 host zone")
 	s.Require().Equal("OSMO", failedSweeps[0], "sweep all tokens fails for osmo")
 	s.Require().Equal([]sdkmath.Int{sdkmath.NewInt(2_000_000)}, sweepAmounts, "correct amount of tokens swept for each host zone")
+}
+
+func (s *KeeperTestSuite) TestGetTotalRedemptionSweepAmountAndRecordsIds() {
+	hostBlockTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	validUnbondTime := uint64(hostBlockTime.Add(-1 * time.Minute).UnixNano())
+
+	epochUnbondingRecords := []recordtypes.EpochUnbondingRecord{
+		{
+			EpochNumber: uint64(1),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Summed
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(1),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+				{
+					// Different host zone
+					HostZoneId:        "different",
+					NativeTokenAmount: sdkmath.NewInt(2),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+			},
+		},
+		{
+			EpochNumber: uint64(2),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Different host zone
+					HostZoneId:        "different",
+					NativeTokenAmount: sdkmath.NewInt(3),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+				{
+					// Summed
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(4),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+			},
+		},
+		{
+			EpochNumber: uint64(3),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Different Status
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(5),
+					Status:            recordtypes.HostZoneUnbonding_UNBONDING_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+			},
+		},
+		{
+			EpochNumber: uint64(4),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Unbonding time not set
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(6),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     0,
+				},
+			},
+		},
+		{
+			EpochNumber: uint64(5),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Unbonding time after block time
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(7),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     uint64(hostBlockTime.Add(time.Minute).UnixNano()),
+				},
+			},
+		},
+		{
+			EpochNumber: uint64(6),
+			HostZoneUnbondings: []*recordtypes.HostZoneUnbonding{
+				{
+					// Summed
+					HostZoneId:        HostChainId,
+					NativeTokenAmount: sdkmath.NewInt(8),
+					Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+					UnbondingTime:     validUnbondTime,
+				},
+			},
+		},
+	}
+
+	for _, epochUnbondingRecord := range epochUnbondingRecords {
+		s.App.RecordsKeeper.SetEpochUnbondingRecord(s.Ctx, epochUnbondingRecord)
+	}
+
+	expectedUnbondAmount := int64(1 + 4 + 8)
+	expectedRecordIds := []uint64{1, 2, 6}
+
+	hostBlockTimeNano := uint64(hostBlockTime.UnixNano())
+	actualUnbondAmount, actualRecordIds := s.App.StakeibcKeeper.GetTotalRedemptionSweepAmountAndRecordIds(s.Ctx, HostChainId, hostBlockTimeNano)
+	s.Require().Equal(expectedUnbondAmount, actualUnbondAmount.Int64(), "unbonded amount")
+	s.Require().Equal(expectedRecordIds, actualRecordIds, "epoch unbonding record IDs")
 }

--- a/x/stakeibc/types/events.go
+++ b/x/stakeibc/types/events.go
@@ -20,6 +20,7 @@ const (
 	EventTypeValidatorExchangeRateChange = "validator_exchange_rate_change"
 	EventTypeValidatorSlash              = "validator_slash"
 	EventTypeUndelegation                = "undelegation"
+	EventTypeRedemptionSweep             = "redemption_sweep"
 
 	AttributeKeyHostZone         = "host_zone"
 	AttributeKeyConnectionId     = "connection_id"

--- a/x/stakeibc/types/events.go
+++ b/x/stakeibc/types/events.go
@@ -35,6 +35,7 @@ const (
 	AttributeKeyNativeBaseDenom   = "native_base_denom"
 	AttributeKeyNativeIBCDenom    = "native_ibc_denom"
 	AttributeKeyTotalUnbondAmount = "total_unbond_amount"
+	AttributeKeySweptAmount       = "swept_amount"
 	AttributeKeyLSMTokenBaseDenom = "lsm_token_base_denom"
 	AttributeKeyNativeAmount      = "native_amount"
 	AttributeKeyStTokenAmount     = "sttoken_amount"


### PR DESCRIPTION
## Context
The original redemption sweep code was severely under-tested - I actually recall there being an open ticket to add coverage that's been around since launch.

I had to refactor the function in order to wrap it in the temporary cache context function, so I took it as an opportunity to clean it up a bit and add more test coverage.

**I'd recommend scrolling commit by commit - nothing logical should have changed**.

## Changelog
* Refactored `SweepAllUnbondedTokensForHostZone` into a function that returns an error (so that it can be wrapped in the cache context)
* Split the start of `SweepAllUnbondedTokensForHostZone` into a sub function called `GetTotalRedemptionSweepAmountAndRecordIds`
* Added event emission to redemption sweep
* Added unit tests for each function