### PR TITLE
Adjusting upgrade handler for registering stTokens to whitelist

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -168,6 +168,7 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 		v13.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
+			app.StakeibcKeeper,
 		),
 	)
 

--- a/app/upgrades/v13/upgrades.go
+++ b/app/upgrades/v13/upgrades.go
@@ -4,6 +4,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	stakeibckeeper "github.com/Stride-Labs/stride/v12/x/stakeibc/keeper"
+	stakeibctypes "github.com/Stride-Labs/stride/v12/x/stakeibc/types"
 )
 
 var (
@@ -14,9 +17,19 @@ var (
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
+	stakeibcKeeper stakeibckeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v13...")
+		hostZones := stakeibcKeeper.GetAllHostZone(ctx)
+		allDenoms := []string{}
+
+		// get all stToken denoms
+		for _, zone := range hostZones {
+			allDenoms = append(allDenoms, stakeibctypes.StAssetDenomFromHostZoneDenom(zone.HostDenom))
+		}
+
+		stakeibcKeeper.RegisterStTokenDenomsToWhitelist(ctx, allDenoms)
 		return mm.RunMigrations(ctx, configurator, vm)
 	}
 }

--- a/app/upgrades/v13/upgrades.go
+++ b/app/upgrades/v13/upgrades.go
@@ -21,6 +21,8 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v13...")
+
+		ctx.Logger().Info("Registering stTokens to consumer reward denom whitelist...")
 		hostZones := stakeibcKeeper.GetAllHostZone(ctx)
 		allDenoms := []string{}
 


### PR DESCRIPTION
## Brief Changelog
  - *Updated v13 upgrade handler for registering missing stTokens to the reward denom whitelist*

## Author's Checklist
- [x] Confirmed that reward denoms were registered properly after upgrading to v13.