### PR TITLE
fixed ibc hooks store key

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -351,7 +351,7 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 		}
 	case "v22":
 		storeUpgrades = &storetypes.StoreUpgrades{
-			Added: []string{ibchookstypes.ModuleName},
+			Added: []string{ibchookstypes.StoreKey},
 		}
 	}
 


### PR DESCRIPTION
## Context
Contrary to most new modules, the store key for ibc hooks is not the module name