### PR TITLE
Move disable tokenization to hooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,10 +30,9 @@
 	path = deps/evmos
 	url = https://github.com/evmos/evmos
 [submodule "deps/dydx"]
-	# TODO [DYDX]: Switch to official dydxprotocol release after ICA PR is merged
-	# Commit: fafd3a9e2083180d7f7809f5080897e714e52bec
+	# Commit: protocol/v3.0.0-rc1
 	path = deps/dydx
-	url = https://github.com/Stride-Labs/v4-chain.git
+	url = https://github.com/dydxprotocol/v4-chain.git
 [submodule "deps/noble"]
 	# Commit: v3.1.0
 	path = deps/noble

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,10 +5,9 @@
 # TODO [LSM]: Revert to cosmos relayer once they've merged 
 # the fix for the unbonding time query
 [submodule "deps/relayer"]
-	# Branch: sam/lsm-poc
-	# Commit: 0136134766142f133f263f3bba72d7077e7bc2c1
+	# Commit: v2.4.2
 	path = deps/relayer
-	url = https://github.com/Stride-Labs/relayer.git
+	url = https://github.com/cosmos/relayer.git
 [submodule "deps/gaia"]
 	# Commit: v12.0.0-rc0
 	path = deps/gaia

--- a/app/upgrades/v17/upgrades_test.go
+++ b/app/upgrades/v17/upgrades_test.go
@@ -71,17 +71,12 @@ func TestKeeperTestSuite(t *testing.T) {
 func (s *UpgradeTestSuite) TestUpgrade() {
 	dummyUpgradeHeight := int64(5)
 
-	// Create the gaia delegation channel
-	owner := stakeibctypes.FormatHostZoneICAOwner(v17.GaiaChainId, stakeibctypes.ICAAccountType_DELEGATION)
-	channelId, portId := s.CreateICAChannel(owner)
-
 	// Setup store before upgrade
 	checkHostZonesAfterUpgrade := s.SetupHostZonesBeforeUpgrade()
 	checkMigrateUnbondingRecords := s.SetupMigrateUnbondingRecords()
 	checkRateLimitsAfterUpgrade := s.SetupRateLimitsBeforeUpgrade()
 	checkCommunityPoolTaxAfterUpgrade := s.SetupCommunityPoolTaxBeforeUpgrade()
 	checkQueriesAfterUpgrade := s.SetupQueriesBeforeUpgrade()
-	checkDisableTokenizationICASubmitted := s.SetupTestDisableTokenization(channelId, portId)
 	checkProp225AfterUpgrade := s.SetupProp225BeforeUpgrade()
 
 	// Submit upgrade and confirm handler succeeds
@@ -93,7 +88,6 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	checkRateLimitsAfterUpgrade()
 	checkCommunityPoolTaxAfterUpgrade()
 	checkQueriesAfterUpgrade()
-	checkDisableTokenizationICASubmitted()
 	checkProp225AfterUpgrade()
 }
 
@@ -473,17 +467,6 @@ func (s *UpgradeTestSuite) SetupQueriesBeforeUpgrade() func() {
 		// Confirm the other query is still there
 		_, found = s.App.InterchainqueryKeeper.GetQuery(s.Ctx, "query-2")
 		s.Require().True(found, "non-slash query should not have been removed")
-	}
-}
-
-func (s *UpgradeTestSuite) SetupTestDisableTokenization(channelId, portId string) func() {
-	// Get the current sequence number (to check that it incremented)
-	startSequence := s.MustGetNextSequenceNumber(portId, channelId)
-
-	// Return callback to that the ICA was submitted
-	return func() {
-		endSequence := s.MustGetNextSequenceNumber(portId, channelId)
-		s.Require().Equal(startSequence+1, endSequence, "sequence number should have incremented from disabling detokenization")
 	}
 }
 
@@ -867,20 +850,4 @@ func (s *UpgradeTestSuite) TestAddRateLimitToOsmosis() {
 
 	err = v17.AddRateLimitToOsmosis(s.Ctx, s.App.RatelimitKeeper)
 	s.Require().ErrorContains(err, "channel value is zero")
-}
-
-func (s *UpgradeTestSuite) TestDisableTokenization() {
-	// Create the host zone and delegation channel
-	owner := stakeibctypes.FormatHostZoneICAOwner(v17.GaiaChainId, stakeibctypes.ICAAccountType_DELEGATION)
-	channelId, portId := s.CreateICAChannel(owner)
-
-	s.App.StakeibcKeeper.SetHostZone(s.Ctx, stakeibctypes.HostZone{
-		ChainId:      v17.GaiaChainId,
-		ConnectionId: ibctesting.FirstConnectionID,
-	})
-
-	// Call the disable function and confirm the sequence number incremented (indicating an ICA was submitted)
-	s.CheckICATxSubmitted(portId, channelId, func() error {
-		return v17.DisableTokenization(s.Ctx, s.App.StakeibcKeeper, v17.GaiaChainId)
-	})
 }

--- a/dockernet/config/ica_host.json
+++ b/dockernet/config/ica_host.json
@@ -15,6 +15,7 @@
                     "/cosmos.staking.v1beta1.MsgRedeemTokensForShares",
                     "/cosmos.staking.v1beta1.MsgTokenizeShares",
                     "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation",
+                    "/cosmos.staking.v1beta1.MsgDisableTokenizeShares",
                     "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
                     "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
                     "/cosmos.distribution.v1beta1.MsgFundCommunityPool",

--- a/dockernet/dockerfiles/Dockerfile.dydx
+++ b/dockernet/dockerfiles/Dockerfile.dydx
@@ -4,9 +4,9 @@ WORKDIR /opt/
 
 RUN set -eux; apk add --no-cache ca-certificates build-base git linux-headers
 
-RUN git clone https://github.com/Stride-Labs/v4-chain.git \
+RUN git clone https://github.com/dydxprotocol/v4-chain.git \
     && cd v4-chain/protocol \
-    && git checkout fafd3a9e2083180d7f7809f5080897e714e52bec
+    && git checkout protocol/v3.0.0-rc1
 
 WORKDIR /opt/v4-chain/protocol
 

--- a/dockernet/dockerfiles/Dockerfile.dydx
+++ b/dockernet/dockerfiles/Dockerfile.dydx
@@ -23,4 +23,5 @@ WORKDIR /home/dydx
 
 EXPOSE 26657 26656 1317 9090
 
-CMD ["dydxprotocold", "start"]
+CMD dydxprotocold start \
+    --bridge-daemon-eth-rpc-endpoint https://eth-sepolia.g.alchemy.com/v2/demo

--- a/dockernet/dockerfiles/Dockerfile.dydx
+++ b/dockernet/dockerfiles/Dockerfile.dydx
@@ -24,4 +24,7 @@ WORKDIR /home/dydx
 EXPOSE 26657 26656 1317 9090
 
 CMD dydxprotocold start \
-    --bridge-daemon-eth-rpc-endpoint https://eth-sepolia.g.alchemy.com/v2/demo
+    --price-daemon-enabled false \
+    --bridge-daemon-enabled false \
+    --liquidation-daemon-enabled false \
+    --bridge-daemon-eth-rpc-endpoint https://eth-sepolia.g.alchemy.com/v2/demo 

--- a/dockernet/dockerfiles/Dockerfile.relayer
+++ b/dockernet/dockerfiles/Dockerfile.relayer
@@ -3,12 +3,10 @@ FROM golang:1.20-alpine3.16 AS builder
 
 WORKDIR /src/
 
-# TODO [LSM]: Revert
-# ENV COMMIT_HASH=v2.4.1
-ENV COMMIT_HASH=0136134766142f133f263f3bba72d7077e7bc2c1
+ENV COMMIT_HASH=v2.4.2
 
 RUN apk add --update git make gcc linux-headers libc-dev eudev-dev 
-RUN git clone https://github.com/Stride-Labs/relayer.git \
+RUN git clone https://github.com/cosmos/relayer.git \
     && cd relayer \
     && git checkout $COMMIT_HASH \
     && make install

--- a/dockernet/upgrades/Dockerfile.cosmovisor
+++ b/dockernet/upgrades/Dockerfile.cosmovisor
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1
-FROM golang:1.21-alpine3.15 AS builder
+FROM golang:1.21-alpine3.19 AS builder
 
 ARG old_commit_hash
 ARG stride_admin_address

--- a/x/autopilot/keeper/liquidstake.go
+++ b/x/autopilot/keeper/liquidstake.go
@@ -144,6 +144,9 @@ func (k Keeper) IBCTransferStToken(
 	}
 
 	// Store the original receiver as the fallback address in case the transfer fails
+	// autopilotMetadata.StrideAddress is never the hashed address, because the autopilotMetadata struct
+	// is parsed upstream of hashing the receiver
+	// So StrideAddress is used as the fallback (which is always the original receiver)
 	k.SetTransferFallbackAddress(ctx, channelId, transferResponse.Sequence, autopilotMetadata.StrideAddress)
 
 	return err

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -360,7 +360,7 @@ func (k Keeper) ReinvestRewards(ctx sdk.Context) {
 func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
 	k.Logger(ctx).Info("Disabling LSM tokenization Gaia delegations")
 
-	chainId := "GAIA"
+	chainId := "cosmoshub-4"
 	hostZone, found := k.GetHostZone(ctx, chainId)
 	if !found {
 		k.Logger(ctx).Error("Gaia host zone not found, unable to disable tokenization")

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -358,7 +358,7 @@ func (k Keeper) ReinvestRewards(ctx sdk.Context) {
 
 // TODO [cleanup]: Remove after v17 upgrade
 func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
-	k.Logger(ctx).Info("Disabling tokenization of LSM shares for Gaia")
+	k.Logger(ctx).Info("Disabling LSM tokenization Gaia delegations")
 
 	chainId := "GAIA"
 	hostZone, found := k.GetHostZone(ctx, chainId)

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -103,7 +103,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 
 	// TODO [cleanup]: Remove after v17 upgrade
 	// Submit ICA to disable gaia tokenization (this only needs to be run once)
-	if epochInfo.Identifier == epochstypes.HOUR_EPOCH && epochNumber%10 == 0 {
+	if epochInfo.Identifier == epochstypes.HOUR_EPOCH {
 		k.DisableHubTokenization(ctx)
 	}
 }
@@ -358,6 +358,8 @@ func (k Keeper) ReinvestRewards(ctx sdk.Context) {
 
 // TODO [cleanup]: Remove after v17 upgrade
 func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
+	k.Logger(ctx).Info("Disabling tokenization of LSM shares for Gaia")
+
 	chainId := "cosmoshub-4"
 	hostZone, found := k.GetHostZone(ctx, chainId)
 	if !found {

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -103,7 +103,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 
 	// TODO [cleanup]: Remove after v17 upgrade
 	// Submit ICA to disable gaia tokenization (this only needs to be run once)
-	if epochInfo.Identifier == epochstypes.HOUR_EPOCH {
+	if epochInfo.Identifier == epochstypes.HOUR_EPOCH && epochNumber%10 == 0 {
 		k.DisableHubTokenization(ctx)
 	}
 }

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -103,7 +103,7 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 
 	// TODO [cleanup]: Remove after v17 upgrade
 	// Submit ICA to disable gaia tokenization (this only needs to be run once)
-	if epochInfo.Identifier == epochstypes.HOUR_EPOCH && epochNumber%10 == 0 {
+	if epochInfo.Identifier == epochstypes.DAY_EPOCH && epochNumber%10 == 0 {
 		k.DisableHubTokenization(ctx)
 	}
 }
@@ -360,7 +360,7 @@ func (k Keeper) ReinvestRewards(ctx sdk.Context) {
 func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
 	k.Logger(ctx).Info("Disabling tokenization of LSM shares for Gaia")
 
-	chainId := "cosmoshub-4"
+	chainId := "GAIA"
 	hostZone, found := k.GetHostZone(ctx, chainId)
 	if !found {
 		k.Logger(ctx).Error("Gaia host zone not found, unable to disable tokenization")

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -358,7 +358,7 @@ func (k Keeper) ReinvestRewards(ctx sdk.Context) {
 
 // TODO [cleanup]: Remove after v17 upgrade
 func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
-	k.Logger(ctx).Info("Disabling LSM tokenization Gaia delegations")
+	k.Logger(ctx).Info("Disabling the ability to tokenize Gaia delegations")
 
 	chainId := "cosmoshub-4"
 	hostZone, found := k.GetHostZone(ctx, chainId)

--- a/x/stakeibc/keeper/host_zone_test.go
+++ b/x/stakeibc/keeper/host_zone_test.go
@@ -7,6 +7,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 	"github.com/stretchr/testify/require"
 
 	keepertest "github.com/Stride-Labs/stride/v17/testutil/keeper"
@@ -495,4 +496,24 @@ func (s *KeeperTestSuite) TestCheckValidatorWeightsBelowCap() {
 			}
 		})
 	}
+}
+
+// TODO [cleanup]: Remove after v17 upgrade
+func (s *KeeperTestSuite) TestDisableHubTokenization() {
+	chainId := "cosmoshub-4"
+
+	// Create the host zone and delegation channel
+	owner := types.FormatHostZoneICAOwner(chainId, types.ICAAccountType_DELEGATION)
+	channelId, portId := s.CreateICAChannel(owner)
+
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, types.HostZone{
+		ChainId:      chainId,
+		ConnectionId: ibctesting.FirstConnectionID,
+	})
+
+	// Call the disable function and confirm the sequence number incremented (indicating an ICA was submitted)
+	s.CheckICATxSubmitted(portId, channelId, func() error {
+		s.App.StakeibcKeeper.DisableHubTokenization(s.Ctx)
+		return nil
+	})
 }


### PR DESCRIPTION
## Context
Submitting the detokenization ICA from the upgrade handler doesn't seem trivial. Instead, we're temporarily moving it to hooks and will remove in the next upgrade.

## Brief Changelog
* Moved disable tokenization function to hooks, running once every 10 days
* Fixed/moved unit tests

## Testing Strategy
* Changed `cosmoshub-4` chain-id to `GAIA` in the code and changed it to run every day epoch (instead of every 10)
* Started dockernet on the old binary (wasn't totally necessary)
* Checked that the delegation ICA was locked
```bash
>>> gaiadl q staking tokenize-share-lock-info cosmos1eld82php5h2dpgke8ansn5pajrgu69pzkpajn0mkuf3ujk6lvz9qyvdd48
expiration_time: ""
status: TOKENIZE_SHARE_LOCK_STATUS_UNLOCKED
```
* Ran through the upgrade
* Waited for an epoch
* Confirmed the account was locked
```
>>> gaiadl q staking tokenize-share-lock-info cosmos1eld82php5h2dpgke8ansn5pajrgu69pzkpajn0mkuf3ujk6lvz9qyvdd48
expiration_time: ""
status: TOKENIZE_SHARE_LOCK_STATUS_LOCKED
```
* Confirmed there were ack errors after the first one succeeded (since you can only lock once), but that the failures were just ignored and the account stayed locked