### PR TITLE
reset delegation change in progress to 0 when a channel is restored

### DIFF
--- a/x/stakeibc/keeper/msg_server_restore_interchain_account.go
+++ b/x/stakeibc/keeper/msg_server_restore_interchain_account.go
@@ -53,6 +53,13 @@ func (k msgServer) RestoreInterchainAccount(goCtx context.Context, msg *types.Ms
 			return nil, types.ErrHostZoneNotFound.Wrapf("delegation ICA supplied, but no associated host zone")
 		}
 
+		// Since any ICAs along the original channel will never get relayed,
+		// we have to reset the delegation_changes_in_progress field on each validator
+		for _, validator := range hostZone.Validators {
+			validator.DelegationChangesInProgress = 0
+		}
+		k.SetHostZone(ctx, hostZone)
+
 		// revert DELEGATION_IN_PROGRESS records for the closed ICA channel (so that they can be staked)
 		depositRecords := k.RecordsKeeper.GetAllDepositRecord(ctx)
 		for _, depositRecord := range depositRecords {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Context 
The `DelegationChangesInProgress` field on the validator struct is a mechanism to prevent ICA/ICQ overlap. When ICAs are submitted, the `DelegationChangesInProgress` field is incremented, and when the ack comes back, it is decremented.

In order to prevent ICA/ICQ overlap, when a slash ICQ is relayed, it [[checks](https://github.com/Stride-Labs/stride/blob/main/x/stakeibc/keeper/icqcallbacks_delegator_shares.go#L147-L148)] if there are any active delegation changes in progress, and if so, the query is retried (since the results can’t be trusted)

However, when an ICA packet times out, the channel is closed and the pending packets are never relayed. Since we never receive the ack for these packets, the `DelegationChangesInProgress` field never gets decremented. 

This PR sets the `DelegationChangesInProgress` field to 0 when the ICA channel is restored.

## Brief Changelog
* Set the `DelegationChangesInProgress` to 0 when a channel is restored and added unit test

