### PR TITLE
TESTNET: Fix wasmvm directory

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -553,13 +553,14 @@ func NewStrideApp(
 	wasmContractMemoryLimit := uint32(32)
 	wasmCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4"
 	wasmDir := filepath.Join(homePath, "wasm")
+	wasmVmDir := filepath.Join(homePath, "wasm", "wasm")
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))
 	}
 
 	wasmer, err := wasmvm.NewVM(
-		wasmDir,
+		wasmVmDir,
 		wasmCapabilities,
 		wasmContractMemoryLimit,
 		wasmConfig.ContractDebugMode,


### PR DESCRIPTION
In v22.1 we added the wasm IBC client. To not create two instances of wasmvm, we created it in `app.go` and passed it to `wasmkeeper.NewKeeper()` rather than have it create it inside. In doing so we accidentally passed the wrong directory to `wasmvm.NewVM()`.