### PR TITLE
 batched delegations callback

### DIFF
--- a/x/stakeibc/keeper/icacallbacks_delegate_test.go
+++ b/x/stakeibc/keeper/icacallbacks_delegate_test.go
@@ -63,11 +63,12 @@ func (s *KeeperTestSuite) SetupDelegateCallback() DelegateCallbackTestCase {
 		TotalDelegations: totalDelegation,
 	}
 	depositRecord := recordtypes.DepositRecord{
-		Id:                 1,
-		DepositEpochNumber: 1,
-		HostZoneId:         HostChainId,
-		Amount:             balanceToStake,
-		Status:             recordtypes.DepositRecord_DELEGATION_QUEUE,
+		Id:                      1,
+		DepositEpochNumber:      1,
+		HostZoneId:              HostChainId,
+		Amount:                  balanceToStake,
+		Status:                  recordtypes.DepositRecord_DELEGATION_QUEUE,
+		DelegationTxsInProgress: 1,
 	}
 	s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
 	s.App.RecordsKeeper.SetDepositRecord(s.Ctx, depositRecord)
@@ -121,8 +122,7 @@ func (s *KeeperTestSuite) TestDelegateCallback_Successful() {
 	s.Require().NoError(err)
 
 	// Confirm total delegation has increased
-	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, HostChainId)
-	s.Require().True(found)
+	hostZone := s.MustGetHostZone(HostChainId)
 	s.Require().Equal(initialState.totalDelegation.Add(initialState.balanceToStake), hostZone.TotalDelegations, "total delegation should have increased")
 
 	// Confirm delegations have been added to validators and number delegation changes in progress was reduced
@@ -155,6 +155,7 @@ func (s *KeeperTestSuite) checkDelegateStateIfCallbackFailed(tc DelegateCallback
 	s.Require().Len(records, 1, "number of deposit records")
 	record := records[0]
 	s.Require().Equal(recordtypes.DepositRecord_DELEGATION_QUEUE, record.Status, "deposit record status should not have changed")
+	s.Require().Zero(record.DelegationTxsInProgress, "record delegation changes in progress should have reset")
 }
 
 func (s *KeeperTestSuite) TestDelegateCallback_DelegateCallbackTimeout() {

--- a/x/stakeibc/types/errors.go
+++ b/x/stakeibc/types/errors.go
@@ -67,4 +67,5 @@ var (
 	ErrValidatorExceedsWeightCap           = errorsmod.Register(ModuleName, 1560, "validator exceeds weight cap")
 	ErrFeeSplitInvariantFailed             = errorsmod.Register(ModuleName, 1561, "failed to calculate fee split")
 	ErrFailedToRegisterRebate              = errorsmod.Register(ModuleName, 1562, "failed to register rebate")
+	ErrInvalidDelegationsInProgress        = errorsmod.Register(ModuleName, 1563, "invalid delegation changes in progress")
 )


### PR DESCRIPTION
## Context
Counterpart to #1201 implementing the callback.

TODO: add unit test coverage

## Brief Changelog
* Decremented the delegation changes in progress regardless of ack success
* For a successful ack, decrement the total batch amount on the deposit record and only remove the record when it goes to zero