### PR TITLE
Fix validator weight check

### DIFF
--- a/x/stakeibc/keeper/gov.go
+++ b/x/stakeibc/keeper/gov.go
@@ -13,6 +13,11 @@ func (k Keeper) AddValidatorsProposal(ctx sdk.Context, msg *types.AddValidatorsP
 		}
 	}
 
+	// Confirm none of the validator's exceed the weight cap
+	if err := k.CheckValidatorWeightsBelowCap(ctx, msg.HostZone); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/x/stakeibc/keeper/host_zone_test.go
+++ b/x/stakeibc/keeper/host_zone_test.go
@@ -488,7 +488,13 @@ func (s *KeeperTestSuite) TestCheckValidatorWeightsBelowCap() {
 			params.ValidatorWeightCap = tc.weightCap
 			s.App.StakeibcKeeper.SetParams(s.Ctx, params)
 
-			err := s.App.StakeibcKeeper.CheckValidatorWeightsBelowCap(s.Ctx, tc.validators)
+			hostZone := types.HostZone{
+				ChainId:    HostChainId,
+				Validators: tc.validators,
+			}
+			s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+
+			err := s.App.StakeibcKeeper.CheckValidatorWeightsBelowCap(s.Ctx, HostChainId)
 			if !tc.exceedsCap {
 				s.Require().NoError(err, "set should not have exceeded cap")
 			} else {

--- a/x/stakeibc/keeper/msg_server.go
+++ b/x/stakeibc/keeper/msg_server.go
@@ -291,6 +291,11 @@ func (k msgServer) AddValidators(goCtx context.Context, msg *types.MsgAddValidat
 		}
 	}
 
+	// Confirm none of the validator's exceed the weight cap
+	if err := k.CheckValidatorWeightsBelowCap(ctx, msg.HostZone); err != nil {
+		return nil, err
+	}
+
 	return &types.MsgAddValidatorsResponse{}, nil
 }
 
@@ -334,7 +339,7 @@ func (k msgServer) ChangeValidatorWeight(goCtx context.Context, msg *types.MsgCh
 	}
 
 	// Confirm the new weights wouldn't cause any validator to exceed the weight cap
-	if err := k.CheckValidatorWeightsBelowCap(ctx, hostZone.Validators); err != nil {
+	if err := k.CheckValidatorWeightsBelowCap(ctx, msg.HostZone); err != nil {
 		return nil, errorsmod.Wrapf(err, "unable to change validator weight")
 	}
 


### PR DESCRIPTION
## Context
The validator weight check was be run after each validator was added. It should instead be done once after all validators were added - otherwise, it can error prematurely. 

## Brief Changelog
* Pulled out `CheckValidatorWeightsBelowCap` into relevant msg_server functions (with and without gov)
* Updated `CheckValidatorWeightsBelowCap` to take a chainId as an arg and look up the host zone + validators (instead of taking validators as an arg)
* Fixed the unit test

## Testing
* Created the following [add-validator-propoal-file](https://github.com/Stride-Labs/stride/files/14953726/add-vals.json). This has the same weights that were used for stSAGA
* Started dockernet **on main branch**, placing an early exit in `register_host.sh` before the validators were added normally
* Added validators using the attached file, confirmed it errored
```bash
>>> strided tx stakeibc add-validators GAIA add-vals.json --from admin -y --gas 1000000

raw_log: 'failed to execute message; message index: 0: validator cosmosvaloper14kn0kk33szpwus9nh8n87fjel8djx0y070ymmj
  exceeds weight cap, has 11.39913057478667% of the total weight when the cap is 10%:
```
* Restarted the process on this PR's branch, added validators with the same file, and confirmed it succeeded
* Changed the first validators weight to 1200 and repeated the process - confirming that registration failed 
