### PR TITLE
Faster `make sync`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test-integration-docker-all:
 
 sync:
 	@git submodule sync --recursive
-	@git submodule update --init --recursive
+	@git submodule update --init --recursive --depth 1
 
 build-docker:
 	@bash $(DOCKERNET_HOME)/build.sh -${build} ${BUILDDIR}


### PR DESCRIPTION
The `--depth` flag is available for this subcommand as of git v2.43.0, which was released on 2023-11-20.