### PR TITLE
added wasm light client

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,6 +14,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	packetforwardtypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/types"
 	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/types"
+	ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	consumertypes "github.com/cosmos/interchain-security/v4/x/ccv/consumer/types"
 	evmosvestingtypes "github.com/evmos/vesting/x/vesting/types"
 
@@ -303,6 +304,7 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 		v23.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
+			app.IBCKeeper.ClientKeeper,
 			app.StakeibcKeeper,
 		),
 	)
@@ -363,6 +365,10 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 	case "v22":
 		storeUpgrades = &storetypes.StoreUpgrades{
 			Added: []string{ibchookstypes.StoreKey},
+		}
+	case "v23":
+		storeUpgrades = &storetypes.StoreUpgrades{
+			Added: []string{ibcwasmtypes.ModuleName},
 		}
 	}
 

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -4,6 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
+	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	stakeibckeeper "github.com/Stride-Labs/stride/v22/x/stakeibc/keeper"
 )
@@ -16,10 +18,14 @@ var (
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
+	clientKeeper clientkeeper.Keeper,
 	stakeibcKeeper stakeibckeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("Starting upgrade v23...")
+
+		ctx.Logger().Info("Adding wasm client...")
+		AddWasmAllowedClient(ctx, clientKeeper)
 
 		ctx.Logger().Info("Migrating trade routes...")
 		MigrateTradeRoutes(ctx, stakeibcKeeper)
@@ -27,6 +33,13 @@ func CreateUpgradeHandler(
 		ctx.Logger().Info("Running module migrations...")
 		return mm.RunMigrations(ctx, configurator, vm)
 	}
+}
+
+// Add the wasm client to the IBC client's allowed clients
+func AddWasmAllowedClient(ctx sdk.Context, k clientkeeper.Keeper) {
+	params := k.GetParams(ctx)
+	params.AllowedClients = append(params.AllowedClients, ibcwasmtypes.Wasm)
+	k.SetParams(ctx, params)
 }
 
 // Migration to deprecate the trade config

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/math v1.3.0
 	github.com/CosmWasm/wasmd v0.45.0
+	github.com/CosmWasm/wasmvm v1.5.2
 	github.com/Stride-Labs/ibc-rate-limiting v1.0.0
 	github.com/cometbft/cometbft v0.37.4
 	github.com/cometbft/cometbft-db v0.8.0
@@ -16,6 +17,7 @@ require (
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 v7.1.3-0.20240228213828-cce7f56d000b
 	github.com/cosmos/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240403143657-8e64543c87e0
+	github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.1.2-0.20240412103620-7ee2a2452b79
 	github.com/cosmos/ibc-go/v7 v7.4.0
 	github.com/cosmos/ics23/go v0.10.0
 	github.com/cosmos/interchain-security/v4 v4.0.0
@@ -49,7 +51,6 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/ChainSafe/go-schnorrkel v1.0.0 // indirect
-	github.com/CosmWasm/wasmvm v1.5.2 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go v1.44.203 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,8 @@ github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 v7.1.3-0.2024
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 v7.1.3-0.20240228213828-cce7f56d000b/go.mod h1:UvDmcGIWJPIytq+Q78/ff5NTOsuX/7IrNgEugTW5i0s=
 github.com/cosmos/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240403143657-8e64543c87e0 h1:obD+CSx+aXpMEUWHLyMkWEcxLuYAcxvQaIXTwjjh3qI=
 github.com/cosmos/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240403143657-8e64543c87e0/go.mod h1:JwHFbo1oX/ht4fPpnPvmhZr+dCkYK1Vihw+vZE9umR4=
+github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.1.2-0.20240412103620-7ee2a2452b79 h1:Y7zi+3BksgH5kCMLFfC2vghihNoQVrt3Ft+sHtgywPQ=
+github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.1.2-0.20240412103620-7ee2a2452b79/go.mod h1:VR2Hg2i/X1bafbmmNsV2Khwsg0PzNeuWoVKmSN5dAwo=
 github.com/cosmos/ibc-go/v7 v7.4.0 h1:8FqYMptvksgMvlbN4UW9jFxTXzsPyfAzEZurujXac8M=
 github.com/cosmos/ibc-go/v7 v7.4.0/go.mod h1:L/KaEhzV5TGUCTfGysVgMBQtl5Dm7hHitfpk+GIeoAo=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=


### PR DESCRIPTION
## Context
Added wasm light client to integrate with union bridge.

Referenced the following during the integration:
* ~[Wasm client integration guide](https://github.com/cosmos/ibc-go/blob/main/docs/docs/03-light-clients/04-wasm/03-integration.md)~ [Wasm client integration guide](https://ibc.cosmos.network/v7/ibc/light-clients/wasm/integration/)
* [Integrating light clients guide](https://github.com/cosmos/ibc-go/blob/main/docs/docs/01-ibc/02-integration.md#integrating-light-clients)
* [Osmosis integration](https://github.com/osmosis-labs/osmosis/pull/7637/files)

## Open Questions
* The [compatibility matrix ](https://github.com/cosmos/ibc-go/blob/main/docs/docs/03-light-clients/04-wasm/03-integration.md#importing-the-08-wasm-module) doesn't list ibc v7.4 - I used commit `7ee2a2452b79d0bc8316dc622a1243afa058e8cb` which is for v7.3
* The client router is not in ibc v7 so I excluded the following lines from app.go
```go
 clientRouter := app.IBCKeeper.ClientKeeper.GetRouter()
 wasmLightClientModule := wasm.NewLightClientModule(app.WasmClientKeeper)
 clientRouter.AddRoute(ibcwasmtypes.ModuleName, &wasmLightClientModule)
```

## Brief Changelog
* Added wasm client, sharing the same wasmVM as x/wasm
* Added the store key 
* Added the client name to `AllowedClients` in the upgrade handler