### PR TITLE
fix the integration testing framework for devs not using english-based systems. 

### DIFF
--- a/dockernet/config.sh
+++ b/dockernet/config.sh
@@ -3,6 +3,8 @@
 set -eu
 DOCKERNET_HOME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+LC_NUMERIC=en_US.UTF-8
+
 STATE=$DOCKERNET_HOME/state
 LOGS=$DOCKERNET_HOME/logs
 UPGRADES=$DOCKERNET_HOME/upgrades


### PR DESCRIPTION
## Context and purpose of the change

This pull request fixes the testing framework for devs not using english-based systems. 
An integration test failed when the framework is used with the local numerical formatting variable not set to en_US. 
This PR adds and set explicitly the LC_NUMERIC variable to overcome this issue.

## Brief Changelog

Set `LC_NUMERIC=en_US.UTF-8` in dockernet/config.sh so this is used by `integration_tests.bats`.


## Author's Checklist

I have...

- [x ] Run and PASSED locally all GAIA integration tests
- [ ] If the change is contentful, I either:
    - [ ] Added a new unit test OR 
    - [ ] Added test cases to existing unit tests
- [ ] OR this change is a trivial rework / code cleanup without any test coverage

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [ ] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
