### PR TITLE
Add Prop 225 to v17 Upgrade Handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -223,11 +223,11 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 		v17.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
+			app.BankKeeper,
 			app.DistrKeeper,
 			app.InterchainqueryKeeper,
 			app.RatelimitKeeper,
 			app.StakeibcKeeper,
-			app.BankKeeper,
 		),
 	)
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -227,6 +227,7 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 			app.InterchainqueryKeeper,
 			app.RatelimitKeeper,
 			app.StakeibcKeeper,
+			app.BankKeeper,
 		),
 	)
 

--- a/app/upgrades/v17/upgrades.go
+++ b/app/upgrades/v17/upgrades.go
@@ -65,7 +65,7 @@ var (
 
 	// Constants for Prop 225
 	CommunityPoolGrowthAddress = "stride1lj0m72d70qerts9ksrsphy9nmsd4h0s88ll9gfphmhemh8ewet5qj44jc9"
-	LiquidityCustodian         = "stride1auhjs4zgp3ahvrpkspf088r2psz7wpyrypcnal"
+	LiquidityReceiver          = "stride1auhjs4zgp3ahvrpkspf088r2psz7wpyrypcnal"
 	Prop225TransferAmount      = sdk.NewInt(31_572_300_000)
 	Ustrd                      = "ustrd"
 )
@@ -316,7 +316,7 @@ func AddRateLimitToOsmosis(ctx sdk.Context, k ratelimitkeeper.Keeper) error {
 // Execute Prop 225, release STRD to stride1auhjs4zgp3ahvrpkspf088r2psz7wpyrypcnal
 func ExecuteProp225(ctx sdk.Context, k bankkeeper.Keeper) error {
 	communityPoolGrowthAddress := sdk.MustAccAddressFromBech32(CommunityPoolGrowthAddress)
-	liquidityCustodianAddress := sdk.MustAccAddressFromBech32(LiquidityCustodian)
+	liquidityReceivernAddress := sdk.MustAccAddressFromBech32(LiquidityReceiver)
 	transferCoin := sdk.NewCoin(Ustrd, Prop225TransferAmount)
-	return k.SendCoins(ctx, communityPoolGrowthAddress, liquidityCustodianAddress, sdk.NewCoins(transferCoin))
+	return k.SendCoins(ctx, communityPoolGrowthAddress, liquidityReceivernAddress, sdk.NewCoins(transferCoin))
 }

--- a/app/upgrades/v17/upgrades.go
+++ b/app/upgrades/v17/upgrades.go
@@ -74,11 +74,11 @@ var (
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
+	bankKeeper bankkeeper.Keeper,
 	distributionkeeper distributionkeeper.Keeper,
 	icqKeeper icqkeeper.Keeper,
 	ratelimitKeeper ratelimitkeeper.Keeper,
 	stakeibcKeeper stakeibckeeper.Keeper,
-	bankKeeper bankkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v17...")
@@ -316,7 +316,7 @@ func AddRateLimitToOsmosis(ctx sdk.Context, k ratelimitkeeper.Keeper) error {
 // Execute Prop 225, release STRD to stride1auhjs4zgp3ahvrpkspf088r2psz7wpyrypcnal
 func ExecuteProp225(ctx sdk.Context, k bankkeeper.Keeper) error {
 	communityPoolGrowthAddress := sdk.MustAccAddressFromBech32(CommunityPoolGrowthAddress)
-	liquidityReceivernAddress := sdk.MustAccAddressFromBech32(LiquidityReceiver)
+	liquidityReceiverAddress := sdk.MustAccAddressFromBech32(LiquidityReceiver)
 	transferCoin := sdk.NewCoin(Ustrd, Prop225TransferAmount)
-	return k.SendCoins(ctx, communityPoolGrowthAddress, liquidityReceivernAddress, sdk.NewCoins(transferCoin))
+	return k.SendCoins(ctx, communityPoolGrowthAddress, liquidityReceiverAddress, sdk.NewCoins(transferCoin))
 }

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -76,6 +76,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	checkRateLimitsAfterUpgrade := s.SetupRateLimitsBeforeUpgrade()
 	checkCommunityPoolTaxAfterUpgrade := s.SetupCommunityPoolTaxBeforeUpgrade()
 	checkQueriesAfterUpgrade := s.SetupQueriesBeforeUpgrade()
+	checkProp225AfterUpgrade := s.SetupProp225BeforeUpgrade()
 
 	// Submit upgrade and confirm handler succeeds
 	s.ConfirmUpgradeSucceededs("v17", dummyUpgradeHeight)
@@ -85,6 +86,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	checkRateLimitsAfterUpgrade()
 	checkCommunityPoolTaxAfterUpgrade()
 	checkQueriesAfterUpgrade()
+	checkProp225AfterUpgrade()
 }
 
 // Helper function to check that the community pool stake and redeem holding
@@ -345,6 +347,35 @@ func (s *UpgradeTestSuite) SetupQueriesBeforeUpgrade() func() {
 		// Confirm the other query is still there
 		_, found = s.App.InterchainqueryKeeper.GetQuery(s.Ctx, "query-2")
 		s.Require().True(found, "non-slash query should not have been removed")
+	}
+}
+
+func (s *UpgradeTestSuite) SetupProp225BeforeUpgrade() func() {
+	// Grab the community pool growth address and balance
+	communityPoolGrowthAddress := sdk.MustAccAddressFromBech32(v17.CommunityPoolGrowthAddress)
+	// Set the balance to 3x the amount that will be transferred
+	newCoin := sdk.NewCoin(v17.Ustrd, v17.Prop225TransferAmount.MulRaw(3))
+	s.FundAccount(communityPoolGrowthAddress, newCoin)
+	originalCommunityGrowthBalance := s.App.BankKeeper.GetBalance(s.Ctx, communityPoolGrowthAddress, v17.Ustrd)
+
+	// Grab the liquidity custodian address and balance
+	liquidityCustodianAddress := sdk.MustAccAddressFromBech32(v17.LiquidityCustodian)
+	originalLiquidityCustodianBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityCustodianAddress, v17.Ustrd)
+
+	// grab how much we want to transfer
+	transferAmount := v17.Prop225TransferAmount.Int64()
+
+	// Return callback to check store after upgrade
+	return func() {
+		// verify funds left community growth
+		newCommunityGrowthBalance := s.App.BankKeeper.GetBalance(s.Ctx, communityPoolGrowthAddress, v17.Ustrd)
+		communityGrowthBalanceChange := originalCommunityGrowthBalance.Sub(newCommunityGrowthBalance)
+		s.Require().Equal(transferAmount, communityGrowthBalanceChange.Amount.Int64(), "community growth decreased by correct amount")
+
+		// verify funds entered liquidity custodian
+		newLiquidityCustodianBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityCustodianAddress, v17.Ustrd)
+		liquidityCustodianBalanceChange := newLiquidityCustodianBalance.Sub(originalLiquidityCustodianBalance).Amount.Int64()
+		s.Require().Equal(transferAmount, liquidityCustodianBalanceChange, "custodian balance increased by correct amount")
 	}
 }
 

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -358,9 +358,9 @@ func (s *UpgradeTestSuite) SetupProp225BeforeUpgrade() func() {
 	s.FundAccount(communityPoolGrowthAddress, newCoin)
 	originalCommunityGrowthBalance := s.App.BankKeeper.GetBalance(s.Ctx, communityPoolGrowthAddress, v17.Ustrd)
 
-	// Grab the liquidity custodian address and balance
-	liquidityCustodianAddress := sdk.MustAccAddressFromBech32(v17.LiquidityCustodian)
-	originalLiquidityCustodianBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityCustodianAddress, v17.Ustrd)
+	// Grab the liquidity receiver address and balance
+	liquidityReceiverAddress := sdk.MustAccAddressFromBech32(v17.LiquidityReceiver)
+	originalLiquidityReceiverBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityReceiverAddress, v17.Ustrd)
 
 	// grab how much we want to transfer
 	transferAmount := v17.Prop225TransferAmount.Int64()
@@ -373,8 +373,8 @@ func (s *UpgradeTestSuite) SetupProp225BeforeUpgrade() func() {
 		s.Require().Equal(transferAmount, communityGrowthBalanceChange.Amount.Int64(), "community growth decreased by correct amount")
 
 		// verify funds entered liquidity custodian
-		newLiquidityCustodianBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityCustodianAddress, v17.Ustrd)
-		liquidityCustodianBalanceChange := newLiquidityCustodianBalance.Sub(originalLiquidityCustodianBalance).Amount.Int64()
+		newLiquidityCustodianBalance := s.App.BankKeeper.GetBalance(s.Ctx, liquidityReceiverAddress, v17.Ustrd)
+		liquidityCustodianBalanceChange := newLiquidityCustodianBalance.Sub(originalLiquidityReceiverBalance).Amount.Int64()
 		s.Require().Equal(transferAmount, liquidityCustodianBalanceChange, "custodian balance increased by correct amount")
 	}
 }


### PR DESCRIPTION
This PR adds the execution of Prop 225 to the v17 Upgrade Handler.

Relevant details can be found [here](https://www.mintscan.io/stride/proposals/225) and [here](https://commonwealth.im/stride/discussion/14238-shd-strd-protocol-liquidity-matching-pt2). 

In particular, 31,572.30 STRD should be released to stride1auhjs4zgp3ahvrpkspf088r2psz7wpyrypcnal from [Community Pool Growth](https://www.mintscan.io/stride/address/stride1lj0m72d70qerts9ksrsphy9nmsd4h0s88ll9gfphmhemh8ewet5qj44jc9).