### PR TITLE
remove url escape icq

### DIFF
--- a/dockernet/tests/integration_tests.bats
+++ b/dockernet/tests/integration_tests.bats
@@ -406,7 +406,7 @@ setup_file() {
   # equal to 2 * REDEEM_AMOUNT (since there were two redemptions - one from autopilot, one here)
   redemption_record_amount=$($STRIDE_MAIN_CMD q records list-user-redemption-record  | grep -Fiw 'amount' | head -n 1 | grep -o -E '[0-9]+')
   expected_record_minimum=$(echo "$REDEEM_AMOUNT * 2" | bc)
-  assert_equal "$(($redemption_record_amount > $expected_record_minimum))" "1"
+  assert_equal "$(($redemption_record_amount >= $expected_record_minimum))" "1"
 
   WAIT_FOR_STRING $STRIDE_LOGS "\[REDEMPTION] completed on $HOST_CHAIN_ID"
   WAIT_FOR_BLOCK $STRIDE_LOGS 2

--- a/x/interchainquery/keeper/msg_server.go
+++ b/x/interchainquery/keeper/msg_server.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -88,7 +87,7 @@ func (k Keeper) VerifyKeyProof(ctx sdk.Context, msg *types.MsgSubmitQueryRespons
 	var clientStateProof []*ics23.ProofSpec = tendermintClientState.ProofSpecs
 
 	// Get the merkle path and merkle proof
-	path := commitmenttypes.NewMerklePath([]string{pathParts[1], url.PathEscape(string(query.RequestData))}...)
+	path := commitmenttypes.NewMerklePath([]string{pathParts[1], string(query.RequestData)}...)
 	merkleProof, err := commitmenttypes.ConvertProofs(msg.ProofOps)
 	if err != nil {
 		return errorsmod.Wrapf(types.ErrInvalidICQProof, "Error converting proofs: %s", err.Error())


### PR DESCRIPTION
**Summary**
Upgrading from ibc-go 7.2.0 -> 7.3.1 caused ICQs to fail with the following error
```
dockernet-stride1-1  | 7:35PM INF |   GAIA          |  VALIDATOR ICQCALLBACK  |  Inclusion proof validated - QueryId cd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50 module=x/interchainquery
```

The issue is in `modules/core/23-commitment/types/merkle.go`. Looking at the diff in [merkle.go between those releases](https://github.com/cosmos/ibc-go/compare/v7.2.0...v7.3.1), we see that `GetKey` no long URL escapes merkle paths.

https://github.com/cosmos/ibc-go/compare/v7.2.0...v7.3.1#diff-dd94ec1dde9b047c0cdfba204e30dad74a81de202e3b09ac5b42f493153811afR119

So, we also have to remove url escaping from Stride.

Relevant information from ibc-go: [changelog](https://github.com/cosmos/ibc-go/blob/v7.3.0/CHANGELOG.md#improvements) and [PR](https://github.com/cosmos/ibc-go/pull/4429). 

Also fixes a typo in the integration tests (@sampocs)

**Test plan**
Run integration tests
```
 ✓ [INTEGRATION-BASIC-GAIA] host zones successfully registered
 ✓ [INTEGRATION-BASIC-GAIA] ibc transfer
 ✓ [INTEGRATION-BASIC-GAIA] liquid stake mint and transfer
 ✓ [INTEGRATION-BASIC-GAIA] packet forwarding automatically liquid stake and ibc transfer stAsset to original network
 ✓ [INTEGRATION-BASIC-GAIA] delegation on GAIA
 ✓ [INTEGRATION-BASIC-GAIA] LSM liquid stake
 ✓ [INTEGRATION-BASIC-GAIA] LSM liquid stake with slash query
 ✓ [INTEGRATION-BASIC-GAIA] autopilot liquid stake
 ✓ [INTEGRATION-BASIC-GAIA] autopilot liquid stake and transfer
 ✓ [INTEGRATION-BASIC-GAIA] autopilot redeem stake
```