### PR TITLE
batch undelegations - redemption sweep

### DIFF
--- a/x/stakeibc/keeper/icacallbacks_claim.go
+++ b/x/stakeibc/keeper/icacallbacks_claim.go
@@ -100,7 +100,7 @@ func (k Keeper) DecrementHostZoneUnbonding(ctx sdk.Context, userRedemptionRecord
 	}
 
 	// decrement the hzu by the amount claimed
-	hostZoneUnbonding.NativeTokenAmount = hostZoneUnbonding.NativeTokenAmount.Sub(userRedemptionRecord.NativeTokenAmount)
+	hostZoneUnbonding.ClaimableNativeTokens = hostZoneUnbonding.ClaimableNativeTokens.Sub(userRedemptionRecord.NativeTokenAmount)
 
 	// save the updated hzu on the epoch unbonding record
 	epochUnbondingRecord, success := k.RecordsKeeper.AddHostZoneToEpochUnbondingRecord(ctx, callbackArgs.EpochNumber, callbackArgs.ChainId, hostZoneUnbonding)

--- a/x/stakeibc/keeper/icacallbacks_claim_test.go
+++ b/x/stakeibc/keeper/icacallbacks_claim_test.go
@@ -58,24 +58,24 @@ func (s *KeeperTestSuite) SetupClaimCallback() ClaimCallbackTestCase {
 		HostZoneId:            HostChainId,
 		Status:                recordtypes.HostZoneUnbonding_CLAIMABLE,
 		UserRedemptionRecords: []string{recordId1, recordId2},
-		NativeTokenAmount:     sdkmath.NewInt(1_000_000),
+		ClaimableNativeTokens: sdkmath.NewInt(1_000_000),
 	}
 	hostZoneUnbonding2 := recordtypes.HostZoneUnbonding{
 		HostZoneId:            "not_gaia",
 		Status:                recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
 		UserRedemptionRecords: []string{recordId3},
-		NativeTokenAmount:     sdkmath.NewInt(1_000_000),
+		ClaimableNativeTokens: sdkmath.NewInt(1_000_000),
 	}
 	// some other hzus in the future
 	hostZoneUnbonding3 := recordtypes.HostZoneUnbonding{
-		HostZoneId:        "not_gaia",
-		Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
-		NativeTokenAmount: sdkmath.NewInt(1_000_000),
+		HostZoneId:            "not_gaia",
+		Status:                recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+		ClaimableNativeTokens: sdkmath.NewInt(1_000_000),
 	}
 	hostZoneUnbonding4 := recordtypes.HostZoneUnbonding{
-		HostZoneId:        HostChainId,
-		Status:            recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
-		NativeTokenAmount: sdkmath.NewInt(1_000_000),
+		HostZoneId:            HostChainId,
+		Status:                recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE,
+		ClaimableNativeTokens: sdkmath.NewInt(1_000_000),
 	}
 	epochUnbondingRecord1 := recordtypes.EpochUnbondingRecord{
 		EpochNumber:        epochNumber,
@@ -106,7 +106,7 @@ func (s *KeeperTestSuite) SetupClaimCallback() ClaimCallbackTestCase {
 			callbackArgs:    callbackArgs,
 			epochNumber:     epochNumber,
 			decrementAmount: decrementAmount,
-			hzu1TokenAmount: hostZoneUnbonding1.NativeTokenAmount,
+			hzu1TokenAmount: hostZoneUnbonding1.ClaimableNativeTokens,
 		},
 		validArgs: ClaimCallbackArgs{
 			packet:      packet,
@@ -140,14 +140,14 @@ func (s *KeeperTestSuite) TestClaimCallback_Successful() {
 	hzu4 := epochUnbondingRecord2.HostZoneUnbondings[1]
 
 	// check that hzu1 has a decremented amount
-	s.Require().Equal(hzu1.NativeTokenAmount, tc.initialState.hzu1TokenAmount.Sub(tc.initialState.decrementAmount), "hzu1 amount decremented")
+	s.Require().Equal(hzu1.ClaimableNativeTokens, tc.initialState.hzu1TokenAmount.Sub(tc.initialState.decrementAmount), "hzu1 amount decremented")
 	s.Require().Equal(hzu1.Status, recordtypes.HostZoneUnbonding_CLAIMABLE, "hzu1 status set to transferred")
 	// verify the other hzus are unchanged
-	s.Require().Equal(hzu2.NativeTokenAmount, hzu2.NativeTokenAmount, "hzu2 amount unchanged")
+	s.Require().Equal(hzu2.ClaimableNativeTokens, hzu2.ClaimableNativeTokens, "hzu2 amount unchanged")
 	s.Require().Equal(hzu2.Status, recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE, "hzu2 status set to transferred")
-	s.Require().Equal(hzu3.NativeTokenAmount, hzu3.NativeTokenAmount, "hzu3 amount unchanged")
+	s.Require().Equal(hzu3.ClaimableNativeTokens, hzu3.ClaimableNativeTokens, "hzu3 amount unchanged")
 	s.Require().Equal(hzu3.Status, recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE, "hzu3 status set to transferred")
-	s.Require().Equal(hzu4.NativeTokenAmount, hzu4.NativeTokenAmount, "hzu4 amount unchanged")
+	s.Require().Equal(hzu4.ClaimableNativeTokens, hzu4.ClaimableNativeTokens, "hzu4 amount unchanged")
 	s.Require().Equal(hzu4.Status, recordtypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE, "hzu4 status set to transferred")
 }
 
@@ -220,7 +220,7 @@ func (s *KeeperTestSuite) TestDecrementHostZoneUnbonding_Success() {
 	hzu1 := epochUnbondingRecord1.HostZoneUnbondings[0]
 
 	// check that hzu1 has a decremented amount
-	s.Require().Equal(hzu1.NativeTokenAmount.Sub(userRedemptionRecord.NativeTokenAmount), hzu1.NativeTokenAmount, "hzu1 amount decremented")
+	s.Require().Equal(hzu1.ClaimableNativeTokens.Sub(userRedemptionRecord.NativeTokenAmount), hzu1.ClaimableNativeTokens, "hzu1 amount decremented")
 }
 
 func (s *KeeperTestSuite) TestDecrementHostZoneUnbonding_HzuNotFound() {

--- a/x/stakeibc/keeper/icacallbacks_redemption.go
+++ b/x/stakeibc/keeper/icacallbacks_redemption.go
@@ -85,7 +85,7 @@ func (k Keeper) RedemptionCallback(ctx sdk.Context, packet channeltypes.Packet, 
 	for _, epochNumber := range redemptionCallback.EpochUnbondingRecordIds {
 		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochNumber, chainId)
 		if !found {
-			return recordstypes.ErrHostUnbondingRecordNotFound.Wrapf("record not found for epoch %d and chain %s",
+			return recordstypes.ErrHostUnbondingRecordNotFound.Wrapf("unbonding record not found for epoch %d and chain %s",
 				epochNumber, chainId)
 		}
 

--- a/x/stakeibc/keeper/records.go
+++ b/x/stakeibc/keeper/records.go
@@ -60,7 +60,7 @@ func (k Keeper) CreateEpochUnbondingRecord(ctx sdk.Context, epochNumber uint64) 
 }
 
 // Deletes any epoch unbonding records that have had all unbondings claimed
-func (k Keeper) CleanupEpochUnbondingRecords(ctx sdk.Context, epochNumber uint64) bool {
+func (k Keeper) CleanupEpochUnbondingRecords(ctx sdk.Context, epochNumber uint64) {
 	k.Logger(ctx).Info("Cleaning Claimed Epoch Unbonding Records...")
 
 	for _, epochUnbondingRecord := range k.RecordsKeeper.GetAllEpochUnbondingRecord(ctx) {
@@ -70,18 +70,15 @@ func (k Keeper) CleanupEpochUnbondingRecords(ctx sdk.Context, epochNumber uint64
 		for _, hostZoneUnbonding := range hostZoneUnbondings {
 			// if an EpochUnbondingRecord has any HostZoneUnbonding with non-zero balances, we don't delete the EpochUnbondingRecord
 			// because it has outstanding tokens that need to be claimed
-			if !hostZoneUnbonding.NativeTokenAmount.Equal(sdkmath.ZeroInt()) {
+			notClaimable := hostZoneUnbonding.Status != recordstypes.HostZoneUnbonding_CLAIMABLE
+			hasUnclaimedTokens := !hostZoneUnbonding.ClaimableNativeTokens.Equal(sdkmath.ZeroInt())
+			if notClaimable || hasUnclaimedTokens {
 				shouldDeleteEpochUnbondingRecord = false
 				break
 			}
 		}
 		if shouldDeleteEpochUnbondingRecord {
-			k.Logger(ctx).Info(fmt.Sprintf("  EpochUnbondingRecord %d - All unbondings claimed, removing record", epochUnbondingRecord.EpochNumber))
 			k.RecordsKeeper.RemoveEpochUnbondingRecord(ctx, epochUnbondingRecord.EpochNumber)
-		} else {
-			k.Logger(ctx).Info(fmt.Sprintf("  EpochUnbondingRecord %d - Has unclaimed unbondings", epochUnbondingRecord.EpochNumber))
 		}
 	}
-
-	return true
 }


### PR DESCRIPTION
## Context
Updated redemption sweep to use `ClaimableNativeTokens` instead of `NativeTokens`

## Brief Changelog
* Updated redemption callback to set `ClaimableNativeTokens` at the same time that the status is updated to `Claimable`
* Updated the claim callback to decrement `ClaimableNativeTokens` 
* Fixed a bug in CleanupEpochUnbondingRecords so that it only removes records that are in status Claimable
* Updated unit tests