### PR TITLE
v14 cleanup

### DIFF
--- a/x/stakeibc/keeper/icacallbacks_delegate.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cast"
@@ -67,12 +66,6 @@ func (k Keeper) DelegateCallback(ctx sdk.Context, packet channeltypes.Packet, ac
 	// Regardless of failure/success/timeout, indicate that this ICA has completed
 	for _, splitDelegation := range delegateCallback.SplitDelegations {
 		if err := k.DecrementValidatorDelegationChangesInProgress(&hostZone, splitDelegation.Validator); err != nil {
-			// TODO: Revert after v14 upgrade
-			if errors.Is(err, types.ErrInvalidValidatorDelegationUpdates) {
-				k.Logger(ctx).Error(utils.LogICACallbackWithHostZone(chainId, ICACallbackID_Delegate,
-					"Invariant failed - delegation changes in progress fell below 0 for %s", splitDelegation.Validator))
-				continue
-			}
 			return err
 		}
 	}

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -48,12 +48,6 @@ func (k Keeper) UndelegateCallback(ctx sdk.Context, packet channeltypes.Packet, 
 	}
 	for _, splitDelegation := range undelegateCallback.SplitDelegations {
 		if err := k.DecrementValidatorDelegationChangesInProgress(&hostZone, splitDelegation.Validator); err != nil {
-			// TODO: Revert after v14 upgrade
-			if errors.Is(err, types.ErrInvalidValidatorDelegationUpdates) {
-				k.Logger(ctx).Error(utils.LogICACallbackWithHostZone(chainId, ICACallbackID_Undelegate,
-					"Invariant failed - delegation changes in progress fell below 0 for %s", splitDelegation.Validator))
-				continue
-			}
 			return err
 		}
 	}


### PR DESCRIPTION
## Context
For upgrade v14, we added the field `DelegationChangesInProgress` initialized to 0. There was a tail risk that there would actually be an ICA in progress at the time that the upgrade happened, so we had temporarily swallowed an error case of the changes going below 0.

Now that the upgrade has succeeded and this case should no longer be possible, we can go back to throwing an error.

[[Relevant PR](https://github.com/Stride-Labs/stride/pull/910)]
[[Relevant Comment](https://github.com/Stride-Labs/stride/pull/910#discussion_r1306686032)]

## Brief Changelog
* Removed error swallow in delegation and undelegation callback