### PR TITLE
remove stride address

### DIFF
--- a/x/autopilot/types/parser.go
+++ b/x/autopilot/types/parser.go
@@ -25,24 +25,49 @@ type ModuleRoutingInfo interface {
 	Validate() error
 }
 
+// NOTE: I removed StakeibcPacketMetadata from StakeibcPacketMetadata/ClaimPacketMetadata because it was
+// just being set to the receiver.
+// I'm not sure this was necessary for airdrop linking, but it was necessary for liquid stakes, because the
+// address that liquid stakes _must_ be the address that received tokens.
+// A cleaner design here would be to do something like PFM, which is
+// liquid_staking_address = hash(channel, sender)
+// This removes the need for a receiving address.
+// Tokens can be liquid staked via this protocol-owned address, which more clearly separates
+// concerns (random addresses can't receive tokens, then be forced to liquid stake, which is the case today).
+// The above isn't a big deal at face value - if you want to send someone an LST you can also do it using the bank module.
+// For liquid stake, this is straightforward - we can just use a bank send after the tokens have been liquid staked.
+
+// For liquid stake and forward, it is slightly more challenging, because if the IBC transfer fails, a fallback address on Stride
+// is required (and this might not happen immediately - it could happen in a timeout). Unfortunately, liquid stake and forward
+// re-introduces the PFM bug, because senders can no longer be trusted. Consider the following case:
+// - A on Evmos sends 10 EVMOS to C on Stride, to be forwarded to B on Osmosis
+// - 10 EVMOS -> 10 stEVMOS via B on Stride, IBC transferred to C on Osmosis with sender B
+// - solution: enforce B is the same address as A, so A = B = C and the sender is trusted
+// - drawback: doesn't work for chains with a different address derivition - the fallback address B
+// 				might not be accessible (low confidence)
+
+// Possible solutions
+// (1) Just make the sender hash(channel, sender) so it's unusable on the destination chain
+// 		pros: PFM-like solution, proven in prod
+// 		cons: more complex since we need a fallback if the IBC transfer fails
+// (2) Constrain the forwarding logic
+// 		(1) tokens can only be sent to/from Evmos on the canonical channel
+// 		(2) the receiver on Stride is overridden and set to the mechanical Stride address
+// 			- what if the IBC times out and the user needs to manually claim their tokens?
+// 			- we could design a retry mechanism (tx on Stride that anyone can call)
+
 // Packet metadata info specific to Stakeibc (e.g. 1-click liquid staking)
 type StakeibcPacketMetadata struct {
-	Action        string `json:"action"`
-	StrideAddress string
+	Action string `json:"action"`
 }
 
 // Packet metadata info specific to Claim (e.g. airdrops for non-118 coins)
 type ClaimPacketMetadata struct {
-	StrideAddress string
 }
 
 // Validate stakeibc packet metadata fields
 // including the stride address and action type
 func (m StakeibcPacketMetadata) Validate() error {
-	_, err := sdk.AccAddressFromBech32(m.StrideAddress)
-	if err != nil {
-		return err
-	}
 	if m.Action != "LiquidStake" {
 		return errorsmod.Wrapf(ErrUnsupportedStakeibcAction, "action %s is not supported", m.Action)
 	}
@@ -50,13 +75,8 @@ func (m StakeibcPacketMetadata) Validate() error {
 	return nil
 }
 
-// Validate claim packet metadata includes the stride address
+// Should we remove this struct?
 func (m ClaimPacketMetadata) Validate() error {
-	_, err := sdk.AccAddressFromBech32(m.StrideAddress)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -89,13 +109,11 @@ func ParsePacketMetadata(metadata string) (*PacketForwardMetadata, error) {
 	var routingInfo ModuleRoutingInfo
 	if raw.Autopilot.Stakeibc != nil {
 		// override the stride address with the receiver address
-		raw.Autopilot.Stakeibc.StrideAddress = raw.Autopilot.Receiver
 		moduleCount++
 		routingInfo = *raw.Autopilot.Stakeibc
 	}
 	if raw.Autopilot.Claim != nil {
 		// override the stride address with the receiver address
-		raw.Autopilot.Claim.StrideAddress = raw.Autopilot.Receiver
 		moduleCount++
 		routingInfo = *raw.Autopilot.Claim
 	}


### PR DESCRIPTION
## Context and purpose of the change

Removes the unused `StrideAddress` (this was just being set to receiver).


## Brief Changelog
* rename `data` -> `fungibleTokenPacketData`
* remove code related to `StrideAddress` in `x/autopilot/types/parser.go`
* use `fungibleTokenPacketData.Receiver` where `packetMetadata.StrideAddress` was previously used in both airdrop address linking and autopilot liquid staking 

## TODO
* Run integration tests for both airdrop address linking and autopilot liquid staking