### PR TITLE
V23 upgrade handler (batching and stTIA)

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -303,7 +303,9 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 		v23.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
+			app.RecordsKeeper,
 			app.StakeibcKeeper,
+			app.StaketiaKeeper,
 		),
 	)
 

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -1,10 +1,13 @@
 package v23
 
 import (
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	recordskeeper "github.com/Stride-Labs/stride/v22/x/records/keeper"
+	recordstypes "github.com/Stride-Labs/stride/v22/x/records/types"
 	stakeibckeeper "github.com/Stride-Labs/stride/v22/x/stakeibc/keeper"
 )
 
@@ -17,12 +20,16 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	stakeibcKeeper stakeibckeeper.Keeper,
+	recordsKeeper recordskeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v23...")
 
 		ctx.Logger().Info("Migrating trade routes...")
 		MigrateTradeRoutes(ctx, stakeibcKeeper)
+
+		ctx.Logger().Info("Migrating epoch unbonding records...")
+		MigrateEpochUnbondingRecords(ctx, recordsKeeper)
 
 		ctx.Logger().Info("Running module migrations...")
 		return mm.RunMigrations(ctx, configurator, vm)
@@ -35,5 +42,51 @@ func MigrateTradeRoutes(ctx sdk.Context, k stakeibckeeper.Keeper) {
 	for _, tradeRoute := range k.GetAllTradeRoutes(ctx) {
 		tradeRoute.MinTransferAmount = tradeRoute.TradeConfig.MinSwapAmount
 		k.SetTradeRoute(ctx, tradeRoute)
+	}
+}
+
+// Migrates a single host zone unbonding record to add the new fields: StTokensToBurn,
+// NativeTokensToUnbond, and ClaimableNativeTokens
+//
+// If the record is in status: UNBONDING_QUEUE, EXIT_TRANSFER_QUEUE, or EXIT_TRANSFER_IN_PROGRESS,
+// set stTokensToBurn, NativeTokensToUnbond, and ClaimableNativeTokens all to 0
+//
+// If the record is in status: UNBONDING_IN_PROGRESS
+// set StTokensToBurn to the value of StTokenAmount, NativeTokensToUnbond to the value of NativeTokenAmount,
+// and ClaimableNativeTokens to 0
+//
+// If the record is in status CLAIMABLE,
+// set StTokensToBurn and NativeTokensToUnbond to 0, and set ClaimableNativeTokens to the value of NativeTokenAmount
+func MigrateHostZoneUnbondingRecords(hostZoneUnbonding *recordstypes.HostZoneUnbonding) *recordstypes.HostZoneUnbonding {
+	if hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_UNBONDING_QUEUE ||
+		hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_EXIT_TRANSFER_QUEUE ||
+		hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_EXIT_TRANSFER_IN_PROGRESS {
+
+		hostZoneUnbonding.StTokensToBurn = sdkmath.ZeroInt()
+		hostZoneUnbonding.NativeTokensToUnbond = sdkmath.ZeroInt()
+		hostZoneUnbonding.ClaimableNativeTokens = sdkmath.ZeroInt()
+
+	} else if hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_UNBONDING_IN_PROGRESS {
+		hostZoneUnbonding.StTokensToBurn = hostZoneUnbonding.StTokenAmount
+		hostZoneUnbonding.NativeTokensToUnbond = hostZoneUnbonding.NativeTokenAmount
+		hostZoneUnbonding.ClaimableNativeTokens = sdkmath.ZeroInt()
+
+	} else if hostZoneUnbonding.Status == recordstypes.HostZoneUnbonding_CLAIMABLE {
+		hostZoneUnbonding.StTokensToBurn = sdkmath.ZeroInt()
+		hostZoneUnbonding.NativeTokensToUnbond = sdkmath.ZeroInt()
+		hostZoneUnbonding.ClaimableNativeTokens = hostZoneUnbonding.NativeTokenAmount
+	}
+
+	return hostZoneUnbonding
+}
+
+// Migrate epoch unbonding records to add the new fields from the batched undelegations code
+func MigrateEpochUnbondingRecords(ctx sdk.Context, k recordskeeper.Keeper) {
+	for _, epochUnbondingRecord := range k.GetAllEpochUnbondingRecord(ctx) {
+		for i, oldHostZoneUnbondingRecord := range epochUnbondingRecord.HostZoneUnbondings {
+			updatedHostZoneUnbondingRecord := MigrateHostZoneUnbondingRecords(oldHostZoneUnbondingRecord)
+			epochUnbondingRecord.HostZoneUnbondings[i] = updatedHostZoneUnbondingRecord
+		}
+		k.SetEpochUnbondingRecord(ctx, epochUnbondingRecord)
 	}
 }

--- a/x/staketia/keeper/migration.go
+++ b/x/staketia/keeper/migration.go
@@ -13,8 +13,6 @@ import (
 	"github.com/Stride-Labs/stride/v22/x/staketia/types"
 )
 
-// TODO [UPGRADE HANDLER]: Migrate stakeibc host zone (set redemptions enabled to true on each host zone)
-
 // Helper to deserialize the host zone with the old types
 func (k Keeper) GetLegacyHostZone(ctx sdk.Context) (hostZone oldtypes.HostZone, err error) {
 	store := ctx.KVStore(k.storeKey)


### PR DESCRIPTION
## Context
Portion of v23 upgrade handler related to the batching of ICAs and the stTIA migration.

## Brief Changelog
* Added new host zone unbonding record fields, setting them based on the status
* Set redemptions enabled field to false on host zones
* Initiated staketia migration to stakeibc

## Testing
* Build the old binary
```bash
make UPGRADE_OLD_VERSION=v22.0.0 upgrade-build-old-binary
```
* Upgrade constants in `celestia.go` to re-use the existing gaia channel
  * `CelestiaChainId`: `GAIA`
  * `CelestiaBechPrefix`: `cosmos`
  * CelestiaConnectionId`: `connection-0`
 * Comment out the `register_host.sh` [line](https://github.com/Stride-Labs/stride/blob/main/dockernet/start_network.sh#L72) in `start_network.sh`
 * Start the network
```bash
make UPGRADE_OLD_VERSION=v22.0.0 UPGRADE_NAME=v23 start-docker
```
* Submit the upgrade
```bash
make UPGRADE_NAME=v23 submit-upgrade-immediately
```