### PR TITLE
Use detokenization amount from tx response

### DIFF
--- a/x/stakeibc/keeper/icacallbacks_detokenize.go
+++ b/x/stakeibc/keeper/icacallbacks_detokenize.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -61,8 +63,21 @@ func (k Keeper) DetokenizeCallback(ctx sdk.Context, packet channeltypes.Packet, 
 	// If the ICA succeeded, remove the token deposit
 	k.RecordsKeeper.RemoveLSMTokenDeposit(ctx, deposit.ChainId, deposit.Denom)
 
+	// Determine the actual number of tokens that were turned to native stake
+	// (this can be slightly different than the amount initiated in the redeem tokens tx
+	// due a precision error in the SDK)
+	if len(ackResponse.MsgResponses) != 1 {
+		return fmt.Errorf("Invalid number of messages (%d) in detokenize response: %v",
+			len(ackResponse.MsgResponses), ackResponse.MsgResponses)
+	}
+	var detokenizeResponse types.MsgRedeemTokensForSharesResponse
+	if err := proto.Unmarshal(ackResponse.MsgResponses[0], &detokenizeResponse); err != nil {
+		return err
+	}
+	stakeAmount := detokenizeResponse.Amount.Amount
+
 	// Update delegation on the host zone and validator
-	err := k.AddDelegationToValidator(ctx, &hostZone, deposit.ValidatorAddress, deposit.Amount, ICACallbackID_Detokenize)
+	err := k.AddDelegationToValidator(ctx, &hostZone, deposit.ValidatorAddress, stakeAmount, ICACallbackID_Detokenize)
 	if err != nil {
 		return err
 	}

--- a/x/stakeibc/keeper/icacallbacks_detokenize_test.go
+++ b/x/stakeibc/keeper/icacallbacks_detokenize_test.go
@@ -2,10 +2,12 @@ package keeper_test
 
 import (
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
 	icacallbackstypes "github.com/Stride-Labs/stride/v14/x/icacallbacks/types"
+	icacallbacktypes "github.com/Stride-Labs/stride/v14/x/icacallbacks/types"
 	recordstypes "github.com/Stride-Labs/stride/v14/x/records/types"
 	"github.com/Stride-Labs/stride/v14/x/stakeibc/types"
 )
@@ -14,18 +16,20 @@ type DetokenizeCallbackTestCase struct {
 	callbackBz                  []byte
 	expectedValidatorDelegation int64
 	expectedTotalDelegation     int64
+	ackResponse                 *icacallbacktypes.AcknowledgementResponse
 }
 
 // Helper function to setup the detokenize ICA callback test
 // Returns the serialized callback args which will be an input parameter
 // to the callback
-func (s *KeeperTestSuite) SetupTestDetokenizeCallback() DetokenizeCallbackTestCase {
+func (s *KeeperTestSuite) SetupTestDetokenizeCallback(ackStatus icacallbacktypes.AckResponseStatus) DetokenizeCallbackTestCase {
 	stakeAmount := sdkmath.NewInt(1000)
+	detokenizedAmount := sdkmath.NewInt(999) // mimics SDK rounding bug
 	initialValidatorDelegation := sdkmath.NewInt(5000)
 	initialTotalDelegation := sdkmath.NewInt(10000)
 
-	expectedValidatorDelegation := int64(6000)
-	expectedTotalDelegation := int64(11000)
+	expectedValidatorDelegation := int64(5999) // 5000 + 999
+	expectedTotalDelegation := int64(10999)    // 10000 + 999
 
 	// Store host zone with validator
 	hostZone := types.HostZone{
@@ -55,21 +59,32 @@ func (s *KeeperTestSuite) SetupTestDetokenizeCallback() DetokenizeCallbackTestCa
 	})
 	s.Require().NoError(err, "no error expected when marshalling callback args")
 
+	// Message response includes the redeemed amount
+	detokenizeResponse := types.MsgRedeemTokensForSharesResponse{
+		Amount: sdk.NewCoin(Atom, detokenizedAmount),
+	}
+	detokenizeResponseBz, err := proto.Marshal(&detokenizeResponse)
+	s.Require().NoError(err, "no error expected when marshaling detokenize response")
+
+	// Build the ack response with the detokenized amount and ack status
+	ackResponse := &icacallbacktypes.AcknowledgementResponse{
+		Status:       ackStatus,
+		MsgResponses: [][]byte{detokenizeResponseBz},
+	}
+
 	return DetokenizeCallbackTestCase{
 		callbackBz:                  callbackBz,
 		expectedValidatorDelegation: expectedValidatorDelegation,
 		expectedTotalDelegation:     expectedTotalDelegation,
+		ackResponse:                 ackResponse,
 	}
 }
 
 func (s *KeeperTestSuite) TestDetokenizeCallback_Successful() {
-	tc := s.SetupTestDetokenizeCallback()
+	tc := s.SetupTestDetokenizeCallback(icacallbackstypes.AckResponseStatus_SUCCESS)
 
 	// Call the callback with a successful response
-	ackSuccess := &icacallbackstypes.AcknowledgementResponse{
-		Status: icacallbackstypes.AckResponseStatus_SUCCESS,
-	}
-	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, ackSuccess, tc.callbackBz)
+	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, tc.ackResponse, tc.callbackBz)
 	s.Require().NoError(err, "no error expected during callback")
 
 	// Check that the deposit was removed
@@ -87,19 +102,16 @@ func (s *KeeperTestSuite) TestDetokenizeCallback_Successful() {
 }
 
 func (s *KeeperTestSuite) TestDetokenizeCallback_InvalidCallbackArgs() {
-	s.SetupTestDetokenizeCallback()
+	tc := s.SetupTestDetokenizeCallback(icacallbackstypes.AckResponseStatus_SUCCESS)
 
 	// Call the callback with a successful ack, but invalid callback args
 	invalidCallbackArgs := []byte{1, 2, 3}
-	ackSuccess := &icacallbackstypes.AcknowledgementResponse{
-		Status: icacallbackstypes.AckResponseStatus_SUCCESS,
-	}
-	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, ackSuccess, invalidCallbackArgs)
+	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, tc.ackResponse, invalidCallbackArgs)
 	s.Require().ErrorContains(err, "unable to unmarshal detokenize callback")
 }
 
 func (s *KeeperTestSuite) TestDetokenizeCallback_HostNotFound() {
-	s.SetupTestDetokenizeCallback()
+	tc := s.SetupTestDetokenizeCallback(icacallbackstypes.AckResponseStatus_SUCCESS)
 
 	// Call the callback with a host zone that does not exist - it should fail
 	invalidCallbackArgs, err := proto.Marshal(&types.DetokenizeSharesCallback{
@@ -109,21 +121,15 @@ func (s *KeeperTestSuite) TestDetokenizeCallback_HostNotFound() {
 	})
 	s.Require().NoError(err, "no error expected when marshalling callback data")
 
-	ackSuccess := &icacallbackstypes.AcknowledgementResponse{
-		Status: icacallbackstypes.AckResponseStatus_SUCCESS,
-	}
-	err = s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, ackSuccess, invalidCallbackArgs)
+	err = s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, tc.ackResponse, invalidCallbackArgs)
 	s.Require().ErrorContains(err, "Host zone not found")
 }
 
 func (s *KeeperTestSuite) TestDetokenizeCallback_AckTimeout() {
-	tc := s.SetupTestDetokenizeCallback()
+	tc := s.SetupTestDetokenizeCallback(icacallbackstypes.AckResponseStatus_TIMEOUT)
 
 	// Call the callback with a timed-out response
-	ackTimeout := &icacallbackstypes.AcknowledgementResponse{
-		Status: icacallbackstypes.AckResponseStatus_TIMEOUT,
-	}
-	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, ackTimeout, tc.callbackBz)
+	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, tc.ackResponse, tc.callbackBz)
 	s.Require().NoError(err, "no error expected during callback")
 
 	// The deposit should still be there in status IN_PROGRESS
@@ -138,13 +144,10 @@ func (s *KeeperTestSuite) TestDetokenizeCallback_AckTimeout() {
 }
 
 func (s *KeeperTestSuite) TestDetokenizeCallback_AckFailure() {
-	tc := s.SetupTestDetokenizeCallback()
+	tc := s.SetupTestDetokenizeCallback(icacallbackstypes.AckResponseStatus_FAILURE)
 
 	// Call the callback with an ack-failure response
-	ackFailure := &icacallbackstypes.AcknowledgementResponse{
-		Status: icacallbackstypes.AckResponseStatus_FAILURE,
-	}
-	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, ackFailure, tc.callbackBz)
+	err := s.App.StakeibcKeeper.DetokenizeCallback(s.Ctx, channeltypes.Packet{}, tc.ackResponse, tc.callbackBz)
 	s.Require().NoError(err, "no error expected during callback")
 
 	// The deposit status should be FAILED


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context 
Similar to unbondings, detokenization ICAs have the potential to return slightly less tokens than were specified in the tx due to rounding imprecision in the SDK (see #933 for more context). This can create a small difference in stride's internal record keeping (on the order of < 10uatom). 

However, the number of tokens that winds up being detokenized is part of the tx response, so we can just use that value instead, which will prevent the rounding imprecision from being reflected in record keeping.

## Brief Changelog
* Updated detokenize callback to use the response from the `RedeemTokensForShares` message

## Author's Checklist

I have...

- [ ] Run and PASSED locally all GAIA integration tests
- [ ] If the change is contentful, I either:
    - [X] Added a new unit test OR 
    - [ ] Added test cases to existing unit tests
- [ ] OR this change is a trivial rework / code cleanup without any test coverage

If skipped any of the tests above, explain.
<!-- *(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...* -->

## Integration Tests
```bash
integration_tests.bats
 ✓ [INTEGRATION-BASIC-GAIA] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer updates all balances
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mint and transfer
 ✓ [INTEGRATION-BASIC-GAIA] tokens on GAIA were staked
 ✓ [INTEGRATION-BASIC-GAIA] LSM liquid stake
 ✓ [INTEGRATION-BASIC-GAIA] LSM liquid stake with slash query
 ✓ [INTEGRATION-BASIC-GAIA] packet forwarding automatically liquid stakes
 ✓ [INTEGRATION-BASIC-GAIA] redemption works
 ✓ [INTEGRATION-BASIC-GAIA] claimed tokens are properly distributed
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being reinvested, exchange rate updating
 ✓ [INTEGRATION-BASIC-GAIA] rewards are being distributed to stakers
```


## Documentation and Release Note
  - [ ] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [ ] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
