### PR TITLE
Removed consumer param store updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 4. Whitelist missing param keys and register stTokens as consumer fees ([#881](https://github.com/Stride-Labs/stride/pull/881)) 
 5. Add v13 Upgrade Handler ([#886](https://github.com/Stride-Labs/stride/pull/886)) 
 6. Change paths to point towards v13 ([#891](https://github.com/Stride-Labs/stride/pull/888))
+7. Removed consumer param store updates ([#892](https://github.com/Stride-Labs/stride/pull/892))
 
 ### Off-Chain changes
 1. Add `build-linux` command ([#859](https://github.com/Stride-Labs/stride/pull/859))

--- a/app/upgrades/v13/README.md
+++ b/app/upgrades/v13/README.md
@@ -5,3 +5,4 @@
 4. Whitelist missing param keys and register stTokens as consumer fees ([#881](https://github.com/Stride-Labs/stride/pull/881)) 
 5. Add v13 Upgrade Handler ([#886](https://github.com/Stride-Labs/stride/pull/886)) 
 6. Change paths to point towards v13 ([#891](https://github.com/Stride-Labs/stride/pull/888))
+7. Removed consumer param store updates ([#892](https://github.com/Stride-Labs/stride/pull/892))

--- a/app/upgrades/v13/upgrades.go
+++ b/app/upgrades/v13/upgrades.go
@@ -1,14 +1,11 @@
 package v13
 
 import (
-	errorsmod "cosmossdk.io/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	stakeibckeeper "github.com/Stride-Labs/stride/v13/x/stakeibc/keeper"
-	stakeibctypes "github.com/Stride-Labs/stride/v13/x/stakeibc/types"
 )
 
 var (
@@ -23,21 +20,6 @@ func CreateUpgradeHandler(
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v13...")
-
-		ctx.Logger().Info("Registering stTokens to consumer reward denom whitelist...")
-		hostZones := stakeibcKeeper.GetAllHostZone(ctx)
-		allDenoms := []string{}
-
-		// get all stToken denoms
-		for _, zone := range hostZones {
-			allDenoms = append(allDenoms, stakeibctypes.StAssetDenomFromHostZoneDenom(zone.HostDenom))
-		}
-
-		err := stakeibcKeeper.RegisterStTokenDenomsToWhitelist(ctx, allDenoms)
-		if err != nil {
-			return nil, errorsmod.Wrapf(err, "unable to register stTokens to whitelist")
-		}
-
 		return mm.RunMigrations(ctx, configurator, vm)
 	}
 }

--- a/app/upgrades/v13/upgrades_test.go
+++ b/app/upgrades/v13/upgrades_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Stride-Labs/stride/v13/app/apptesting"
-	stakeibctypes "github.com/Stride-Labs/stride/v13/x/stakeibc/types"
 )
 
 type UpgradeTestSuite struct {
@@ -23,27 +22,5 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (s *UpgradeTestSuite) TestUpgrade() {
 	dummyUpgradeHeight := int64(5)
-
-	// Clear the reward denoms in the consumer keeper
-	consumerParams := s.App.ConsumerKeeper.GetConsumerParams(s.Ctx)
-	consumerParams.RewardDenoms = []string{"denomA", "denomB"}
-	s.App.ConsumerKeeper.SetParams(s.Ctx, consumerParams)
-
-	// Add host zones
-	hostZones := []stakeibctypes.HostZone{
-		{ChainId: "cosmoshub-4", HostDenom: "uatom"},
-		{ChainId: "osmosis-1", HostDenom: "uosmo"},
-		{ChainId: "juno-1", HostDenom: "ujuno"},
-	}
-	for _, hostZone := range hostZones {
-		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
-	}
-
-	// Submit the upgrade which should register the new host denoms
 	s.ConfirmUpgradeSucceededs("v13", dummyUpgradeHeight)
-
-	// Confirm the new reward denoms were registered
-	expectedRewardDenoms := []string{"denomA", "denomB", "stuatom", "stuosmo", "stujuno"}
-	consumerParams = s.App.ConsumerKeeper.GetConsumerParams(s.Ctx)
-	s.Require().ElementsMatch(expectedRewardDenoms, consumerParams.RewardDenoms)
 }

--- a/x/stakeibc/keeper/consumer_test.go
+++ b/x/stakeibc/keeper/consumer_test.go
@@ -12,8 +12,13 @@ func (s *KeeperTestSuite) TestRegisterStTokenDenomsToWhitelist() {
 	_, err := s.GetMsgServer().RegisterHostZone(sdk.WrapSDKContext(s.Ctx), &tc.validMsg)
 	s.Require().NoError(err, "able to successfully register host zone")
 
-	// RegisterHostZone should have already registered stToken to consumer reward denom whitelist
+	// TODO: Remove this change after ICS consumer keeper validation is fixed
 	params := s.App.ConsumerKeeper.GetConsumerParams(s.Ctx)
+	params.RewardDenoms = []string{"stuatom"}
+	s.App.ConsumerKeeper.SetParams(s.Ctx, params)
+
+	// RegisterHostZone should have already registered stToken to consumer reward denom whitelist
+	params = s.App.ConsumerKeeper.GetConsumerParams(s.Ctx)
 	stDenom := stakeibctypes.StAssetDenomFromHostZoneDenom(tc.validMsg.HostDenom)
 	expectedWhitelist := []string{stDenom}
 	s.Require().Equal([]string{stDenom}, params.RewardDenoms)

--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -186,15 +186,6 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	}
 	k.RecordsKeeper.AppendDepositRecord(ctx, depositRecord)
 
-	// register stToken to consumer reward denom whitelist so that
-	// stToken rewards can be distributed to provider validators
-	err = k.RegisterStTokenDenomsToWhitelist(ctx, []string{types.StAssetDenomFromHostZoneDenom(zone.HostDenom)})
-	if err != nil {
-		errMsg := fmt.Sprintf("unable to register reward denom, err: %s", err.Error())
-		k.Logger(ctx).Error(errMsg)
-		return nil, errorsmod.Wrapf(types.ErrFailedToRegisterHostZone, errMsg)
-	}
-
 	// emit events
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
The CCV paramstore runs a bech32 address verification on the provider fee pool address; however, it tries to verify the address using the consumer chain's address prefix, causing the validation to fail (i.e. it tries to verify a `cosmos` address by checking if it has a `stride` prefix`. This should be resolved in ICS before the consumer keeper can safely set params. As a result, this PR removes all occurrences of `ConsumerKeeper.SetParams`. 

## Brief Changelog
* Removed calls to `RegisterStTokenDenomsToWhitelist` in upgrade handler and host zone registration (`RegisterStTokenDenomsToWhitelist` calls `ConsumerKeeper.SetParams`)

## Upgrades Tests
```bash
integration_tests.bats
 ✓ [INTEGRATION-BASIC-GAIA] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mint and transfer
 ✓ [INTEGRATION-BASIC-GAIA] packet forwarding automatically liquid stakes
 ✓ [INTEGRATION-BASIC-GAIA] tokens on GAIA were staked
 ✓ [INTEGRATION-BASIC-GAIA] redemption works
 ✓ [INTEGRATION-BASIC-GAIA] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being reinvested, exchange rate updating
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being distributed to stakers

// upgrade passed

integration_tests.bats
 ✓ [INTEGRATION-BASIC-EVMOS] host zones successfully registered
 ✓ [INTEGRATION-BASIC-EVMOS] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-EVMOS] liquid stake mint and transfer
 - [INTEGRATION-BASIC-EVMOS] packet forwarding automatically liquid stakes (skipped: Packet forward liquid stake test is only run on GAIA and HOST)
 ✓ [INTEGRATION-BASIC-EVMOS] tokens on EVMOS were staked
 ✓ [INTEGRATION-BASIC-EVMOS] redemption works
 ✓ [INTEGRATION-BASIC-EVMOS] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-EVMOS] rewards are being reinvested, exchange rate updating
 ✓ [INTEGRATION-BASIC-EVMOS] rewards are being distributed to stakers

integration_tests.bats
 ✓ [INTEGRATION-BASIC-HOST] host zones successfully registered
 ✓ [INTEGRATION-BASIC-HOST] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-HOST] liquid stake mint and transfer
 ✓ [INTEGRATION-BASIC-HOST] packet forwarding automatically liquid stakes
 ✓ [INTEGRATION-BASIC-HOST] tokens on HOST were staked
 ✓ [INTEGRATION-BASIC-HOST] redemption works
 ✓ [INTEGRATION-BASIC-HOST] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-HOST] rewards are being reinvested, exchange rate updating
 ✓ [INTEGRATION-BASIC-HOST] rewards are being distributed to stakers
```
