### PR TITLE
reward converter - add trade route ID to portId

### DIFF
--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -231,7 +231,10 @@ func (s *AppTestHelper) CreateICAChannel(owner string) (channelID, portID string
 	_, transferChannelExists := s.App.IBCKeeper.ChannelKeeper.GetChannel(s.Ctx, ibctesting.TransferPort, ibctesting.FirstChannelID)
 	if !transferChannelExists {
 		ownerSplit := strings.Split(owner, ".")
-		s.Require().Equal(2, len(ownerSplit), "owner should be of the form: {HostZone}.{AccountName}")
+		isHostZoneICA := len(ownerSplit) == 2
+		isTradeRouteICA := len(ownerSplit) == 3
+		s.Require().True(isHostZoneICA || isTradeRouteICA,
+			"owner should be either of the form: {chainId}.{AccountName} or {chainId}.{rewarDenom}-{hostDenom}.{accountName}")
 
 		hostChainID := ownerSplit[0]
 		s.CreateTransferChannel(hostChainID)

--- a/x/stakeibc/keeper/ibc.go
+++ b/x/stakeibc/keeper/ibc.go
@@ -57,32 +57,32 @@ func (k Keeper) StoreHostZoneIcaAddress(ctx sdk.Context, chainId, portId, addres
 	}
 
 	// expected port IDs for each ICA account type
-	delegationOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_DELEGATION)
+	delegationOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_DELEGATION)
 	delegationPortID, err := icatypes.NewControllerPortID(delegationOwner)
 	if err != nil {
 		return err
 	}
-	withdrawalOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_WITHDRAWAL)
+	withdrawalOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_WITHDRAWAL)
 	withdrawalPortID, err := icatypes.NewControllerPortID(withdrawalOwner)
 	if err != nil {
 		return err
 	}
-	feeOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_FEE)
+	feeOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_FEE)
 	feePortID, err := icatypes.NewControllerPortID(feeOwner)
 	if err != nil {
 		return err
 	}
-	redemptionOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_REDEMPTION)
+	redemptionOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_REDEMPTION)
 	redemptionPortID, err := icatypes.NewControllerPortID(redemptionOwner)
 	if err != nil {
 		return err
 	}
-	communityPoolDepositOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
+	communityPoolDepositOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
 	communityPoolDepositPortID, err := icatypes.NewControllerPortID(communityPoolDepositOwner)
 	if err != nil {
 		return err
 	}
-	communityPoolReturnOwner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_RETURN)
+	communityPoolReturnOwner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_RETURN)
 	communityPoolReturnPortID, err := icatypes.NewControllerPortID(communityPoolReturnOwner)
 	if err != nil {
 		return err

--- a/x/stakeibc/keeper/ibc_test.go
+++ b/x/stakeibc/keeper/ibc_test.go
@@ -40,7 +40,7 @@ func (s *KeeperTestSuite) TestOnChanOpenAck() {
 	})
 
 	// Create the ICA channels for both the delegation and trade accounts
-	delegationOwner := types.FormatICAAccountOwner(delegationChainId, types.ICAAccountType_DELEGATION)
+	delegationOwner := types.FormatHostZoneICAOwner(delegationChainId, types.ICAAccountType_DELEGATION)
 	delegationPortId, _ := icatypes.NewControllerPortID(delegationOwner)
 
 	tradeOwner := types.FormatTradeRouteICAOwner(tradeChainId, RewardDenom, HostDenom, types.ICAAccountType_CONVERTER_TRADE)
@@ -189,7 +189,7 @@ func (s *KeeperTestSuite) TestStoreHostZoneIcaAddress() {
 		// If the portId is -1, pass a non-ica port
 		portId := "not-ica-port"
 		if accountType != -1 {
-			owner := types.FormatICAAccountOwner(HostChainId, accountType)
+			owner := types.FormatHostZoneICAOwner(HostChainId, accountType)
 			portId, _ = icatypes.NewControllerPortID(owner)
 		}
 

--- a/x/stakeibc/keeper/ibc_test.go
+++ b/x/stakeibc/keeper/ibc_test.go
@@ -35,6 +35,7 @@ func (s *KeeperTestSuite) TestOnChanOpenAck() {
 		HostDenomOnHostZone:     HostDenom,
 		TradeAccount: types.ICAAccount{
 			ChainId: tradeChainId,
+			Type:    types.ICAAccountType_CONVERTER_TRADE,
 		},
 	})
 
@@ -42,7 +43,7 @@ func (s *KeeperTestSuite) TestOnChanOpenAck() {
 	delegationOwner := types.FormatICAAccountOwner(delegationChainId, types.ICAAccountType_DELEGATION)
 	delegationPortId, _ := icatypes.NewControllerPortID(delegationOwner)
 
-	tradeOwner := types.FormatICAAccountOwner(tradeChainId, types.ICAAccountType_CONVERTER_TRADE)
+	tradeOwner := types.FormatTradeRouteICAOwner(tradeChainId, RewardDenom, HostDenom, types.ICAAccountType_CONVERTER_TRADE)
 	tradePortId, _ := icatypes.NewControllerPortID(tradeOwner)
 
 	// Mock out an ICA address for each
@@ -247,9 +248,11 @@ func (s *KeeperTestSuite) TestStoreTradeRouteIcaAddress() {
 		HostDenomOnHostZone:     HostDenom,
 		RewardAccount: types.ICAAccount{
 			ChainId: HostChainId,
+			Type:    types.ICAAccountType_CONVERTER_UNWIND,
 		},
 		TradeAccount: types.ICAAccount{
 			ChainId: HostChainId,
+			Type:    types.ICAAccountType_CONVERTER_TRADE,
 		},
 	}
 
@@ -261,7 +264,7 @@ func (s *KeeperTestSuite) TestStoreTradeRouteIcaAddress() {
 		// If the portId is -1, pass a non-ica port
 		portId := "not-ica-port"
 		if accountType != -1 {
-			owner := types.FormatICAAccountOwner(HostChainId, accountType)
+			owner := types.FormatTradeRouteICAOwner(HostChainId, RewardDenom, HostDenom, accountType)
 			portId, _ = icatypes.NewControllerPortID(owner)
 		}
 
@@ -277,7 +280,7 @@ func (s *KeeperTestSuite) TestStoreTradeRouteIcaAddress() {
 
 	// Check with a matching port, but no matching chainId
 	accountType := types.ICAAccountType_CONVERTER_TRADE
-	owner := types.FormatICAAccountOwner(HostChainId, accountType)
+	owner := types.FormatTradeRouteICAOwner(HostChainId, RewardDenom, HostDenom, accountType)
 	portId, _ := icatypes.NewControllerPortID(owner)
 	address := accountType.String()
 

--- a/x/stakeibc/keeper/lsm.go
+++ b/x/stakeibc/keeper/lsm.go
@@ -339,7 +339,7 @@ func (k Keeper) DetokenizeAllLSMDeposits(ctx sdk.Context) {
 	// Submit detokenization ICAs for each active host zone
 	for _, hostZone := range k.GetAllActiveHostZone(ctx) {
 		// Get the host zone's delegation ICA portID
-		delegationICAOwner := types.FormatICAAccountOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
+		delegationICAOwner := types.FormatHostZoneICAOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
 		delegationICAPortID, err := icatypes.NewControllerPortID(delegationICAOwner)
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to get delegation port ID for %s: %s", hostZone.ChainId, err))

--- a/x/stakeibc/keeper/lsm_test.go
+++ b/x/stakeibc/keeper/lsm_test.go
@@ -582,7 +582,7 @@ func (s *KeeperTestSuite) TestTransferAllLSMDeposits() {
 
 func (s *KeeperTestSuite) TestDetokenizeLSMDeposit() {
 	// Create the delegation ICA
-	owner := types.FormatICAAccountOwner(HostChainId, types.ICAAccountType_DELEGATION)
+	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_DELEGATION)
 	s.CreateICAChannel(owner)
 	portId, err := icatypes.NewControllerPortID(owner)
 	s.Require().NoError(err, "no error expected when formatting portId")
@@ -649,7 +649,7 @@ func (s *KeeperTestSuite) TestDetokenizeLSMDeposit() {
 
 func (s *KeeperTestSuite) TestDetokenizeAllLSMDeposits() {
 	// Create an open delegation ICA channel
-	owner := types.FormatICAAccountOwner(HostChainId, types.ICAAccountType_DELEGATION)
+	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_DELEGATION)
 	s.CreateICAChannel(owner)
 	portId, err := icatypes.NewControllerPortID(owner)
 	s.Require().NoError(err, "no error expected when formatting portId")

--- a/x/stakeibc/keeper/msg_server_create_trade_route.go
+++ b/x/stakeibc/keeper/msg_server_create_trade_route.go
@@ -165,7 +165,7 @@ func (k Keeper) RegisterTradeRouteICAAccount(
 	}
 	counterpartyConnectionId := connection.Counterparty.ConnectionId
 
-	// Build the appVersion with the counterparty connection ID
+	// Build the appVersion, owner, and portId needed for registration
 	appVersion := string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{
 		Version:                icatypes.Version,
 		ControllerConnectionId: connectionId,
@@ -173,17 +173,17 @@ func (k Keeper) RegisterTradeRouteICAAccount(
 		Encoding:               icatypes.EncodingProtobuf,
 		TxType:                 icatypes.TxTypeSDKMultiMsg,
 	}))
+	owner := types.FormatTradeRouteICAOwnerFromRouteId(chainId, tradeRouteId, icaAccountType)
+	portID, err := icatypes.NewControllerPortID(owner)
+	if err != nil {
+		return account, err
+	}
 
-	// Create the associate ICAAccount object, and determine the owner and portId
+	// Create the associate ICAAccount object
 	account = types.ICAAccount{
 		ChainId:      chainId,
 		Type:         icaAccountType,
 		ConnectionId: connectionId,
-	}
-	owner := types.FormatTradeRouteICAOwnerFromAccount(tradeRouteId, account)
-	portID, err := icatypes.NewControllerPortID(owner)
-	if err != nil {
-		return account, err
 	}
 
 	// Check if an ICA account has already been created

--- a/x/stakeibc/keeper/msg_server_create_trade_route.go
+++ b/x/stakeibc/keeper/msg_server_create_trade_route.go
@@ -79,7 +79,7 @@ func (ms msgServer) CreateTradeRoute(goCtx context.Context, msg *types.MsgCreate
 	}
 
 	// Register the new ICA accounts
-	tradeRouteId := types.GetTradeRouteId(msg.RewardDenomOnReward, msg.RewardDenomOnHost)
+	tradeRouteId := types.GetTradeRouteId(msg.RewardDenomOnReward, msg.HostDenomOnHost)
 	hostICA := types.ICAAccount{
 		ChainId:      msg.HostChainId,
 		Type:         types.ICAAccountType_WITHDRAWAL,

--- a/x/stakeibc/keeper/msg_server_register_host_zone.go
+++ b/x/stakeibc/keeper/msg_server_register_host_zone.go
@@ -128,7 +128,7 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 
 	// generate delegate account
 	// NOTE: in the future, if we implement proxy governance, we'll need many more delegate accounts
-	delegateAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_DELEGATION)
+	delegateAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_DELEGATION)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, delegateAccount, appVersion); err != nil {
 		errMsg := fmt.Sprintf("unable to register delegation account, err: %s", err.Error())
 		k.Logger(ctx).Error(errMsg)
@@ -136,7 +136,7 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	}
 
 	// generate fee account
-	feeAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_FEE)
+	feeAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_FEE)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, feeAccount, appVersion); err != nil {
 		errMsg := fmt.Sprintf("unable to register fee account, err: %s", err.Error())
 		k.Logger(ctx).Error(errMsg)
@@ -144,7 +144,7 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	}
 
 	// generate withdrawal account
-	withdrawalAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_WITHDRAWAL)
+	withdrawalAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_WITHDRAWAL)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, withdrawalAccount, appVersion); err != nil {
 		errMsg := fmt.Sprintf("unable to register withdrawal account, err: %s", err.Error())
 		k.Logger(ctx).Error(errMsg)
@@ -152,7 +152,7 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	}
 
 	// generate redemption account
-	redemptionAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_REDEMPTION)
+	redemptionAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_REDEMPTION)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, redemptionAccount, appVersion); err != nil {
 		errMsg := fmt.Sprintf("unable to register redemption account, err: %s", err.Error())
 		k.Logger(ctx).Error(errMsg)
@@ -160,13 +160,13 @@ func (k msgServer) RegisterHostZone(goCtx context.Context, msg *types.MsgRegiste
 	}
 
 	// create community pool deposit account
-	communityPoolDepositAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
+	communityPoolDepositAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, communityPoolDepositAccount, appVersion); err != nil {
 		return nil, errorsmod.Wrapf(types.ErrFailedToRegisterHostZone, "failed to register community pool deposit ICA")
 	}
 
 	// create community pool return account
-	communityPoolReturnAccount := types.FormatICAAccountOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_RETURN)
+	communityPoolReturnAccount := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_RETURN)
 	if err := k.ICAControllerKeeper.RegisterInterchainAccount(ctx, zone.ConnectionId, communityPoolReturnAccount, appVersion); err != nil {
 		return nil, errorsmod.Wrapf(types.ErrFailedToRegisterHostZone, "failed to register community pool return ICA")
 	}

--- a/x/stakeibc/keeper/msg_server_restore_interchain_account.go
+++ b/x/stakeibc/keeper/msg_server_restore_interchain_account.go
@@ -33,7 +33,7 @@ func (k msgServer) RestoreInterchainAccount(goCtx context.Context, msg *types.Ms
 	counterpartyConnection := connectionEnd.Counterparty
 
 	// only allow restoring an account if it already exists
-	owner := types.FormatICAAccountOwner(msg.ChainId, msg.AccountType)
+	owner := types.FormatHostZoneICAOwner(msg.ChainId, msg.AccountType)
 	portID, err := icatypes.NewControllerPortID(owner)
 	if err != nil {
 		errMsg := fmt.Sprintf("could not create portID for ICA controller account address: %s", owner)

--- a/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -34,7 +34,7 @@ import (
 func (k Keeper) DelegateOnHost(ctx sdk.Context, hostZone types.HostZone, amt sdk.Coin, depositRecord recordstypes.DepositRecord) error {
 	// TODO: Remove this block and use connection-id from host zone
 	// the relevant ICA is the delegate account
-	owner := types.FormatICAAccountOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
+	owner := types.FormatHostZoneICAOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
 	portID, err := icatypes.NewControllerPortID(owner)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "%s has no associated portId", owner)
@@ -117,7 +117,7 @@ func (k Keeper) DelegateOnHost(ctx sdk.Context, hostZone types.HostZone, amt sdk
 func (k Keeper) SetWithdrawalAddressOnHost(ctx sdk.Context, hostZone types.HostZone) error {
 	// TODO: Remove this block and use connection-id from host zone
 	// The relevant ICA is the delegate account
-	owner := types.FormatICAAccountOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
+	owner := types.FormatHostZoneICAOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
 	portID, err := icatypes.NewControllerPortID(owner)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "%s has no associated portId", owner)
@@ -261,6 +261,7 @@ func (k Keeper) SubmitTxsEpoch(
 }
 
 // SubmitTxs submits an ICA transaction containing multiple messages
+// This function only supports messages to ICAs on the host zone
 func (k Keeper) SubmitTxs(
 	ctx sdk.Context,
 	connectionId string,
@@ -274,7 +275,7 @@ func (k Keeper) SubmitTxs(
 	if err != nil {
 		return 0, err
 	}
-	owner := types.FormatICAAccountOwner(chainId, icaAccountType)
+	owner := types.FormatHostZoneICAOwner(chainId, icaAccountType)
 	portID, err := icatypes.NewControllerPortID(owner)
 	if err != nil {
 		return 0, err

--- a/x/stakeibc/keeper/msg_server_submit_tx.go
+++ b/x/stakeibc/keeper/msg_server_submit_tx.go
@@ -332,17 +332,10 @@ func (k Keeper) SubmitTxs(
 func (k Keeper) SubmitICATxWithoutCallback(
 	ctx sdk.Context,
 	connectionId string,
-	icaAccountType types.ICAAccountType,
+	icaAccountOwner string,
 	msgs []proto.Message,
 	timeoutTimestamp uint64,
 ) error {
-	// Compute useful connection properties to avoid needing them as params
-	chainId, err := k.GetChainIdFromConnectionId(ctx, connectionId)
-	if err != nil {
-		return err
-	}
-	owner := types.FormatICAAccountOwner(chainId, icaAccountType)
-
 	// Serialize tx messages
 	txBz, err := icatypes.SerializeCosmosTx(k.cdc, msgs)
 	if err != nil {
@@ -356,7 +349,7 @@ func (k Keeper) SubmitICATxWithoutCallback(
 
 	// Submit ICA, no need to store callback data or register callback function
 	icaMsgServer := icacontrollerkeeper.NewMsgServerImpl(&k.ICAControllerKeeper)
-	msgSendTx := icacontrollertypes.NewMsgSendTx(owner, connectionId, relativeTimeoutOffset, packetData)
+	msgSendTx := icacontrollertypes.NewMsgSendTx(icaAccountOwner, connectionId, relativeTimeoutOffset, packetData)
 	_, err = icaMsgServer.SendTx(ctx, msgSendTx)
 	if err != nil {
 		return errorsmod.Wrapf(err, "unable to send ICA tx")

--- a/x/stakeibc/keeper/reward_converter.go
+++ b/x/stakeibc/keeper/reward_converter.go
@@ -132,7 +132,8 @@ func (k Keeper) TransferRewardTokensHostToTrade(ctx sdk.Context, amount sdkmath.
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
 	hostZoneConnectionId := route.HostAccount.ConnectionId
-	err = k.SubmitICATxWithoutCallback(ctx, hostZoneConnectionId, types.ICAAccountType_WITHDRAWAL, msgs, msg.TimeoutTimestamp)
+	withdrawalOwner := route.HostAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	err = k.SubmitICATxWithoutCallback(ctx, hostZoneConnectionId, withdrawalOwner, msgs, msg.TimeoutTimestamp)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
 	}
@@ -173,7 +174,8 @@ func (k Keeper) TransferConvertedTokensTradeToHost(ctx sdk.Context, amount sdkma
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
 	tradeZoneConnectionId := route.TradeAccount.ConnectionId
-	err := k.SubmitICATxWithoutCallback(ctx, tradeZoneConnectionId, types.ICAAccountType_CONVERTER_TRADE, msgs, timeout)
+	tradeOwner := route.TradeAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	err := k.SubmitICATxWithoutCallback(ctx, tradeZoneConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
 	}
@@ -261,7 +263,8 @@ func (k Keeper) SwapRewardTokens(ctx sdk.Context, rewardAmount sdkmath.Int, rout
 	timeout := uint64(strideEpochTracker.NextEpochStartTime)
 
 	// Send the ICA tx to perform the swap on the tradeZone
-	err = k.SubmitICATxWithoutCallback(ctx, tradeIcaAccount.ConnectionId, types.ICAAccountType_CONVERTER_TRADE, msgs, timeout)
+	tradeOwner := route.TradeAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	err = k.SubmitICATxWithoutCallback(ctx, tradeIcaAccount.ConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx for the swap, Messages: %v", msgs)
 	}

--- a/x/stakeibc/keeper/reward_converter.go
+++ b/x/stakeibc/keeper/reward_converter.go
@@ -132,7 +132,7 @@ func (k Keeper) TransferRewardTokensHostToTrade(ctx sdk.Context, amount sdkmath.
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
 	hostZoneConnectionId := route.HostAccount.ConnectionId
-	withdrawalOwner := route.HostAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	withdrawalOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.HostAccount)
 	err = k.SubmitICATxWithoutCallback(ctx, hostZoneConnectionId, withdrawalOwner, msgs, msg.TimeoutTimestamp)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
@@ -174,7 +174,7 @@ func (k Keeper) TransferConvertedTokensTradeToHost(ctx sdk.Context, amount sdkma
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
 	tradeZoneConnectionId := route.TradeAccount.ConnectionId
-	tradeOwner := route.TradeAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	tradeOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.TradeAccount)
 	err := k.SubmitICATxWithoutCallback(ctx, tradeZoneConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
@@ -263,7 +263,7 @@ func (k Keeper) SwapRewardTokens(ctx sdk.Context, rewardAmount sdkmath.Int, rout
 	timeout := uint64(strideEpochTracker.NextEpochStartTime)
 
 	// Send the ICA tx to perform the swap on the tradeZone
-	tradeOwner := route.TradeAccount.FormatTradeRouteICAOwner(route.GetRouteId())
+	tradeOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.TradeAccount)
 	err = k.SubmitICATxWithoutCallback(ctx, tradeIcaAccount.ConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx for the swap, Messages: %v", msgs)

--- a/x/stakeibc/keeper/reward_converter.go
+++ b/x/stakeibc/keeper/reward_converter.go
@@ -131,9 +131,9 @@ func (k Keeper) TransferRewardTokensHostToTrade(ctx sdk.Context, amount sdkmath.
 		"Preparing MsgTransfer of %+v from %s to %s to %s", msg.Token, hostZoneId, rewardZoneId, tradeZoneId))
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
-	hostZoneConnectionId := route.HostAccount.ConnectionId
-	withdrawalOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.HostAccount)
-	err = k.SubmitICATxWithoutCallback(ctx, hostZoneConnectionId, withdrawalOwner, msgs, msg.TimeoutTimestamp)
+	hostAccount := route.HostAccount
+	withdrawalOwner := types.FormatTradeRouteICAOwnerFromRouteId(hostAccount.ChainId, route.GetRouteId(), hostAccount.Type)
+	err = k.SubmitICATxWithoutCallback(ctx, hostAccount.ConnectionId, withdrawalOwner, msgs, msg.TimeoutTimestamp)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
 	}
@@ -173,9 +173,9 @@ func (k Keeper) TransferConvertedTokensTradeToHost(ctx sdk.Context, amount sdkma
 		"Preparing MsgTransfer of %+v from %s to %s", sendTokens, tradeZoneId, hostZoneId))
 
 	// Send the ICA tx to kick off transfer from hostZone through rewardZone to the tradeZone (no callbacks)
-	tradeZoneConnectionId := route.TradeAccount.ConnectionId
-	tradeOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.TradeAccount)
-	err := k.SubmitICATxWithoutCallback(ctx, tradeZoneConnectionId, tradeOwner, msgs, timeout)
+	tradeAccount := route.TradeAccount
+	tradeOwner := types.FormatTradeRouteICAOwnerFromRouteId(tradeAccount.ChainId, route.GetRouteId(), tradeAccount.Type)
+	err := k.SubmitICATxWithoutCallback(ctx, tradeAccount.ConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx, Messages: %+v", msgs)
 	}
@@ -251,8 +251,8 @@ func (k Keeper) SwapRewardTokens(ctx sdk.Context, rewardAmount sdkmath.Int, rout
 	}
 	msgs := []proto.Message{&msg}
 
-	tradeIcaAccount := route.TradeAccount
-	k.Logger(ctx).Info(utils.LogWithHostZone(tradeIcaAccount.ChainId,
+	tradeAccount := route.TradeAccount
+	k.Logger(ctx).Info(utils.LogWithHostZone(tradeAccount.ChainId,
 		"Preparing MsgSwapExactAmountIn of %+v from the trade account", msg.TokenIn))
 
 	// Timeout the swap at the end of the epoch
@@ -263,8 +263,8 @@ func (k Keeper) SwapRewardTokens(ctx sdk.Context, rewardAmount sdkmath.Int, rout
 	timeout := uint64(strideEpochTracker.NextEpochStartTime)
 
 	// Send the ICA tx to perform the swap on the tradeZone
-	tradeOwner := types.FormatTradeRouteICAOwnerFromAccount(route.GetRouteId(), route.TradeAccount)
-	err = k.SubmitICATxWithoutCallback(ctx, tradeIcaAccount.ConnectionId, tradeOwner, msgs, timeout)
+	tradeOwner := types.FormatTradeRouteICAOwnerFromRouteId(tradeAccount.ChainId, route.GetRouteId(), tradeAccount.Type)
+	err = k.SubmitICATxWithoutCallback(ctx, tradeAccount.ConnectionId, tradeOwner, msgs, timeout)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Failed to submit ICA tx for the swap, Messages: %v", msgs)
 	}

--- a/x/stakeibc/keeper/reward_converter_test.go
+++ b/x/stakeibc/keeper/reward_converter_test.go
@@ -16,7 +16,7 @@ import (
 // Tests TransferRewardTokensHostToTrade and BuildHostToTradeTransferMsg
 func (s *KeeperTestSuite) TestTransferRewardTokensHostToTrade() {
 	// Create an ICA channel for the transfer submission
-	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_WITHDRAWAL)
+	owner := types.FormatTradeRouteICAOwner(HostChainId, RewardDenom, HostDenom, types.ICAAccountType_WITHDRAWAL)
 	channelId, portId := s.CreateICAChannel(owner)
 
 	// Define components of transfer message
@@ -24,7 +24,7 @@ func (s *KeeperTestSuite) TestTransferRewardTokensHostToTrade() {
 	rewardToTradeChannelId := "channel-1"
 
 	rewardDenomOnHostZone := "ibc/reward_on_host"
-	rewardDenomOnRewardZone := "reward_on_reward"
+	rewardDenomOnRewardZone := RewardDenom
 
 	withdrawalAddress := "withdrawal_address"
 	unwindAddress := "unwind_address"
@@ -47,10 +47,13 @@ func (s *KeeperTestSuite) TestTransferRewardTokensHostToTrade() {
 
 		RewardDenomOnHostZone:   rewardDenomOnHostZone,
 		RewardDenomOnRewardZone: rewardDenomOnRewardZone,
+		HostDenomOnHostZone:     HostDenom,
 
 		HostAccount: types.ICAAccount{
+			ChainId:      HostChainId,
 			Address:      withdrawalAddress,
 			ConnectionId: ibctesting.FirstConnectionID,
+			Type:         types.ICAAccountType_WITHDRAWAL,
 		},
 		RewardAccount: types.ICAAccount{
 			Address: unwindAddress,
@@ -288,19 +291,24 @@ func (s *KeeperTestSuite) TestBuildSwapMsg() {
 
 func (s *KeeperTestSuite) TestSwapRewardTokens() {
 	// Create an ICA channel for the transfer submission
-	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_CONVERTER_TRADE)
+	owner := types.FormatTradeRouteICAOwner(HostChainId, RewardDenom, HostDenom, types.ICAAccountType_CONVERTER_TRADE)
 	channelId, portId := s.CreateICAChannel(owner)
 
 	minSwapAmount := sdkmath.NewInt(10)
 	rewardAmount := sdkmath.NewInt(100)
 
 	route := types.TradeRoute{
+		RewardDenomOnRewardZone: RewardDenom,
+		HostDenomOnHostZone:     HostDenom,
+
 		RewardDenomOnTradeZone: "ibc/reward_on_trade",
 		HostDenomOnTradeZone:   "ibc/host_on_trade",
 
 		TradeAccount: types.ICAAccount{
+			ChainId:      HostChainId,
 			Address:      "trade_address",
 			ConnectionId: ibctesting.FirstConnectionID,
+			Type:         types.ICAAccountType_CONVERTER_TRADE,
 		},
 
 		TradeConfig: types.TradeConfig{

--- a/x/stakeibc/keeper/reward_converter_test.go
+++ b/x/stakeibc/keeper/reward_converter_test.go
@@ -16,7 +16,7 @@ import (
 // Tests TransferRewardTokensHostToTrade and BuildHostToTradeTransferMsg
 func (s *KeeperTestSuite) TestTransferRewardTokensHostToTrade() {
 	// Create an ICA channel for the transfer submission
-	owner := types.FormatICAAccountOwner(HostChainId, types.ICAAccountType_WITHDRAWAL)
+	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_WITHDRAWAL)
 	channelId, portId := s.CreateICAChannel(owner)
 
 	// Define components of transfer message
@@ -288,7 +288,7 @@ func (s *KeeperTestSuite) TestBuildSwapMsg() {
 
 func (s *KeeperTestSuite) TestSwapRewardTokens() {
 	// Create an ICA channel for the transfer submission
-	owner := types.FormatICAAccountOwner(HostChainId, types.ICAAccountType_CONVERTER_TRADE)
+	owner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_CONVERTER_TRADE)
 	channelId, portId := s.CreateICAChannel(owner)
 
 	minSwapAmount := sdkmath.NewInt(10)

--- a/x/stakeibc/keeper/trade_route.go
+++ b/x/stakeibc/keeper/trade_route.go
@@ -17,9 +17,9 @@ func (k Keeper) SetTradeRoute(ctx sdk.Context, tradeRoute types.TradeRoute) {
 
 // GetTradeRoute returns a tradeRoute from its start and end denoms
 // The start and end denom's are in their native format (e.g. uusdc and udydx)
-func (k Keeper) GetTradeRoute(ctx sdk.Context, startDenom string, endDenom string) (val types.TradeRoute, found bool) {
+func (k Keeper) GetTradeRoute(ctx sdk.Context, rewardDenom string, hostDenom string) (val types.TradeRoute, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TradeRouteKeyPrefix))
-	key := types.TradeRouteKeyFromDenoms(startDenom, endDenom)
+	key := types.TradeRouteKeyFromDenoms(rewardDenom, hostDenom)
 	b := store.Get(key)
 	if len(b) == 0 {
 		return val, false
@@ -30,9 +30,9 @@ func (k Keeper) GetTradeRoute(ctx sdk.Context, startDenom string, endDenom strin
 
 // RemoveTradeRoute removes a tradeRoute from the store
 // The start and end denom's are in their native format (e.g. uusdc and udydx)
-func (k Keeper) RemoveTradeRoute(ctx sdk.Context, startDenom string, endDenom string) {
+func (k Keeper) RemoveTradeRoute(ctx sdk.Context, rewardDenom string, hostDenom string) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TradeRouteKeyPrefix))
-	key := types.TradeRouteKeyFromDenoms(startDenom, endDenom)
+	key := types.TradeRouteKeyFromDenoms(rewardDenom, hostDenom)
 	store.Delete(key)
 }
 

--- a/x/stakeibc/keeper/trade_route_test.go
+++ b/x/stakeibc/keeper/trade_route_test.go
@@ -73,10 +73,10 @@ func (s *KeeperTestSuite) CreateTradeRoutes() (routes []types.TradeRoute) {
 func (s *KeeperTestSuite) TestGetTradeRoute() {
 	routes := s.CreateTradeRoutes()
 	for i, route := range routes {
-		startDenom := route.RewardDenomOnRewardZone
-		endDenom := route.HostDenomOnHostZone
+		rewardDenom := route.RewardDenomOnRewardZone
+		hostDenom := route.HostDenomOnHostZone
 
-		actualRoute, found := s.App.StakeibcKeeper.GetTradeRoute(s.Ctx, startDenom, endDenom)
+		actualRoute, found := s.App.StakeibcKeeper.GetTradeRoute(s.Ctx, rewardDenom, hostDenom)
 		s.Require().True(found, "route should have been found")
 		s.Require().Equal(routes[i], actualRoute, "route doesn't match")
 	}

--- a/x/stakeibc/keeper/transfer_test.go
+++ b/x/stakeibc/keeper/transfer_test.go
@@ -24,7 +24,7 @@ type TransferCommunityPoolDepositToHoldingTestCase struct {
 }
 
 func (s *KeeperTestSuite) SetupTransferCommunityPoolDepositToHolding() TransferCommunityPoolDepositToHoldingTestCase {
-	owner := types.FormatICAAccountOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
+	owner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_COMMUNITY_POOL_DEPOSIT)
 	channelId, portId := s.CreateICAChannel(owner)
 
 	holdingAddress := s.TestAccs[0].String()

--- a/x/stakeibc/keeper/unbonding_records_get_host_zone_unbondings_msgs_test.go
+++ b/x/stakeibc/keeper/unbonding_records_get_host_zone_unbondings_msgs_test.go
@@ -35,7 +35,7 @@ func (s *KeeperTestSuite) SetupTestUnbondFromHostZone(
 	unbondAmount sdkmath.Int,
 	validators []*types.Validator,
 ) UnbondingTestCase {
-	delegationAccountOwner := types.FormatICAAccountOwner(HostChainId, types.ICAAccountType_DELEGATION)
+	delegationAccountOwner := types.FormatHostZoneICAOwner(HostChainId, types.ICAAccountType_DELEGATION)
 	delegationChannelID, delegationPortID := s.CreateICAChannel(delegationAccountOwner)
 
 	// Sanity checks:

--- a/x/stakeibc/keeper/undelegate_host_test.go
+++ b/x/stakeibc/keeper/undelegate_host_test.go
@@ -22,7 +22,7 @@ func (s *KeeperTestSuite) SetupTestUndelegateHost(
 	unbondAmount sdkmath.Int,
 	validators []*types.Validator,
 ) UnbondingTestCase {
-	delegationAccountOwner := types.FormatICAAccountOwner(UndelegateHostZoneChainId, types.ICAAccountType_DELEGATION)
+	delegationAccountOwner := types.FormatHostZoneICAOwner(UndelegateHostZoneChainId, types.ICAAccountType_DELEGATION)
 	delegationChannelID, delegationPortID := s.CreateICAChannel(delegationAccountOwner)
 
 	// Sanity checks:

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -2,9 +2,9 @@ package types
 
 import fmt "fmt"
 
-// Helper function to build the ICA owner in the form "{id}.{ICA_TYPE}"
-func FormatICAAccountOwner(id string, accountType ICAAccountType) (result string) {
-	return id + "." + accountType.String()
+// Helper function to build the host zone ICA owner in the form "{chainId}.{ICA_TYPE}"
+func FormatHostZoneICAOwner(chainId string, accountType ICAAccountType) (result string) {
+	return chainId + "." + accountType.String()
 }
 
 // Helper function to build the ICA owner for a trade route ICA

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -1,5 +1,5 @@
 package types
 
-func FormatICAAccountOwner(chainId string, accountType ICAAccountType) (result string) {
-	return chainId + "." + accountType.String()
+func FormatICAAccountOwner(id string, accountType ICAAccountType) (result string) {
+	return id + "." + accountType.String()
 }

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -2,10 +2,20 @@ package types
 
 import fmt "fmt"
 
-func FormatICAAccountOwner(chainId string, accountType ICAAccountType) (result string) {
-	return chainId + "." + accountType.String()
+// Helper function to build the ICA owner in the form "{id}.{ICA_TYPE}"
+func FormatICAAccountOwner(id string, accountType ICAAccountType) (result string) {
+	return id + "." + accountType.String()
 }
 
-func (a ICAAccount) FormatTradeRouteICAOwner(tradeRouteId string) string {
-	return fmt.Sprintf("%s.%s.%s", a.ChainId, tradeRouteId, a.Type.String())
+// Helper function to build the ICA owner for a trade route ICA
+// in the form "{chainId}.{rewardDenom}-{hostDenom}.{ICA_TYPE}"
+func FormatTradeRouteICAOwner(chainId, rewardDenom, hostDenom string, icaAccountType ICAAccountType) string {
+	return fmt.Sprintf("%s.%s-%s.%s", chainId, rewardDenom, hostDenom, icaAccountType.String())
+}
+
+// Helper function to build the ICA owner for a trade route ICA
+// in the form "{chainId}.{rewardDenom}-{hostDenom}.{ICA_TYPE}"
+// from an ICAAccount
+func FormatTradeRouteICAOwnerFromAccount(tradeRouteId string, icaAccount ICAAccount) string {
+	return fmt.Sprintf("%s.%s.%s", icaAccount.ChainId, tradeRouteId, icaAccount.Type.String())
 }

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -10,7 +10,8 @@ func FormatHostZoneICAOwner(chainId string, accountType ICAAccountType) (result 
 // Helper function to build the ICA owner for a trade route ICA
 // in the form "{chainId}.{rewardDenom}-{hostDenom}.{ICA_TYPE}"
 func FormatTradeRouteICAOwner(chainId, rewardDenom, hostDenom string, icaAccountType ICAAccountType) string {
-	return fmt.Sprintf("%s.%s-%s.%s", chainId, rewardDenom, hostDenom, icaAccountType.String())
+	tradeRouteId := GetTradeRouteId(rewardDenom, hostDenom)
+	return fmt.Sprintf("%s.%s.%s", chainId, tradeRouteId, icaAccountType.String())
 }
 
 // Helper function to build the ICA owner for a trade route ICA

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -1,5 +1,11 @@
 package types
 
-func FormatICAAccountOwner(id string, accountType ICAAccountType) (result string) {
-	return id + "." + accountType.String()
+import fmt "fmt"
+
+func FormatICAAccountOwner(chainId string, accountType ICAAccountType) (result string) {
+	return chainId + "." + accountType.String()
+}
+
+func (a ICAAccount) FormatTradeRouteICAOwner(tradeRouteId string) string {
+	return fmt.Sprintf("%s.%s.%s", a.ChainId, tradeRouteId, a.Type.String())
 }

--- a/x/stakeibc/types/ica_account.go
+++ b/x/stakeibc/types/ica_account.go
@@ -11,12 +11,11 @@ func FormatHostZoneICAOwner(chainId string, accountType ICAAccountType) (result 
 // in the form "{chainId}.{rewardDenom}-{hostDenom}.{ICA_TYPE}"
 func FormatTradeRouteICAOwner(chainId, rewardDenom, hostDenom string, icaAccountType ICAAccountType) string {
 	tradeRouteId := GetTradeRouteId(rewardDenom, hostDenom)
-	return fmt.Sprintf("%s.%s.%s", chainId, tradeRouteId, icaAccountType.String())
+	return FormatTradeRouteICAOwnerFromRouteId(chainId, tradeRouteId, icaAccountType)
 }
 
 // Helper function to build the ICA owner for a trade route ICA
-// in the form "{chainId}.{rewardDenom}-{hostDenom}.{ICA_TYPE}"
-// from an ICAAccount
-func FormatTradeRouteICAOwnerFromAccount(tradeRouteId string, icaAccount ICAAccount) string {
-	return fmt.Sprintf("%s.%s.%s", icaAccount.ChainId, tradeRouteId, icaAccount.Type.String())
+// in the form "{chainId}.{tradeRouteId}.{ICA_TYPE}"
+func FormatTradeRouteICAOwnerFromRouteId(chainId, tradeRouteId string, icaAccountType ICAAccountType) string {
+	return fmt.Sprintf("%s.%s.%s", chainId, tradeRouteId, icaAccountType.String())
 }

--- a/x/stakeibc/types/ica_account_test.go
+++ b/x/stakeibc/types/ica_account_test.go
@@ -1,0 +1,85 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Stride-Labs/stride/v16/x/stakeibc/types"
+)
+
+func TestFormatHostZoneICAOwner(t *testing.T) {
+	chainId := "chain-0"
+
+	testCases := []struct {
+		accountType types.ICAAccountType
+		owner       string
+	}{
+		{
+			accountType: types.ICAAccountType_DELEGATION,
+			owner:       "chain-0.DELEGATION",
+		},
+		{
+			accountType: types.ICAAccountType_WITHDRAWAL,
+			owner:       "chain-0.WITHDRAWAL",
+		},
+		{
+			accountType: types.ICAAccountType_REDEMPTION,
+			owner:       "chain-0.REDEMPTION",
+		},
+		{
+			accountType: types.ICAAccountType_FEE,
+			owner:       "chain-0.FEE",
+		},
+		{
+			accountType: types.ICAAccountType_COMMUNITY_POOL_DEPOSIT,
+			owner:       "chain-0.COMMUNITY_POOL_DEPOSIT",
+		},
+		{
+			accountType: types.ICAAccountType_COMMUNITY_POOL_RETURN,
+			owner:       "chain-0.COMMUNITY_POOL_RETURN",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.accountType.String(), func(t *testing.T) {
+			actual := types.FormatHostZoneICAOwner(chainId, tc.accountType)
+			require.Equal(t, tc.owner, actual)
+		})
+	}
+}
+
+func TestFormatTradeRouteICAOwner(t *testing.T) {
+	chainId := "chain-0"
+	rewardDenom := "ureward"
+	hostDenom := "uhost"
+
+	testCases := []struct {
+		accountType types.ICAAccountType
+		owner       string
+	}{
+		{
+			accountType: types.ICAAccountType_CONVERTER_UNWIND,
+			owner:       "chain-0.ureward-uhost.CONVERTER_UNWIND",
+		},
+		{
+			accountType: types.ICAAccountType_CONVERTER_TRADE,
+			owner:       "chain-0.ureward-uhost.CONVERTER_TRADE",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.accountType.String(), func(t *testing.T) {
+			actual := types.FormatTradeRouteICAOwner(chainId, rewardDenom, hostDenom, tc.accountType)
+			require.Equal(t, actual, tc.owner, "format trade route ICA owner")
+
+			tradeRouteId := "ureward-uhost"
+			account := types.ICAAccount{
+				ChainId: chainId,
+				Type:    tc.accountType,
+			}
+			actual = types.FormatTradeRouteICAOwnerFromAccount(tradeRouteId, account)
+			require.Equal(t, actual, tc.owner, "format trade route ICA owner by account")
+		})
+	}
+}

--- a/x/stakeibc/types/ica_account_test.go
+++ b/x/stakeibc/types/ica_account_test.go
@@ -74,11 +74,7 @@ func TestFormatTradeRouteICAOwner(t *testing.T) {
 			require.Equal(t, actual, tc.owner, "format trade route ICA owner")
 
 			tradeRouteId := "ureward-uhost"
-			account := types.ICAAccount{
-				ChainId: chainId,
-				Type:    tc.accountType,
-			}
-			actual = types.FormatTradeRouteICAOwnerFromAccount(tradeRouteId, account)
+			actual = types.FormatTradeRouteICAOwnerFromRouteId(chainId, tradeRouteId, tc.accountType)
 			require.Equal(t, actual, tc.owner, "format trade route ICA owner by account")
 		})
 	}

--- a/x/stakeibc/types/keys.go
+++ b/x/stakeibc/types/keys.go
@@ -48,8 +48,8 @@ func EpochTrackerKey(epochIdentifier string) []byte {
 }
 
 // Definition for the store key format based on tradeRoute start and end denoms
-func TradeRouteKeyFromDenoms(startDenom string, endDenom string) (key []byte) {
-	return []byte(startDenom + "-" + endDenom)
+func TradeRouteKeyFromDenoms(rewardDenom, hostDenom string) (key []byte) {
+	return []byte(rewardDenom + "-" + hostDenom)
 }
 
 const (

--- a/x/stakeibc/types/trade_route.go
+++ b/x/stakeibc/types/trade_route.go
@@ -2,6 +2,11 @@ package types
 
 import fmt "fmt"
 
+// Builds the store key (as a string) from the reward and host denom's
+func (t TradeRoute) GetID() string {
+	return t.RewardDenomOnRewardZone + "-" + t.HostDenomOnHostZone
+}
+
 // Builds the store key from the reward and host denom's
 func (t TradeRoute) GetKey() []byte {
 	return TradeRouteKeyFromDenoms(t.RewardDenomOnRewardZone, t.HostDenomOnHostZone)

--- a/x/stakeibc/types/trade_route.go
+++ b/x/stakeibc/types/trade_route.go
@@ -3,8 +3,13 @@ package types
 import fmt "fmt"
 
 // Builds the store key (as a string) from the reward and host denom's
+func GetTradeRouteId(rewardDenom, hostDenom string) string {
+	return rewardDenom + "-" + hostDenom
+}
+
+// Builds the store key (as a string) from the reward and host denom's
 func (t TradeRoute) GetRouteId() string {
-	return t.RewardDenomOnRewardZone + "-" + t.HostDenomOnHostZone
+	return GetTradeRouteId(t.RewardDenomOnRewardZone, t.HostDenomOnHostZone)
 }
 
 // Builds the store key from the reward and host denom's

--- a/x/stakeibc/types/trade_route.go
+++ b/x/stakeibc/types/trade_route.go
@@ -3,7 +3,7 @@ package types
 import fmt "fmt"
 
 // Builds the store key (as a string) from the reward and host denom's
-func (t TradeRoute) GetID() string {
+func (t TradeRoute) GetRouteId() string {
 	return t.RewardDenomOnRewardZone + "-" + t.HostDenomOnHostZone
 }
 


### PR DESCRIPTION
## Context
We need to have a separate trade ICA for each trade route. Otherwise, if two trade routes shared a common denom, it could interfere with the queries.

## Brief Changelog
* Added `FormatTradeRouteICAOwner` and `FormatTradeRouteICAOwnerFromAccount` 
* Renamed `FormatICAAccountOwner` to `FormatHostZoneICAOwner`
* Updated trade route ICA owners to use the new function
* Added unit tests for the relevant types functions

**NOTE**: @ethan-stride, I'm not really loving the implementation of these owner functions. Curious if you can think of a better way to do it