### PR TITLE
added wasm to cosmovisor upgrade image

### DIFF
--- a/dockernet/upgrades/Dockerfile.cosmovisor
+++ b/dockernet/upgrades/Dockerfile.cosmovisor
@@ -15,14 +15,20 @@ RUN git clone https://github.com/cosmos/cosmos-sdk \
     && git checkout cosmovisor/v1.1.0 
 RUN --mount=type=cache,target=/root/.cache/go-build cd /opt/cosmos-sdk && make cosmovisor 
 
-# Build the old binary
-RUN git clone https://github.com/Stride-Labs/stride.git \
-    && cd stride \
-    && git checkout $old_commit_hash \
-    && sed -i -E "s|stride1k8c2m5cn322akk5wy8lpt87dd2f4yh9azg7jlh|$stride_admin_address|g" utils/admins.go \
-    && env GOOS=linux GOARCH=amd64 go build -mod=readonly -trimpath -o /opt/build/ ./... \
-    && mv /opt/build/strided /opt/build/strided1 
+# Download stride and checkout the old version
+RUN git clone https://github.com/Stride-Labs/stride.git 
+WORKDIR /opt/stride
 
-RUN --mount=type=cache,target=/root/.cache/go-build cd /opt/stride && make build
+RUN git checkout $old_commit_hash \
+    && sed -i -E "s|stride1k8c2m5cn322akk5wy8lpt87dd2f4yh9azg7jlh|$stride_admin_address|g" utils/admins.go 
 
+# Install wasm
+RUN WASMVM_VERSION=$(cat go.mod | grep github.com/CosmWasm/wasmvm | awk '{print $2}') \
+    && wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
+    -O /lib/libwasmvm_muslc.a
 
+# Build the old stride binary
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    BUILD_TAGS=muslc LINK_STATICALLY=true make build \
+    && mkdir /opt/build \
+    && mv /opt/stride/build/strided /opt/build/strided1 


### PR DESCRIPTION
## Context
In order to run the dockernet upgrade, we need wasm on the docker image that builds the old binary