### PR TITLE
send staketia redemption rate to oracle

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -633,8 +633,9 @@ func NewStrideApp(
 		keys[staketiatypes.StoreKey],
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.TransferKeeper,
+		app.ICAOracleKeeper,
 		app.RatelimitKeeper,
+		app.TransferKeeper,
 	)
 	stakeTiaModule := staketia.NewAppModule(appCodec, app.StaketiaKeeper)
 

--- a/x/staketia/keeper/hooks.go
+++ b/x/staketia/keeper/hooks.go
@@ -32,6 +32,11 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 			return
 		}
 
+		// Post the redemption rate to the oracle (if it doesn't exceed the bounds)
+		if err := k.PostRedemptionRateToOracles(ctx); err != nil {
+			k.Logger(ctx).Error(fmt.Sprintf("Unable to post redemption rate to oracle: %s", err.Error()))
+		}
+
 		// Prepare delegations by transferring the deposited tokens to the host zone
 		if err := k.SafelyPrepareDelegation(ctx, epochNumber, epochInfo.Duration); err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to prepare delegation for epoch %d: %s", epochNumber, err.Error()))

--- a/x/staketia/keeper/keeper.go
+++ b/x/staketia/keeper/keeper.go
@@ -16,8 +16,9 @@ type Keeper struct {
 	storeKey        storetypes.StoreKey
 	accountKeeper   types.AccountKeeper
 	bankKeeper      types.BankKeeper
-	transferKeeper  types.TransferKeeper
+	icaOracleKeeper types.ICAOracleKeeper
 	ratelimitKeeper types.RatelimitKeeper
+	transferKeeper  types.TransferKeeper
 }
 
 func NewKeeper(
@@ -25,16 +26,18 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
-	transferKeeper types.TransferKeeper,
+	icaOracleKeeper types.ICAOracleKeeper,
 	ratelimitKeeper types.RatelimitKeeper,
+	transferKeeper types.TransferKeeper,
 ) *Keeper {
 	return &Keeper{
 		cdc:             cdc,
 		storeKey:        storeKey,
 		accountKeeper:   accountKeeper,
 		bankKeeper:      bankKeeper,
-		transferKeeper:  transferKeeper,
+		icaOracleKeeper: icaOracleKeeper,
 		ratelimitKeeper: ratelimitKeeper,
+		transferKeeper:  transferKeeper,
 	}
 }
 

--- a/x/staketia/keeper/redemption_rate.go
+++ b/x/staketia/keeper/redemption_rate.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/Stride-Labs/stride/v18/utils"
+	icaoracletypes "github.com/Stride-Labs/stride/v18/x/icaoracle/types"
 	"github.com/Stride-Labs/stride/v18/x/staketia/types"
 )
 
@@ -110,7 +111,7 @@ func (k Keeper) CheckRedemptionRateExceedsBounds(ctx sdk.Context) error {
 
 // Pushes a redemption rate update to the ICA oracle
 func (k Keeper) PostRedemptionRateToOracles(ctx sdk.Context, hostDenom string, redemptionRate sdk.Dec) error {
-	stDenom := types.StAssetDenomFromHostZoneDenom(hostDenom)
+	stDenom := utils.StAssetDenomFromHostZoneDenom(hostDenom)
 	attributes, err := json.Marshal(icaoracletypes.RedemptionRateAttributes{
 		SttokenDenom: stDenom,
 	})
@@ -122,7 +123,7 @@ func (k Keeper) PostRedemptionRateToOracles(ctx sdk.Context, hostDenom string, r
 	metricKey := fmt.Sprintf("%s_%s", stDenom, icaoracletypes.MetricType_RedemptionRate)
 	metricValue := redemptionRate.String()
 	metricType := icaoracletypes.MetricType_RedemptionRate
-	k.ICAOracleKeeper.QueueMetricUpdate(ctx, metricKey, metricValue, metricType, string(attributes))
+	k.icaOracleKeeper.QueueMetricUpdate(ctx, metricKey, metricValue, metricType, string(attributes))
 
 	return nil
 }

--- a/x/staketia/keeper/redemption_rate.go
+++ b/x/staketia/keeper/redemption_rate.go
@@ -110,8 +110,18 @@ func (k Keeper) CheckRedemptionRateExceedsBounds(ctx sdk.Context) error {
 }
 
 // Pushes a redemption rate update to the ICA oracle
-func (k Keeper) PostRedemptionRateToOracles(ctx sdk.Context, hostDenom string, redemptionRate sdk.Dec) error {
-	stDenom := utils.StAssetDenomFromHostZoneDenom(hostDenom)
+func (k Keeper) PostRedemptionRateToOracles(ctx sdk.Context) error {
+	if err := k.CheckRedemptionRateExceedsBounds(ctx); err != nil {
+		return errorsmod.Wrapf(err, "preventing oracle update since redemption rate exceeded bounds")
+	}
+
+	hostZone, err := k.GetHostZone(ctx)
+	if err != nil {
+		return err
+	}
+	redemptionRate := hostZone.RedemptionRate
+
+	stDenom := utils.StAssetDenomFromHostZoneDenom(hostZone.NativeTokenDenom)
 	attributes, err := json.Marshal(icaoracletypes.RedemptionRateAttributes{
 		SttokenDenom: stDenom,
 	})

--- a/x/staketia/types/expected_keepers.go
+++ b/x/staketia/types/expected_keepers.go
@@ -36,3 +36,8 @@ type RatelimitKeeper interface {
 	AddDenomToBlacklist(ctx sdk.Context, denom string)
 	RemoveDenomFromBlacklist(ctx sdk.Context, denom string)
 }
+
+// Required ICAOracleKeeper functions
+type ICAOracleKeeper interface {
+	QueueMetricUpdate(ctx sdk.Context, key, value, metricType, attributes string)
+}


### PR DESCRIPTION
## Context
Sends the stTIA redemption rate to the ICA oracle

## Brief Changelog
* Wires up ICAOracle Keeper
* Added function to write RR to oracle (copied from stakeibc and then modified)
* Pushes the RR to the oracle only if the RR update was successful and the bounds were not exceeded

## Open Question
(Not blocking this PR) - Confirming that the 24 hour cadence is fine for integrations
