### PR TITLE
whitelist ICA accounts from rate limit during host zone registration

### DIFF
--- a/x/stakeibc/ibc_middleware.go
+++ b/x/stakeibc/ibc_middleware.go
@@ -92,46 +92,46 @@ func (im IBCMiddleware) OnChanOpenAck(
 	ctx.Logger().Info(fmt.Sprintf("Found matching address for chain: %s, address %s, port %s", zoneInfo.ChainId, address, portID))
 
 	// addresses
-	withdrawalAddress, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_WITHDRAWAL))
+	withdrawalPortID, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_WITHDRAWAL))
 	if err != nil {
 		return err
 	}
-	feeAddress, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_FEE))
+	feePortID, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_FEE))
 	if err != nil {
 		return err
 	}
-	delegationAddress, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_DELEGATION))
+	delegationPortID, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_DELEGATION))
 	if err != nil {
 		return err
 	}
-	redemptionAddress, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_REDEMPTION))
+	redemptionPortID, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_REDEMPTION))
 	if err != nil {
 		return err
 	}
 	communityPoolDepositOwner := types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
-	communityPoolDepositAddress, err := icatypes.NewControllerPortID(communityPoolDepositOwner)
+	communityPoolDepositPortID, err := icatypes.NewControllerPortID(communityPoolDepositOwner)
 	if err != nil {
 		return err
 	}
 	communityPoolReturnOwner := types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_COMMUNITY_POOL_RETURN)
-	communityPoolReturnAddress, err := icatypes.NewControllerPortID(communityPoolReturnOwner)
+	communityPoolReturnPortID, err := icatypes.NewControllerPortID(communityPoolReturnOwner)
 	if err != nil {
 		return err
 	}
 
 	// Set ICA account addresses
 	switch {
-	case portID == withdrawalAddress:
+	case portID == withdrawalPortID:
 		zoneInfo.WithdrawalIcaAddress = address
-	case portID == feeAddress:
+	case portID == feePortID:
 		zoneInfo.FeeIcaAddress = address
-	case portID == delegationAddress:
+	case portID == delegationPortID:
 		zoneInfo.DelegationIcaAddress = address
-	case portID == redemptionAddress:
+	case portID == redemptionPortID:
 		zoneInfo.RedemptionIcaAddress = address
-	case portID == communityPoolDepositAddress:
+	case portID == communityPoolDepositPortID:
 		zoneInfo.CommunityPoolDepositIcaAddress = address
-	case portID == communityPoolReturnAddress:
+	case portID == communityPoolReturnPortID:
 		zoneInfo.CommunityPoolReturnIcaAddress = address
 	default:
 		ctx.Logger().Error(fmt.Sprintf("Missing portId: %s", portID))
@@ -139,7 +139,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 
 	// Once the delegation channel is registered, whitelist epochly transfers so they're not rate limited
 	// Epochly transfers go from the deposit address to the delegation address
-	if portID == delegationAddress {
+	if portID == delegationPortID {
 		im.keeper.RatelimitKeeper.SetWhitelistedAddressPair(ctx, ratelimittypes.WhitelistedAddressPair{
 			Sender:   zoneInfo.DepositAddress,
 			Receiver: zoneInfo.DelegationIcaAddress,
@@ -148,7 +148,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 
 	// Once the fee channel is registered, whitelist reward transfers so they're not rate limited
 	// Reward transfers go from the fee address to the reward collector
-	if portID == feeAddress {
+	if portID == feePortID {
 		rewardCollectorAddress := im.keeper.AccountKeeper.GetModuleAccount(ctx, types.RewardCollectorName).GetAddress()
 		im.keeper.RatelimitKeeper.SetWhitelistedAddressPair(ctx, ratelimittypes.WhitelistedAddressPair{
 			Sender:   zoneInfo.FeeIcaAddress,
@@ -158,7 +158,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 
 	// Once the community pool deposit ICA is registered, whitelist epochly community pool transfers
 	// from the deposit ICA to the community pool holding accounts
-	if portID == communityPoolDepositAddress {
+	if portID == communityPoolDepositPortID {
 		im.keeper.RatelimitKeeper.SetWhitelistedAddressPair(ctx, ratelimittypes.WhitelistedAddressPair{
 			Sender:   zoneInfo.CommunityPoolDepositIcaAddress,
 			Receiver: zoneInfo.CommunityPoolStakeHoldingAddress,
@@ -171,7 +171,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 
 	// Once the community pool return ICA is registered, whitelist epochly community pool transfers
 	// from the community pool stake holding account to the community pool return ICA
-	if portID == communityPoolReturnAddress {
+	if portID == communityPoolReturnPortID {
 		im.keeper.RatelimitKeeper.SetWhitelistedAddressPair(ctx, ratelimittypes.WhitelistedAddressPair{
 			Sender:   zoneInfo.CommunityPoolStakeHoldingAddress,
 			Receiver: zoneInfo.CommunityPoolReturnIcaAddress,

--- a/x/stakeibc/ibc_middleware.go
+++ b/x/stakeibc/ibc_middleware.go
@@ -91,7 +91,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 	}
 	ctx.Logger().Info(fmt.Sprintf("Found matching address for chain: %s, address %s, port %s", zoneInfo.ChainId, address, portID))
 
-	// addresses
+	// expected port IDs for each ICA account type
 	withdrawalPortID, err := icatypes.NewControllerPortID(types.FormatICAAccountOwner(hostChainId, types.ICAAccountType_WITHDRAWAL))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context and purpose of the change
Any epochly transfers between stride and host zones should be whtielisted so they don't trip the rate limit.

## Brief Changelog
* Added the following whitelisted address pairs
  * Deposit address (on stride) to delegation ICA (on host)
  * Fee ICA (on host) to reward collector (on stride)
  * Community pool deposit ICA (on host) to community pool stake holding address (on stride)
  * Community pool deposit ICA (on host) to community pool redeem holding address (on stride)
  * Community pool stake holding address (on stride) to community pool return ICA
* Fixed variable names
