### PR TITLE
reward converter - fix timeouts

### DIFF
--- a/x/stakeibc/keeper/keeper_test.go
+++ b/x/stakeibc/keeper/keeper_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Stride-Labs/stride/v16/app/apptesting"
-	epochtypes "github.com/Stride-Labs/stride/v16/x/epochs/types"
 	"github.com/Stride-Labs/stride/v16/x/stakeibc/keeper"
 	"github.com/Stride-Labs/stride/v16/x/stakeibc/types"
 )
@@ -67,11 +66,11 @@ func (s *KeeperTestSuite) MustGetHostZone(chainId string) types.HostZone {
 	return hostZone
 }
 
-// Helper function to create an stride epoch tracker that dictates the timeout
-func (s *KeeperTestSuite) CreateStrideEpochForICATimeout(timeoutDuration time.Duration) {
+// Helper function to create an epoch tracker that dictates the timeout
+func (s *KeeperTestSuite) CreateEpochForICATimeout(epochType string, timeoutDuration time.Duration) {
 	epochEndTime := uint64(s.Ctx.BlockTime().Add(timeoutDuration).UnixNano())
 	epochTracker := types.EpochTracker{
-		EpochIdentifier:    epochtypes.STRIDE_EPOCH,
+		EpochIdentifier:    epochType,
 		NextEpochStartTime: epochEndTime,
 	}
 	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, epochTracker)

--- a/x/stakeibc/keeper/reward_converter_test.go
+++ b/x/stakeibc/keeper/reward_converter_test.go
@@ -313,7 +313,7 @@ func (s *KeeperTestSuite) TestSwapRewardTokens() {
 	}
 
 	// Create an epoch tracker to dictate the timeout
-	s.CreateStrideEpochForICATimeout(time.Minute) // arbitrary timeout time
+	s.CreateEpochForICATimeout(epochtypes.HOUR_EPOCH, time.Minute) // arbitrary timeout time
 
 	// Execute the swap and confirm the sequence number increments
 	startSequence := s.MustGetNextSequenceNumber(portId, channelId)
@@ -340,7 +340,7 @@ func (s *KeeperTestSuite) TestSwapRewardTokens() {
 	s.Require().ErrorContains(err, "Failed to submit ICA tx")
 
 	// Delete the epoch tracker and confirm the swap fails
-	s.App.StakeibcKeeper.RemoveEpochTracker(s.Ctx, epochtypes.STRIDE_EPOCH)
+	s.App.StakeibcKeeper.RemoveEpochTracker(s.Ctx, epochtypes.HOUR_EPOCH)
 	err = s.App.StakeibcKeeper.SwapRewardTokens(s.Ctx, rewardAmount, route)
 	s.Require().ErrorContains(err, "epoch not found")
 }


### PR DESCRIPTION
We need to timeout the swap at the end of the _hour_ (instead of stride epoch). And we need to timeout the withdrawal balance query at the epoch halfway mark since that's when the first transfer times out