### PR TITLE
statesync for debugging

### DIFF
--- a/scripts/statesync.bash
+++ b/scripts/statesync.bash
@@ -15,12 +15,9 @@ set -uxe
 export GOPATH=~/go
 export PATH=$PATH:~/go/bin
 
-# Install with pebbledb
-go mod edit -replace github.com/tendermint/tm-db=github.com/baabeetaa/tm-db@pebble
-go mod tidy
-go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -X github.com/tendermint/tm-db.ForceSync=1' -tags pebbledb ./...
 
-# go install ./...
+go install ./...
+
 
 # NOTE: ABOVE YOU CAN USE ALTERNATIVE DATABASES, HERE ARE THE EXACT COMMANDS
 # go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb' -tags rocksdb ./...
@@ -56,4 +53,4 @@ STRIDED_P2P_SEEDS=$(curl -s https://raw.githubusercontent.com/cosmos/chain-regis
 export STRIDED_P2P_SEEDS
 
 # Start chain.
-strided start --x-crisis-skip-assert-invariants --db_backend pebbledb
+strided start --x-crisis-skip-assert-invariants 


### PR DESCRIPTION
I find that it helps to get teams on the same page for debugging, if they 
can easily sync a trustworthy version of the node quickly.

Therefore, here's a state sync script :).

Should take 10-15m to sync. 

Please don't update this branch.  It is v12.1.0 + statesync
