### PR TITLE
fixing init_chain script to not clobber new params

### DIFF
--- a/dockernet/src/init_chain.sh
+++ b/dockernet/src/init_chain.sh
@@ -362,7 +362,7 @@ for (( i=2; i <= $NUM_NODES; i++ )); do
     genesis_json="${STATE}/${node_name}/config/genesis.json"
 
     # add the main node as a persistent peer
-    sed -i -E "s|persistent_peers = .*|persistent_peers = \"${MAIN_NODE_ID}\"|g" $config_toml
+    sed -i -E "s|\bpersistent_peers = .*|persistent_peers = \"${MAIN_NODE_ID}\"|g" $config_toml
     # copy the main node's genesis to the peer nodes to ensure they all have the same genesis
     cp $MAIN_GENESIS $genesis_json
 

--- a/dockernet/src/init_chain.sh
+++ b/dockernet/src/init_chain.sh
@@ -362,7 +362,7 @@ for (( i=2; i <= $NUM_NODES; i++ )); do
     genesis_json="${STATE}/${node_name}/config/genesis.json"
 
     # add the main node as a persistent peer
-    sed -i -E "s|\bpersistent_peers = .*|persistent_peers = \"${MAIN_NODE_ID}\"|g" $config_toml
+    sed -i -E "s|^persistent_peers = .*|persistent_peers = \"${MAIN_NODE_ID}\"|g" $config_toml
     # copy the main node's genesis to the peer nodes to ensure they all have the same genesis
     cp $MAIN_GENESIS $genesis_json
 


### PR DESCRIPTION
There are new params when starting the chain which were being overwritten
experimental_max_gossip_connections_to_persistent_peers
experimental_max_gossip_connections_to_non_persistent_peers
Because in the init_chain.sh script we had a regex looking for the variable persistent_peers and it was writing values to these
With the wrong type being written to these params, nodes after the first one would fail to start
This was causing dockernet to only start one validator when expecting 3 and then no blocks could reach consensus

Added a word boundary to that intended variable so these new variables can be left alone.

Dockernet can now start
All unit tests in `make test-unit` are passing again
All integration tests in `make test-integration-docker` are passing again