### PR TITLE
autopilot hashed sender

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -612,6 +612,7 @@ func NewStrideApp(
 		appCodec,
 		keys[autopilottypes.StoreKey],
 		app.GetSubspace(autopilottypes.ModuleName),
+		app.BankKeeper,
 		app.StakeibcKeeper,
 		app.ClaimKeeper,
 		app.TransferKeeper,

--- a/x/autopilot/keeper/airdrop.go
+++ b/x/autopilot/keeper/airdrop.go
@@ -17,6 +17,7 @@ import (
 	stakeibctypes "github.com/Stride-Labs/stride/v16/x/stakeibc/types"
 )
 
+// Attempt to link a host address with a stride address to enable airdrop claims
 func (k Keeper) TryUpdateAirdropClaim(
 	ctx sdk.Context,
 	packet channeltypes.Packet,

--- a/x/autopilot/keeper/airdrop.go
+++ b/x/autopilot/keeper/airdrop.go
@@ -20,8 +20,7 @@ import (
 func (k Keeper) TryUpdateAirdropClaim(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
-	data transfertypes.FungibleTokenPacketData,
-	packetMetadata types.ClaimPacketMetadata,
+	data types.TokenPacketMetadata,
 ) error {
 	params := k.GetParams(ctx)
 	if !params.ClaimActive {
@@ -43,7 +42,7 @@ func (k Keeper) TryUpdateAirdropClaim(
 	if senderStrideAddress == "" {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, fmt.Sprintf("invalid sender address (%s)", data.Sender))
 	}
-	newStrideAddress := packetMetadata.StrideAddress
+	newStrideAddress := data.OriginalReceiver
 
 	// find the airdrop for this host chain ID
 	airdrop, found := k.claimKeeper.GetAirdropByChainId(ctx, hostZone.ChainId)
@@ -58,5 +57,14 @@ func (k Keeper) TryUpdateAirdropClaim(
 	k.Logger(ctx).Info(fmt.Sprintf("updating airdrop address %s (orig %s) to %s for airdrop %s",
 		senderStrideAddress, data.Sender, newStrideAddress, airdropId))
 
-	return k.claimKeeper.UpdateAirdropAddress(ctx, senderStrideAddress, newStrideAddress, airdropId)
+	if err := k.claimKeeper.UpdateAirdropAddress(ctx, senderStrideAddress, newStrideAddress, airdropId); err != nil {
+		return err
+	}
+
+	// Finally send token back to the original reciever (since the hashed receiver was used for the transfer)
+	fromAddress := sdk.MustAccAddressFromBech32(data.HashedReceiver)
+	toAddress := sdk.MustAccAddressFromBech32(data.OriginalReceiver)
+	token := sdk.NewCoin(data.Denom, data.Amount)
+
+	return k.bankkeeper.SendCoins(ctx, fromAddress, toAddress, sdk.NewCoins(token))
 }

--- a/x/autopilot/keeper/keeper.go
+++ b/x/autopilot/keeper/keeper.go
@@ -21,6 +21,7 @@ type (
 		Cdc            codec.BinaryCodec
 		storeKey       storetypes.StoreKey
 		paramstore     paramtypes.Subspace
+		bankkeeper     types.BankKeeper
 		stakeibcKeeper stakeibckeeper.Keeper
 		claimKeeper    claimkeeper.Keeper
 		transferKeeper ibctransferkeeper.Keeper
@@ -31,6 +32,7 @@ func NewKeeper(
 	Cdc codec.BinaryCodec,
 	storeKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
+	bankKeeper types.BankKeeper,
 	stakeibcKeeper stakeibckeeper.Keeper,
 	claimKeeper claimkeeper.Keeper,
 	transferKeeper ibctransferkeeper.Keeper,
@@ -44,6 +46,7 @@ func NewKeeper(
 		Cdc:            Cdc,
 		storeKey:       storeKey,
 		paramstore:     ps,
+		bankkeeper:     bankKeeper,
 		stakeibcKeeper: stakeibcKeeper,
 		claimKeeper:    claimKeeper,
 		transferKeeper: transferKeeper,

--- a/x/autopilot/module_ibc.go
+++ b/x/autopilot/module_ibc.go
@@ -161,8 +161,9 @@ func (im IBCModule) OnRecvPacket(
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
 
-	// If the parsed metadata is nil, that means there is no forwarding logic
+	// If the parsed metadata is nil, that means there is no autopilot forwarding logic
 	// Pass the packet down to the next middleware
+	// PFM packets will also go down this path
 	if packetForwardMetadata == nil {
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}

--- a/x/autopilot/types/autopilot.go
+++ b/x/autopilot/types/autopilot.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	fmt "fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+)
+
+// GenerateHashedReceiver returns the receiver address for a given channel and original sender.
+// It overrides the receiver address to be a hash of the channel/origSender so that
+// the receiver address is deterministic and can be used to identify the sender on the
+// initial chain.
+
+// GenerateHashedReceiver generates a new receiver address for a packet, by hashing
+// the channel and original sender.
+// This makes the receiver address deterministic and can used to identify the sender
+// on the initial chain.
+// Additionally, this prevents a forwarded packet from inpersonating a different account
+// when moving to the next hop (i.e. receiver of this hop, becomes sender of next)
+//
+// This function was borrowed from PFM
+func GenerateHashedReceiver(channelId, originalSender string) (string, error) {
+	senderStr := fmt.Sprintf("%s/%s", channelId, originalSender)
+	senderHash32 := address.Hash(ModuleName, []byte(senderStr))
+	sender := sdk.AccAddress(senderHash32[:20])
+	bech32Prefix := sdk.GetConfig().GetBech32AccountAddrPrefix()
+	return sdk.Bech32ifyAddressBytes(bech32Prefix, sender)
+}

--- a/x/autopilot/types/autopilot.go
+++ b/x/autopilot/types/autopilot.go
@@ -13,7 +13,7 @@ import (
 // TokenPacketMetadata is meant to replicate transfertypes.FungibleTokenPacketData
 // but it drops the original sender (who is untrusted) and adds a hashed receiver
 // that can be used for any forwarding
-type TokenPacketMetadata struct {
+type AutopilotTransferMetadata struct {
 	Sender           string
 	OriginalReceiver string
 	HashedReceiver   string
@@ -21,20 +21,20 @@ type TokenPacketMetadata struct {
 	Denom            string
 }
 
-// Builds a TokenPacketMetadata object using the fields of a FungibleTokenPacketData
+// Builds a AutopilotTransferMetadata object using the fields of a FungibleTokenPacketData
 // and adding a hashed receiver
-func NewTokenPacketMetadata(channelId string, data transfertypes.FungibleTokenPacketData) (TokenPacketMetadata, error) {
+func NewAutopilotTransferMetadata(channelId string, data transfertypes.FungibleTokenPacketData) (AutopilotTransferMetadata, error) {
 	hashedReceiver, err := GenerateHashedReceiver(channelId, data.Sender)
 	if err != nil {
-		return TokenPacketMetadata{}, err
+		return AutopilotTransferMetadata{}, err
 	}
 
 	amount, ok := sdk.NewIntFromString(data.Amount)
 	if !ok {
-		return TokenPacketMetadata{}, errors.New("not a parsable amount field")
+		return AutopilotTransferMetadata{}, errors.New("not a parsable amount field")
 	}
 
-	return TokenPacketMetadata{
+	return AutopilotTransferMetadata{
 		Sender:           data.Sender,
 		OriginalReceiver: data.Receiver,
 		HashedReceiver:   hashedReceiver,

--- a/x/autopilot/types/autopilot.go
+++ b/x/autopilot/types/autopilot.go
@@ -14,6 +14,7 @@ import (
 // but it drops the original sender (who is untrusted) and adds a hashed receiver
 // that can be used for any forwarding
 type TokenPacketMetadata struct {
+	Sender           string
 	OriginalReceiver string
 	HashedReceiver   string
 	Amount           sdkmath.Int
@@ -34,6 +35,7 @@ func NewTokenPacketMetadata(channelId string, data transfertypes.FungibleTokenPa
 	}
 
 	return TokenPacketMetadata{
+		Sender:           data.Sender,
 		OriginalReceiver: data.Receiver,
 		HashedReceiver:   hashedReceiver,
 		Amount:           amount,

--- a/x/autopilot/types/expected_keepers.go
+++ b/x/autopilot/types/expected_keepers.go
@@ -1,0 +1,9 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type BankKeeper interface {
+	SendCoins(ctx sdk.Context, senderAddr sdk.AccAddress, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+}

--- a/x/autopilot/types/parser.go
+++ b/x/autopilot/types/parser.go
@@ -16,7 +16,7 @@ type RawPacketMetadata struct {
 	Forward *interface{} `json:"forward"`
 }
 
-type PacketForwardMetadata struct {
+type AutopilotActionMetadata struct {
 	Receiver    string
 	RoutingInfo ModuleRoutingInfo
 }
@@ -74,10 +74,10 @@ func (m ClaimPacketMetadata) Validate() error {
 
 // Parse packet metadata intended for autopilot
 // In the ICS-20 packet, the metadata can optionally indicate a module to route to (e.g. stakeibc)
-// The PacketForwardMetadata returned from this function contains attributes for each autopilot supported module
+// The AutopilotActionMetadata returned from this function contains attributes for each autopilot supported module
 // It can only be forward to one module per packet
 // Returns nil if there was no autopilot metadata found
-func ParsePacketMetadata(metadata string) (*PacketForwardMetadata, error) {
+func ParseAutopilotActionMetadata(metadata string) (*AutopilotActionMetadata, error) {
 	// If we can't unmarshal the metadata into a PacketMetadata struct,
 	// assume packet forwarding was no used and pass back nil so that autopilot is ignored
 	var raw RawPacketMetadata
@@ -127,7 +127,7 @@ func ParsePacketMetadata(metadata string) (*PacketForwardMetadata, error) {
 		return nil, errorsmod.Wrapf(err, ErrInvalidPacketMetadata.Error())
 	}
 
-	return &PacketForwardMetadata{
+	return &AutopilotActionMetadata{
 		Receiver:    raw.Autopilot.Receiver,
 		RoutingInfo: routingInfo,
 	}, nil

--- a/x/autopilot/types/parser.go
+++ b/x/autopilot/types/parser.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	errorsmod "cosmossdk.io/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/autopilot/types/parser_test.go
+++ b/x/autopilot/types/parser_test.go
@@ -126,6 +126,11 @@ func TestParsePacketMetadata(t *testing.T) {
 			expectedNilMetadata: true,
 		},
 		{
+			name:                "PFM transfer",
+			metadata:            `{"forward": {}}`,
+			expectedNilMetadata: true,
+		},
+		{
 			name:                "empty memo",
 			metadata:            "",
 			expectedNilMetadata: true,
@@ -139,6 +144,11 @@ func TestParsePacketMetadata(t *testing.T) {
 			name:                "different module specified",
 			metadata:            `{ "other_module": { } }`,
 			expectedNilMetadata: true,
+		},
+		{
+			name:        "both autopilot and pfm in the memo",
+			metadata:    `{"autopilot": {}, "forward": {}}`,
+			expectedErr: "autopilot and pfm cannot both be used in the same packet",
 		},
 		{
 			name:        "empty receiver address",


### PR DESCRIPTION
## Context
During liquid stake and forward, the autopilot "receiver" of the inbound transfer becomes the "sender" of the transfer back to the host. However, downstream applications shouldn't trust this new "sender" so we need to use a generated address instead. 

To be clear, using the original sender would not introduce an attack vector on Stride. However, it could introduce an attack vector on a different zone, _if_ they were to trust the sender. The hashed sender is used to make the assumption more explicit that new zones should not trust the address.

This bug appeared in PFM (if more context is needed):
* [Issue](https://github.com/cosmos/ibc-apps/issues/68)
* [PR fix](https://github.com/cosmos/ibc-apps/pull/71)

## Design Considerations
There wasn't an immediately obvious way to implement this. The complexity arises in that the address used for the inbound transfer doesn't always line up with the address used in the autopilot action. 

We send the packet down the stack first to complete the inbound transfer, this means there's a few ways we could implement this:
```
Liquid Stake (no forwarding)
    1. Inbound transfer to ORIGINAL     
    2. Liquid stake with ORIGINAL   
    
              OR               
                                                  
   1. Inbound transfer to HASHED
   2. Liquid stake with HASHED
   3. Bank send to ORIGINAL

Liquid Stake (with forwarding)
   1. Inbound transfer to HASHED
   4. Liquid stake with HASHED
   5. Outbound transfer from HASHED

Redeem Stake / Claim
  1. Inbound transfer to ORIGINAL       
  
             OR     

  1. Inbound transfer to HASHED
  2. Bank send to ORIGINAL
```

Two additional constraints (not that these were impossible, but I think they would have made the code hard to follow)
* There didn't seem to be a clean way to switch between ORIGINAL/HASHED in the inbound transfer (i.e. we have to pick one of the two before calling down the stack)
* There didn't seem to be a clean way to use different inbound transfer addresses across LiquidStake and LiquidStake&Forward (i.e. we couldn't easily use ORIGINAL for LS, and HASHED for LS&Forward)

All that said, I opted with the approach of doing the inbound transfer with the hashed address and doing a bank send later if needed. Very open to a better way of doing this though if you can think of one!

## High Level Design
* Added a new data structure (`AutopilotTransferMetadata`) to replace `FungibleTokenPacketData` and include the hashed sender
* This data structure was sent to each action so the relevant addresses could be retrieved as needed

## Brief Changelog
* Added `GenerateHashedReceiver` to generate the hashed address (body of function taken from PFM)
* Added `AutopilotTransferMetadata` which stores the original packet data + the hashed sender
* Renamed `PacketForwardMetadata` to `AutopilotActionMetadata`
* Passed `AutopilotTransferMetadata` into each action's function instead of `FungibleTokenPacketData`
* Used hashed address for inbound transfer and added a bank send to the original sender afterwards (if needed)
* Restricted packets to being either autopilot or PFM (but not both)
* Cleaned up the variable names to avoid confusion with all the data structures (open to better names though!)