### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,14 @@ start-docker-all: stop-docker build-docker
 	@ALL_HOST_CHAINS=true bash $(DOCKERNET_HOME)/start_network.sh
 
 clean-docker:
-	@docker-compose -f $(DOCKERNET_COMPOSE_FILE) stop
-	@docker-compose -f $(DOCKERNET_COMPOSE_FILE) down
+	@docker compose -f $(DOCKERNET_COMPOSE_FILE) stop
+	@docker compose -f $(DOCKERNET_COMPOSE_FILE) down
 	rm -rf $(DOCKERNET_HOME)/state
 	docker image prune -a
 
 stop-docker:
 	@bash $(DOCKERNET_HOME)/pkill.sh
-	docker-compose -f $(DOCKERNET_COMPOSE_FILE) down
+	docker compose -f $(DOCKERNET_COMPOSE_FILE) down
 
 upgrade-build-old-binary:
 	@DOCKERNET_HOME=$(DOCKERNET_HOME) BUILDDIR=$(BUILDDIR) bash $(DOCKERNET_HOME)/upgrades/build_old_binary.sh
@@ -172,7 +172,7 @@ start-local-to-main:
 	bash scripts/local-to-mainnet/start.sh
 
 stop-local-to-main:
-	docker-compose -f $(LOCAL_TO_MAIN_COMPOSE_FILE) down
+	docker compose -f $(LOCAL_TO_MAIN_COMPOSE_FILE) down
 
 ###############################################################################
 ###                                Protobuf                                 ###
@@ -217,32 +217,32 @@ localnet-clean:
 	@rm -rfI $(HOME)/.stride/
 
 localnet-build:
-	@docker-compose -f $(LOCALNET_COMPOSE_FILE) build
+	@docker compose -f $(LOCALNET_COMPOSE_FILE) build
 
 localnet-start:
-	@docker-compose -f $(LOCALNET_COMPOSE_FILE) up
+	@docker compose -f $(LOCALNET_COMPOSE_FILE) up
 
 localnet-startd:
-	@docker-compose -f $(LOCALNET_COMPOSE_FILE) up -d
+	@docker compose -f $(LOCALNET_COMPOSE_FILE) up -d
 
 localnet-stop:
-	@docker-compose -f $(LOCALNET_COMPOSE_FILE) down
+	@docker compose -f $(LOCALNET_COMPOSE_FILE) down
 
 localnet-state-export-init: localnet-state-export-clean localnet-state-export-build
 
 localnet-state-export-build:
-	@DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f $(STATE_EXPORT_COMPOSE_FILE) build
+	@DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker compose -f $(STATE_EXPORT_COMPOSE_FILE) build
 
 localnet-state-export-start:
-	@docker-compose -f $(STATE_EXPORT_COMPOSE_FILE) up
+	@docker compose -f $(STATE_EXPORT_COMPOSE_FILE) up
 
 localnet-state-export-startd:
-	@docker-compose -f $(STATE_EXPORT_COMPOSE_FILE) up -d
+	@docker compose -f $(STATE_EXPORT_COMPOSE_FILE) up -d
 
 localnet-state-export-upgrade:
 	bash $(LOCALSTRIDE_HOME)/state-export/scripts/submit_upgrade.sh
 
 localnet-state-export-stop:
-	@docker-compose -f $(STATE_EXPORT_COMPOSE_FILE) down
+	@docker compose -f $(STATE_EXPORT_COMPOSE_FILE) down
 
 localnet-state-export-clean: localnet-clean

--- a/dockernet/README.md
+++ b/dockernet/README.md
@@ -69,7 +69,7 @@ ST{CHAIN}_DENOM="st{min_denom}"
 {CHAIN}_ADDRESS_PREFIX=stars
 {CHAIN}_REV_ACCT={n}rev1
 {CHAIN}_DENOM=${CHAIN}_DENOM
-{CHAIN}_RPC_PORT={the one included in the docker-compose above}
+{CHAIN}_RPC_PORT={the one included in the docker compose above}
 {CHAIN}_MAIN_CMD="${CHAIN}_CMD --home $DOCKERNET_HOME/state/${${CHAIN}_NODE_PREFIX}1"
 {CHAIN}_RECEIVER_ADDRESS={any random address on the chain}
 
@@ -80,7 +80,7 @@ ST{CHAIN}_DENOM="st{min_denom}"
 {CHAIN}_MICRO_DENOM_UNITS=000000000000000000
 
 # Add *below* the RELAYER section!
-RELAYER_{CHAIN}_EXEC="docker-compose run --rm relayer-{new-host-zone}"
+RELAYER_{CHAIN}_EXEC="docker compose run --rm relayer-{new-host-zone}"
 RELAYER_{CHAIN}_ACCT=rly{add one since the account from the last host zone}
 
 # NOTE: Update the STRIDE_RELAYER_ACCTS variable directly!

--- a/dockernet/config.sh
+++ b/dockernet/config.sh
@@ -8,7 +8,7 @@ LOGS=$DOCKERNET_HOME/logs
 UPGRADES=$DOCKERNET_HOME/upgrades
 SRC=$DOCKERNET_HOME/src
 PEER_PORT=26656
-DOCKER_COMPOSE="docker-compose -f $DOCKERNET_HOME/docker-compose.yml"
+DOCKER_COMPOSE="docker compose -f $DOCKERNET_HOME/docker-compose.yml"
 
 # Logs
 STRIDE_LOGS=$LOGS/stride.log

--- a/dockernet/pkill.sh
+++ b/dockernet/pkill.sh
@@ -1,3 +1,3 @@
-pkill -f "docker-compose .*stride.* logs" | true
+pkill -f "docker compose .*stride.* logs" | true
 pkill -f "/bin/bash.*create_logs.sh" | true
 pkill -f "tail .*.log" | true

--- a/scripts/local-to-mainnet/commands.sh
+++ b/scripts/local-to-mainnet/commands.sh
@@ -9,11 +9,11 @@ echo "$HOT_WALLET_1_MNEMONIC" | build/gaiad keys add hot --recover --keyring-bac
 #### START RELAYER
 # NOTE: CREATING CONNECTIONS WITH THE GO RELAYER 
 # Create connections and channels
-docker-compose -f scripts/local-to-mainnet/docker-compose.yml run --rm relayer rly transact link stride-host 
+docker compose -f scripts/local-to-mainnet/docker-compose.yml run --rm relayer rly transact link stride-host 
 
 # (OR) If the go relayer isn't working, use hermes (NOTE: you'll have to add the connections to the relayer config in `scripts/state/relayer/config/config.yaml`)
-# docker-compose -f scripts/local-to-mainnet/docker-compose.yml run --rm hermes hermes create connection --a-chain cosmoshub-4 --b-chain local-test-1
-# docker-compose -f scripts/local-to-mainnet/docker-compose.yml run --rm hermes hermes create channel --a-chain local-test-1 --a-connection connection-0 --a-port transfer --b-port transfer
+# docker compose -f scripts/local-to-mainnet/docker-compose.yml run --rm hermes hermes create connection --a-chain cosmoshub-4 --b-chain local-test-1
+# docker compose -f scripts/local-to-mainnet/docker-compose.yml run --rm hermes hermes create channel --a-chain local-test-1 --a-connection connection-0 --a-port transfer --b-port transfer
 
 # Ensure Relayer Config is updated (`scripts/local-to-mainnet/state/relayer/config/config.yaml`)
 #    paths:
@@ -32,8 +32,8 @@ build/strided --home scripts/state/stride1 q ibc channel channels
 transfer_channel=$(build/strided --home scripts/state/stride1 q ibc channel channels | grep channel-0 -A 4 | grep counterparty -A 1 | grep channel | awk '{print $2}') && echo $transfer_channel
 
 # Start Go Relayer 
-docker-compose -f scripts/local-to-mainnet/docker-compose.yml up -d relayer
-docker-compose -f scripts/local-to-mainnet/docker-compose.yml logs -f relayer | sed -r -u "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> scripts/logs/relayer.log 2>&1 &
+docker compose -f scripts/local-to-mainnet/docker-compose.yml up -d relayer
+docker compose -f scripts/local-to-mainnet/docker-compose.yml logs -f relayer | sed -r -u "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> scripts/logs/relayer.log 2>&1 &
 
 
 #### REGISTER HOST

--- a/scripts/local-to-mainnet/start.sh
+++ b/scripts/local-to-mainnet/start.sh
@@ -23,7 +23,7 @@ HOT_WALLET_1_ADDRESS=cosmos1c37n9aywapx2v0s6vk2yedydkkhq65zzeupe92
 STATE=$SCRIPT_DIR/../state
 LOGS=$SCRIPT_DIR/../logs
 STRIDE_LOGS=$LOGS/stride.log
-DOCKER_COMPOSE="docker-compose -f $SCRIPT_DIR/docker-compose.yml"
+DOCKER_COMPOSE="docker compose -f $SCRIPT_DIR/docker-compose.yml"
 
 HERMES_STRIDE_MNEMONIC="alter old invest friend relief slot swear pioneer syrup economy vendor tray focus hedgehog artist legend antenna hair almost donkey spice protect sustain increase"
 RELAYER_STRIDE_MNEMONIC="pride narrow breeze fitness sign bounce dose smart squirrel spell length federal replace coral lunar thunder vital push nuclear crouch fun accident hood need"
@@ -83,7 +83,7 @@ $RELAYER_CMD keys restore host rly2 "$HOT_WALLET_3_MNEMONIC"
 # Update commands template
 COMMANDS_FILE=${SCRIPT_DIR}/commands.sh
 cp ${SCRIPT_DIR}/templates/commands.sh $COMMANDS_FILE
-DOCKER_COMPOSE_RELATIVE="docker-compose -f scripts/local-to-mainnet/docker-compose.yml"
+DOCKER_COMPOSE_RELATIVE="docker compose -f scripts/local-to-mainnet/docker-compose.yml"
 SCRIPTS_RELATIVE=scripts
 STATE_RELATIVE=$SCRIPTS_RELATIVE/state
 LOGS_RELATIVE=$SCRIPTS_RELATIVE/logs

--- a/testutil/localstride/state-export/scripts/submit_upgrade.sh
+++ b/testutil/localstride/state-export/scripts/submit_upgrade.sh
@@ -21,7 +21,7 @@ TRIM_TX() {
   grep -E "code:|txhash:" | sed 's/^/  /'
 }
 
-STRIDE_MAIN_CMD="docker-compose -f ${SCRIPT_DIR}/../docker-compose.yml exec -it stride strided"
+STRIDE_MAIN_CMD="docker compose -f ${SCRIPT_DIR}/../docker-compose.yml exec -it stride strided"
 
 printf "PROPOSAL\n"
 $STRIDE_MAIN_CMD tx gov submit-legacy-proposal software-upgrade $upgrade_name \


### PR DESCRIPTION
From July 2023 Compose V1 (`docker-compose`) stopped receiving updates. It’s also no longer available in new releases of Docker.

Compose V2 (`docker compose`), which was first released in 2020, is included with all currently supported versions of Docker. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.

For more info see https://docs.docker.com/compose/migrate/