### PR TITLE
airdrop - admin cli txs

### DIFF
--- a/proto/stride/airdrop/tx.proto
+++ b/proto/stride/airdrop/tx.proto
@@ -5,13 +5,13 @@ package stride.airdrop;
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
 import "cosmos_proto/cosmos.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/Stride-Labs/stride/v22/x/airdrop/types";
 
 // Msg defines the Msg service.
 service Msg {
-  // User facing messages:
-
   // User transaction to claim all the pending daily airdrop rewards
   rpc ClaimDaily(MsgClaimDaily) returns (MsgClaimDailyResponse);
 
@@ -23,9 +23,22 @@ service Msg {
   // amount now. The funds can be unstaked by the user once the airdrop is over
   rpc ClaimAndStake(MsgClaimAndStake) returns (MsgClaimAndStakeResponse);
 
-  // Admin facing messages:
+  // Admin transaction to create a new airdrop
+  rpc CreateAirdrop(MsgCreateAirdrop) returns (MsgCreateAirdropResponse);
 
-  // TODO
+  // Admin transaction to update an existing airdrop
+  rpc UpdateAirdrop(MsgUpdateAirdrop) returns (MsgUpdateAirdropResponse);
+
+  // Admin transaction to add multiple user allocations for a given airdrop
+  rpc AddAllocations(MsgAddAllocations) returns (MsgAddAllocationsResponse);
+
+  // Admin transaction to update a user's allocation to an airdrop
+  rpc UpdateUserAllocation(MsgUpdateUserAllocation)
+      returns (MsgUpdateUserAllocationResponse);
+
+  // Admin address to link a stride and non-stride address, merging their
+  // allocations
+  rpc LinkAddresses(MsgLinkAddresses) returns (MsgLinkAddressesResponse);
 }
 
 // ClaimDaily
@@ -65,3 +78,168 @@ message MsgClaimAndStake {
   string validator_address = 3;
 }
 message MsgClaimAndStakeResponse {}
+
+// CreateAirdrop
+message MsgCreateAirdrop {
+  option (cosmos.msg.v1.signer) = "admin";
+  option (amino.name) = "airdrop/MsgCreateAirdrop";
+
+  // Airdrop admin address
+  string admin = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Airdrop ID
+  string airdrop_id = 2;
+
+  // The first date that claiming begins and rewards are distributed
+  google.protobuf.Timestamp distribution_start_date = 3
+      [ (gogoproto.stdtime) = true ];
+
+  // The last date for rewards to be distributed. Immediately after this date
+  // the rewards can no longer be claimed, but rewards have not been clawed back
+  // yet
+  google.protobuf.Timestamp distribution_end_date = 4
+      [ (gogoproto.stdtime) = true ];
+
+  // Date with which the rewards are clawed back (occurs after the distribution
+  // end date)
+  google.protobuf.Timestamp clawback_date = 5 [ (gogoproto.stdtime) = true ];
+
+  // Deadline for the user to make a decision on their claim type
+  google.protobuf.Timestamp claim_type_deadline_date = 6
+      [ (gogoproto.stdtime) = true ];
+
+  // Penalty for claiming rewards early - e.g. 0.5 means claiming early will
+  // result in losing 50% of rewards
+  string early_claim_penalty = 7 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+
+  // Bonus rewards for choosing to claim and stake - e.g. 0.05 means stakers
+  // will receive a 5% bonus
+  string claim_and_stake_bonus = 8 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+
+  // Address that holds the total reward balance and distributes to users
+  string distribution_address = 9
+      [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+}
+message MsgCreateAirdropResponse {}
+
+// UpdateAirdrop
+message MsgUpdateAirdrop {
+  option (cosmos.msg.v1.signer) = "admin";
+  option (amino.name) = "airdrop/MsgUpdateAirdrop";
+
+  // Airdrop admin address
+  string admin = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Airdrop ID
+  string airdrop_id = 2;
+
+  // The first date that claiming begins and rewards are distributed
+  google.protobuf.Timestamp distribution_start_date = 3
+      [ (gogoproto.stdtime) = true ];
+
+  // The last date for rewards to be distributed. Immediately after this date
+  // the rewards can no longer be claimed, but rewards have not been clawed back
+  // yet
+  google.protobuf.Timestamp distribution_end_date = 4
+      [ (gogoproto.stdtime) = true ];
+
+  // Date with which the rewards are clawed back (occurs after the distribution
+  // end date)
+  google.protobuf.Timestamp clawback_date = 5 [ (gogoproto.stdtime) = true ];
+
+  // Deadline for the user to make a decision on their claim type
+  google.protobuf.Timestamp claim_type_deadline_date = 6
+      [ (gogoproto.stdtime) = true ];
+
+  // Penalty for claiming rewards early - e.g. 0.5 means claiming early will
+  // result in losing 50% of rewards
+  string early_claim_penalty = 7 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+
+  // Bonus rewards for choosing to claim and stake - e.g. 0.05 means stakers
+  // will receive a 5% bonus
+  string claim_and_stake_bonus = 8 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+
+  // Address that holds the total reward balance and distributes to users
+  string distribution_address = 9
+      [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+}
+message MsgUpdateAirdropResponse {}
+
+// Allocation specification when bootstrapping reward data
+message RawAllocation {
+  string user_address = 1;
+  repeated string allocations = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int"
+  ];
+}
+
+// AddAllocations
+message MsgAddAllocations {
+  option (cosmos.msg.v1.signer) = "admin";
+  option (amino.name) = "airdrop/MsgAddAllocations";
+
+  // Airdrop admin address
+  string admin = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Airdrop ID
+  string airdrop_id = 2;
+
+  // List of address/allocation pairs for each user
+  repeated RawAllocation allocations = 3 [ (gogoproto.nullable) = false ];
+}
+message MsgAddAllocationsResponse {}
+
+// UpdateUserAllocation
+message MsgUpdateUserAllocation {
+  option (cosmos.msg.v1.signer) = "admin";
+  option (amino.name) = "airdrop/MsgUpdateUserAllocation";
+
+  // Airdrop admin address
+  string admin = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Airdrop ID
+  string airdrop_id = 2;
+
+  // Address of the airdrop recipient
+  string user_address = 3 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Allocations - as an array where each element represents the rewards for a
+  // day
+  repeated string allocations = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int"
+  ];
+}
+message MsgUpdateUserAllocationResponse {}
+
+// LinkAddresses
+message MsgLinkAddresses {
+  option (cosmos.msg.v1.signer) = "admin";
+  option (amino.name) = "airdrop/MsgLinkAddresses";
+
+  // Airdrop admin address
+  string admin = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+
+  // Airdrop ID
+  string airdrop_id = 2;
+
+  // Stride address - this address may or may not exist in allocations yet
+  string stride_address = 3;
+
+  // Host address - this address must exist
+  string host_address = 4 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+}
+message MsgLinkAddressesResponse {}

--- a/x/airdrop/client/cli/parser.go
+++ b/x/airdrop/client/cli/parser.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/Stride-Labs/stride/v22/x/airdrop/types"
+)
+
+// Parses an allocations CSV file consisting of allocations for various addresses
+//
+// Example Schema:
+//
+//	strideXXX,10,10,20
+//	strideYYY,0,10,0
+func ParseMultipleUserAllocations(fileName string) ([]types.RawAllocation, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	allAllocations := []types.RawAllocation{}
+	for _, row := range rows {
+		if len(row) < 2 {
+			return nil, errors.New("invalid csv row")
+		}
+
+		userAddress := row[0]
+
+		allocations := []sdkmath.Int{}
+		for _, allocationString := range row[1:] {
+			allocation, ok := sdkmath.NewIntFromString(allocationString)
+			if !ok {
+				return nil, fmt.Errorf("unable to parse allocation %s into sdk.Int", allocationString)
+			}
+			allocations = append(allocations, allocation)
+		}
+
+		allocation := types.RawAllocation{
+			UserAddress: userAddress,
+			Allocations: allocations,
+		}
+		allAllocations = append(allAllocations, allocation)
+	}
+
+	return allAllocations, nil
+}
+
+// Parses a single user's allocations from a single line file with comma separate reward amounts
+// Ex: 10,10,20
+func ParseSingleUserAllocations(fileName string) (allocations []sdkmath.Int, err error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var content string
+
+	if scanner.Scan() {
+		content = scanner.Text()
+	}
+
+	if scanner.Scan() {
+		return nil, fmt.Errorf("file %s has more than one line", fileName)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	allocationsSplit := strings.Split(content, ",")
+	for _, allocationString := range allocationsSplit {
+		allocation, ok := sdkmath.NewIntFromString(allocationString)
+		if !ok {
+			return nil, errors.New("unable to parse reward")
+		}
+		allocations = append(allocations, allocation)
+	}
+
+	return allocations, nil
+}

--- a/x/airdrop/client/cli/parser_test.go
+++ b/x/airdrop/client/cli/parser_test.go
@@ -1,0 +1,75 @@
+package cli_test
+
+import (
+	"os"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Stride-Labs/stride/v22/x/airdrop/client/cli"
+	"github.com/Stride-Labs/stride/v22/x/airdrop/types"
+)
+
+func ParseMultipleUserAllocations(t *testing.T) {
+	inputCSVContents := `strideXXX,10,10,20
+strideYYY,0,10,0
+strideZZZ,5,100,6`
+
+	expectedAllocations := []types.RawAllocation{
+		{
+			UserAddress: "strideXXX",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(10), sdkmath.NewInt(10), sdkmath.NewInt(20)},
+		},
+		{
+			UserAddress: "strideYYY",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(0), sdkmath.NewInt(10), sdkmath.NewInt(0)},
+		},
+		{
+			UserAddress: "strideZZZ",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(5), sdkmath.NewInt(100), sdkmath.NewInt(6)},
+		},
+	}
+
+	// Create a temporary file
+	tmpfile, err := os.CreateTemp("", "allocations*.csv")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	// Write the CSV string to the temp file
+	_, err = tmpfile.WriteString(inputCSVContents)
+	require.NoError(t, err)
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	// Call the function with the temporary file name
+	actualAllocations, err := cli.ParseMultipleUserAllocations(tmpfile.Name())
+	require.NoError(t, err)
+
+	// Validate the allocations match expectations
+	require.Equal(t, expectedAllocations, actualAllocations)
+}
+
+func TestParseSingleUserAllocations(t *testing.T) {
+	inputCSVContents := "10,20,30"
+
+	expectedAllocations := []sdkmath.Int{sdkmath.NewInt(10), sdkmath.NewInt(20), sdkmath.NewInt(30)}
+
+	// Create a temporary file
+	tmpfile, err := os.CreateTemp("", "allocations*.csv")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	// Write the CSV string to the temp file
+	_, err = tmpfile.WriteString(inputCSVContents)
+	require.NoError(t, err)
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	// Call the function with the temporary file name
+	actualAllocations, err := cli.ParseSingleUserAllocations(tmpfile.Name())
+	require.NoError(t, err)
+
+	// Validate the allocations match expectations
+	require.Equal(t, expectedAllocations, actualAllocations)
+}

--- a/x/airdrop/client/cli/tx.go
+++ b/x/airdrop/client/cli/tx.go
@@ -3,14 +3,29 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
 	"github.com/Stride-Labs/stride/v22/x/airdrop/types"
+)
+
+const (
+	FlagDistributionStartDate = "distribution-start-date"
+	FlagDistributionEndDate   = "distribution-end-date"
+	FlagClawbackDate          = "clawback-date"
+	FlagClaimTypeDeadlineDate = "claim-type-deadline-date"
+	FlagEarlyClaimPenalty     = "early-claim-penalty"
+	FlagClaimAndStakeBonus    = "claim-and-stake-bonus"
+	FlagDistributionAddress   = "distribution-address"
+
+	DateLayout = "2006-01-02"
 )
 
 // GetTxCmd returns the transaction commands for this module
@@ -27,6 +42,11 @@ func GetTxCmd() *cobra.Command {
 		CmdClaimDaily(),
 		CmdClaimEarly(),
 		CmdClaimAndStake(),
+		CmdCreateAirdrop(),
+		CmdUpdateAirdrop(),
+		CmdAddAllocations(),
+		CmdUpdateUserAllocation(),
+		CmdLinkAddresses(),
 	)
 
 	return cmd
@@ -140,6 +160,416 @@ Example:
 				clientCtx.GetFromAddress().String(),
 				airdropId,
 				vaildatorAddress,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// Admin transaction to create a new airdrop
+func CmdCreateAirdrop() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-airdrop [airdrop-id]",
+		Short: "Creates a new airdrop",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Registers a new airdrop
+
+Example:
+  $ %[1]s tx %[2]s create-airdrop airdrop-1 \
+  	--distribution-start-date  2024-01-01 \
+	--distribution-end-date    2024-06-01 \
+	--clawback-date            2024-07-01 \
+	--claim-type-deadline-date 2024-02-01 \
+	--early-claim-penalty      0.5 \
+	--claim-and-stake-bonus    0.05 \
+	--distribution-address     strideXXX \
+	--from admin
+`, version.AppName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			airdropId := args[0]
+
+			distributionStartDateString, err := cmd.Flags().GetString(FlagDistributionStartDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution start date")
+			}
+			distributionEndDateString, err := cmd.Flags().GetString(FlagDistributionEndDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution end date")
+			}
+			clawbackDateString, err := cmd.Flags().GetString(FlagClawbackDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse clawback date")
+			}
+			deadlineDateString, err := cmd.Flags().GetString(FlagClaimTypeDeadlineDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim deadline date date")
+			}
+
+			earlyPenaltyString, err := cmd.Flags().GetString(FlagEarlyClaimPenalty)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse early claim penalty address")
+			}
+			stakeBonusString, err := cmd.Flags().GetString(FlagClaimAndStakeBonus)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim and stake bonus")
+			}
+			distributionAddress, err := cmd.Flags().GetString(FlagDistributionAddress)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution address")
+			}
+
+			distributionStartDate, err := time.Parse(DateLayout, distributionStartDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution start date")
+			}
+			distributionEndDate, err := time.Parse(DateLayout, distributionEndDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution end date")
+			}
+			clawbackDate, err := time.Parse(DateLayout, clawbackDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse clawback date")
+			}
+			deadlineDate, err := time.Parse(DateLayout, deadlineDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim type deadline date")
+			}
+
+			earlyClaimPenalty, err := sdk.NewDecFromStr(earlyPenaltyString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse early penalty")
+			}
+			claimAndStakeBonus, err := sdk.NewDecFromStr(stakeBonusString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim and stake bonus")
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgCreateAirdrop(
+				clientCtx.GetFromAddress().String(),
+				airdropId,
+				&distributionStartDate,
+				&distributionEndDate,
+				&clawbackDate,
+				&deadlineDate,
+				earlyClaimPenalty,
+				claimAndStakeBonus,
+				distributionAddress,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(FlagDistributionStartDate, "", "Start date when rewards are distributed")
+	cmd.Flags().String(FlagDistributionEndDate, "", "Last date that rewards are distributed")
+	cmd.Flags().String(FlagClawbackDate, "", "Date when rewards are clawed back (after distribution end date)")
+	cmd.Flags().String(FlagClaimTypeDeadlineDate, "", "Deadline to decide on the claim type")
+	cmd.Flags().String(FlagEarlyClaimPenalty, "", "Decimal (0 to 1) representing the penalty for claiming early")
+	cmd.Flags().String(FlagClaimAndStakeBonus, "", "Decimal (0 to 1) representing the bonus for claiming and staking")
+	cmd.Flags().String(FlagDistributionAddress, "", "Address of the distributor account")
+
+	requiredFlags := []string{
+		FlagDistributionStartDate,
+		FlagDistributionEndDate,
+		FlagClawbackDate,
+		FlagClaimTypeDeadlineDate,
+		FlagEarlyClaimPenalty,
+		FlagClaimAndStakeBonus,
+		FlagDistributionAddress,
+	}
+	for _, flagName := range requiredFlags {
+		if err := cmd.MarkFlagRequired(flagName); err != nil {
+			panic(err)
+		}
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// Admin transaction to update an existing airdrop
+func CmdUpdateAirdrop() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-airdrop [airdrop-id]",
+		Short: "Updates an existing airdrop",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Updates an existing airdrop. All configurations must be provided (even those that will not be changed)
+
+Example:
+  $ %[1]s tx %[2]s update-airdrop airdrop-1 \
+  	--distribution-start-date  2024-01-01 \
+	--distribution-end-date    2024-06-01 \
+	--clawback-date            2024-07-01 \
+	--claim-type-deadline-date 2024-02-01 \
+	--early-claim-penalty      0.5 \
+	--claim-and-stake-bonus    0.05 \
+	--distribution-address     strideXXX \
+	--from admin
+`, version.AppName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			airdropId := args[0]
+
+			distributionStartDateString, err := cmd.Flags().GetString(FlagDistributionStartDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution start date")
+			}
+			distributionEndDateString, err := cmd.Flags().GetString(FlagDistributionEndDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution end date")
+			}
+			clawbackDateString, err := cmd.Flags().GetString(FlagClawbackDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse clawback date")
+			}
+			deadlineDateString, err := cmd.Flags().GetString(FlagClaimTypeDeadlineDate)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim deadline date date")
+			}
+
+			earlyPenaltyString, err := cmd.Flags().GetString(FlagEarlyClaimPenalty)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse early claim penalty address")
+			}
+			stakeBonusString, err := cmd.Flags().GetString(FlagClaimAndStakeBonus)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim and stake bonus")
+			}
+			distributionAddress, err := cmd.Flags().GetString(FlagDistributionAddress)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution address")
+			}
+
+			distributionStartDate, err := time.Parse(DateLayout, distributionStartDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution start date")
+			}
+			distributionEndDate, err := time.Parse(DateLayout, distributionEndDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse distribution end date")
+			}
+			clawbackDate, err := time.Parse(DateLayout, clawbackDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse clawback date")
+			}
+			deadlineDate, err := time.Parse(DateLayout, deadlineDateString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim type deadline date")
+			}
+
+			earlyClaimPenalty, err := sdk.NewDecFromStr(earlyPenaltyString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse early penalty")
+			}
+			claimAndStakeBonus, err := sdk.NewDecFromStr(stakeBonusString)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse claim and stake bonus")
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUpdateAirdrop(
+				clientCtx.GetFromAddress().String(),
+				airdropId,
+				&distributionStartDate,
+				&distributionEndDate,
+				&clawbackDate,
+				&deadlineDate,
+				earlyClaimPenalty,
+				claimAndStakeBonus,
+				distributionAddress,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(FlagDistributionStartDate, "", "Start date when rewards are distributed")
+	cmd.Flags().String(FlagDistributionEndDate, "", "Last date that rewards are distributed")
+	cmd.Flags().String(FlagClawbackDate, "", "Date when rewards are clawed back (after distribution end date)")
+	cmd.Flags().String(FlagClaimTypeDeadlineDate, "", "Deadline to decide on the claim type")
+	cmd.Flags().String(FlagEarlyClaimPenalty, "", "Decimal (0 to 1) representing the penalty for claiming early")
+	cmd.Flags().String(FlagClaimAndStakeBonus, "", "Decimal (0 to 1) representing the bonus for claiming and staking")
+	cmd.Flags().String(FlagDistributionAddress, "", "Address of the distributor account")
+
+	requiredFlags := []string{
+		FlagDistributionStartDate,
+		FlagDistributionEndDate,
+		FlagClawbackDate,
+		FlagClaimTypeDeadlineDate,
+		FlagEarlyClaimPenalty,
+		FlagClaimAndStakeBonus,
+		FlagDistributionAddress,
+	}
+	for _, flagName := range requiredFlags {
+		if err := cmd.MarkFlagRequired(flagName); err != nil {
+			panic(err)
+		}
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// Admin transaction to add multiple user allocations for a given airdrop
+func CmdAddAllocations() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-allocations [airdrop-id] [allocations-csv-file]",
+		Short: "Adds multiple user allocations for a given airdrop",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Adds multiple user allocations for a given airdrop using a CSV file
+
+Example CSV:
+ strideXXX,0,10,10,20,30,40,...
+ strideYYY,0,10,10,20,30,40,...
+
+Example Command:
+  $ %[1]s tx %[2]s add-allocations airdrop-1 allocations.csv --from admin
+`, version.AppName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			airdropId := args[0]
+			allocationsFileName := args[1]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := ParseMultipleUserAllocations(allocationsFileName)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse allocations csv")
+			}
+
+			msg := types.NewMsgAddAllocations(
+				clientCtx.GetFromAddress().String(),
+				airdropId,
+				allocations,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// Admin transaction to update a user's allocation to an airdrop
+func CmdUpdateUserAllocation() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-user-allocation [airdrop-id] [user-address] [allocations-file]",
+		Short: "Update's a single user allocation's for a given airdrop",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Update's a single user allocation's for a given airdrop
+
+Example file:
+ 0,10,10,20,30,40,...
+
+Example Command:
+  $ %[1]s tx %[2]s update-user-allocations airdrop-1 allocations.csv --from admin
+`, version.AppName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			airdropId := args[0]
+			address := args[1]
+			allocationsFileName := args[2]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := ParseSingleUserAllocations(allocationsFileName)
+			if err != nil {
+				return errorsmod.Wrapf(err, "unable to parse allocations csv")
+			}
+
+			msg := types.NewMsgUpdateUserAllocation(
+				clientCtx.GetFromAddress().String(),
+				airdropId,
+				address,
+				allocations,
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// Admin address to link a stride and non-stride address, merging their allocations
+func CmdLinkAddresses() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "link-addresses [airdrop-id] [stride-address] [host-address]",
+		Short: "Links a stride and non-stride address, merging their allocations",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Links a stride and non-stride address, merging their allocations
+
+Example Command:
+  $ %[1]s tx %[2]s link-addresses airdrop-1 strideXXX dymXXX --from admin
+`, version.AppName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			airdropId := args[0]
+			strideAddress := args[1]
+			hostAddress := args[2]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgLinkAddresses(
+				clientCtx.GetFromAddress().String(),
+				airdropId,
+				strideAddress,
+				hostAddress,
 			)
 
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/airdrop/keeper/msg_server.go
+++ b/x/airdrop/keeper/msg_server.go
@@ -56,3 +56,43 @@ func (ms msgServer) ClaimAndStake(goCtx context.Context, msg *types.MsgClaimAndS
 
 	return &types.MsgClaimAndStakeResponse{}, nil
 }
+
+// Admin transaction to create a new airdrop
+func (ms msgServer) CreateAirdrop(goCtx context.Context, msg *types.MsgCreateAirdrop) (*types.MsgCreateAirdropResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+
+	return &types.MsgCreateAirdropResponse{}, nil
+}
+
+// Admin transaction to update an existing airdrop
+func (ms msgServer) UpdateAirdrop(goCtx context.Context, msg *types.MsgUpdateAirdrop) (*types.MsgUpdateAirdropResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+
+	return &types.MsgUpdateAirdropResponse{}, nil
+}
+
+// Admin transaction to add user allocations
+func (ms msgServer) AddAllocations(goCtx context.Context, msg *types.MsgAddAllocations) (*types.MsgAddAllocationsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+
+	return &types.MsgAddAllocationsResponse{}, nil
+}
+
+// Admin transaction to update a user's allocations
+func (ms msgServer) UpdateUserAllocation(goCtx context.Context, msg *types.MsgUpdateUserAllocation) (*types.MsgUpdateUserAllocationResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+
+	return &types.MsgUpdateUserAllocationResponse{}, nil
+}
+
+// Admin address to link a stride and non-stride address, merging their allocations
+func (ms msgServer) LinkAddresses(goCtx context.Context, msg *types.MsgLinkAddresses) (*types.MsgLinkAddressesResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+
+	return &types.MsgLinkAddressesResponse{}, nil
+}

--- a/x/airdrop/types/codec.go
+++ b/x/airdrop/types/codec.go
@@ -13,7 +13,11 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	legacy.RegisterAminoMsg(cdc, &MsgClaimDaily{}, "airdrop/MsgClaimDaily")
 	legacy.RegisterAminoMsg(cdc, &MsgClaimEarly{}, "airdrop/MsgClaimEarly")
 	legacy.RegisterAminoMsg(cdc, &MsgClaimAndStake{}, "airdrop/MsgClaimAndStake")
-	// TODO[airdrop]: add admin messages
+	legacy.RegisterAminoMsg(cdc, &MsgCreateAirdrop{}, "airdrop/MsgCreateAirdrop")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateAirdrop{}, "airdrop/MsgUpdateAirdrop")
+	legacy.RegisterAminoMsg(cdc, &MsgAddAllocations{}, "airdrop/MsgAddAllocations")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateUserAllocation{}, "airdrop/MsgUpdateUserAllocation")
+	legacy.RegisterAminoMsg(cdc, &MsgLinkAddresses{}, "airdrop/MsgLinkAddresses")
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -21,7 +25,11 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgClaimDaily{},
 		&MsgClaimEarly{},
 		&MsgClaimAndStake{},
-		// TODO[airdrop]: add admin messages
+		&MsgCreateAirdrop{},
+		&MsgUpdateAirdrop{},
+		&MsgAddAllocations{},
+		&MsgUpdateUserAllocation{},
+		&MsgLinkAddresses{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/airdrop/types/msgs.go
+++ b/x/airdrop/types/msgs.go
@@ -444,7 +444,8 @@ func (msg *MsgAddAllocations) ValidateBasic() error {
 	}
 
 	addresses := map[string]bool{}
-	for _, allocation := range msg.Allocations {
+	allocationsLength := 0
+	for i, allocation := range msg.Allocations {
 		if allocation.UserAddress == "" {
 			return errors.New("all addresses in allocations must be specified")
 		}
@@ -453,6 +454,14 @@ func (msg *MsgAddAllocations) ValidateBasic() error {
 			return fmt.Errorf("address %s is specified more than once", allocation.UserAddress)
 		}
 		addresses[allocation.UserAddress] = true
+
+		if i == 0 {
+			allocationsLength = len(allocation.Allocations)
+		} else {
+			if len(allocation.Allocations) != allocationsLength {
+				return fmt.Errorf("address %s has an inconsistent number of allocations", allocation.UserAddress)
+			}
+		}
 
 		for _, amount := range allocation.Allocations {
 			if amount.IsNil() || amount.LT(sdkmath.ZeroInt()) {

--- a/x/airdrop/types/msgs.go
+++ b/x/airdrop/types/msgs.go
@@ -2,17 +2,28 @@ package types
 
 import (
 	"errors"
+	fmt "fmt"
+	time "time"
 
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+
+	"github.com/Stride-Labs/stride/v22/utils"
 )
 
 const (
-	TypeMsgClaim         = "claim_daily"
+	TypeMsgClaimDaily    = "claim_daily"
 	TypeMsgClaimAndStake = "claim_and_stake"
 	TypeMsgClaimEarly    = "claim_early"
+
+	TypeMsgCreateAirdrop        = "create_airdrop"
+	TypeMsgUpdateAirdrop        = "update_airdrop"
+	TypeMsgAddAllocations       = "add_allocations"
+	TypeMsgUpdateUserAllocation = "update_user_allocation"
+	TypeMsgLinkAddresses        = "link_addresses"
 )
 
 var (
@@ -20,10 +31,22 @@ var (
 	_ sdk.Msg = &MsgClaimAndStake{}
 	_ sdk.Msg = &MsgClaimEarly{}
 
+	_ sdk.Msg = &MsgCreateAirdrop{}
+	_ sdk.Msg = &MsgUpdateAirdrop{}
+	_ sdk.Msg = &MsgAddAllocations{}
+	_ sdk.Msg = &MsgUpdateUserAllocation{}
+	_ sdk.Msg = &MsgLinkAddresses{}
+
 	// Implement legacy interface for ledger support
 	_ legacytx.LegacyMsg = &MsgClaimDaily{}
 	_ legacytx.LegacyMsg = &MsgClaimAndStake{}
 	_ legacytx.LegacyMsg = &MsgClaimEarly{}
+
+	_ legacytx.LegacyMsg = &MsgCreateAirdrop{}
+	_ legacytx.LegacyMsg = &MsgUpdateAirdrop{}
+	_ legacytx.LegacyMsg = &MsgAddAllocations{}
+	_ legacytx.LegacyMsg = &MsgUpdateUserAllocation{}
+	_ legacytx.LegacyMsg = &MsgLinkAddresses{}
 )
 
 // ----------------------------------------------
@@ -38,7 +61,7 @@ func NewMsgClaimDaily(claimer, airdropId string) *MsgClaimDaily {
 }
 
 func (msg MsgClaimDaily) Type() string {
-	return TypeMsgClaim
+	return TypeMsgClaimDaily
 }
 
 func (msg MsgClaimDaily) Route() string {
@@ -154,6 +177,401 @@ func (msg *MsgClaimAndStake) ValidateBasic() error {
 	}
 	if _, err := sdk.ValAddressFromBech32(msg.ValidatorAddress); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid validator address (%s)", err)
+	}
+
+	return nil
+}
+
+// ----------------------------------------------
+//               MsgCreateAirdrop
+// ----------------------------------------------
+
+func NewMsgCreateAirdrop(
+	admin string,
+	airdropId string,
+	distributionStartDate *time.Time,
+	distributionEndDate *time.Time,
+	clawbackDate *time.Time,
+	claimDeadlineDate *time.Time,
+	earlyClaimPenalty sdk.Dec,
+	claimAndStakeBonus sdk.Dec,
+	distributionAddress string,
+) *MsgCreateAirdrop {
+	return &MsgCreateAirdrop{
+		Admin:                 admin,
+		AirdropId:             airdropId,
+		DistributionStartDate: distributionStartDate,
+		DistributionEndDate:   distributionEndDate,
+		ClawbackDate:          clawbackDate,
+		ClaimTypeDeadlineDate: claimDeadlineDate,
+		EarlyClaimPenalty:     earlyClaimPenalty,
+		ClaimAndStakeBonus:    claimAndStakeBonus,
+		DistributionAddress:   distributionAddress,
+	}
+}
+
+func (msg MsgCreateAirdrop) Type() string {
+	return TypeMsgCreateAirdrop
+}
+
+func (msg MsgCreateAirdrop) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgCreateAirdrop) GetSigners() []sdk.AccAddress {
+	claimer, err := sdk.AccAddressFromBech32(msg.Admin)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{claimer}
+}
+
+func (msg *MsgCreateAirdrop) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgCreateAirdrop) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Admin); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
+	}
+	if err := utils.ValidateAdminAddress(msg.Admin); err != nil {
+		return err
+	}
+
+	if msg.AirdropId == "" {
+		return errors.New("airdrop-id must be specified")
+	}
+
+	if msg.DistributionStartDate == nil || *msg.DistributionStartDate == (time.Time{}) {
+		return errors.New("distribution start date must be specified")
+	}
+	if msg.DistributionEndDate == nil || *msg.DistributionEndDate == (time.Time{}) {
+		return errors.New("distribution end date must be specified")
+	}
+	if msg.ClawbackDate == nil || *msg.ClawbackDate == (time.Time{}) {
+		return errors.New("clawback date must be specified")
+	}
+	if msg.ClaimTypeDeadlineDate == nil || *msg.ClaimTypeDeadlineDate == (time.Time{}) {
+		return errors.New("claim type deadline date must be specified")
+	}
+
+	if !msg.DistributionEndDate.After(*msg.DistributionStartDate) {
+		return errors.New("distribution end date must be after the start date")
+	}
+	if !msg.ClaimTypeDeadlineDate.After(*msg.DistributionStartDate) {
+		return errors.New("claim type deadline date must be after the distribution start date")
+	}
+	if !msg.ClaimTypeDeadlineDate.Before(*msg.DistributionEndDate) {
+		return errors.New("claim type deadline date must be before the distribution end date")
+	}
+	if !msg.ClawbackDate.After(*msg.DistributionEndDate) {
+		return errors.New("clawback date must be after the distribution end date")
+	}
+
+	if msg.EarlyClaimPenalty.IsNil() {
+		return errors.New("early claim penalty must be specified")
+	}
+	if msg.ClaimAndStakeBonus.IsNil() {
+		return errors.New("claim and stake bonus must be specified")
+	}
+
+	if msg.EarlyClaimPenalty.LT(sdk.ZeroDec()) || msg.EarlyClaimPenalty.GT(sdk.OneDec()) {
+		return errors.New("early claim penalty must be between 0 and 1")
+	}
+	if msg.ClaimAndStakeBonus.LT(sdk.ZeroDec()) || msg.ClaimAndStakeBonus.GT(sdk.OneDec()) {
+		return errors.New("early claim penalty must be between 0 and 1")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(msg.DistributionAddress); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid distribution address (%s)", err)
+	}
+
+	return nil
+}
+
+// ----------------------------------------------
+//               MsgUpdateAirdrop
+// ----------------------------------------------
+
+func NewMsgUpdateAirdrop(
+	admin string,
+	airdropId string,
+	distributionStartDate *time.Time,
+	distributionEndDate *time.Time,
+	clawbackDate *time.Time,
+	claimDeadlineDate *time.Time,
+	earlyClaimPenalty sdk.Dec,
+	claimAndStakeBonus sdk.Dec,
+	distributionAddress string,
+) *MsgUpdateAirdrop {
+	return &MsgUpdateAirdrop{
+		Admin:                 admin,
+		AirdropId:             airdropId,
+		DistributionStartDate: distributionStartDate,
+		DistributionEndDate:   distributionEndDate,
+		ClawbackDate:          clawbackDate,
+		ClaimTypeDeadlineDate: claimDeadlineDate,
+		EarlyClaimPenalty:     earlyClaimPenalty,
+		ClaimAndStakeBonus:    claimAndStakeBonus,
+		DistributionAddress:   distributionAddress,
+	}
+}
+
+func (msg MsgUpdateAirdrop) Type() string {
+	return TypeMsgUpdateAirdrop
+}
+
+func (msg MsgUpdateAirdrop) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgUpdateAirdrop) GetSigners() []sdk.AccAddress {
+	claimer, err := sdk.AccAddressFromBech32(msg.Admin)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{claimer}
+}
+
+func (msg *MsgUpdateAirdrop) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgUpdateAirdrop) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Admin); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
+	}
+	if err := utils.ValidateAdminAddress(msg.Admin); err != nil {
+		return err
+	}
+
+	if msg.AirdropId == "" {
+		return errors.New("airdrop-id must be specified")
+	}
+
+	if msg.DistributionStartDate == nil || *msg.DistributionStartDate == (time.Time{}) {
+		return errors.New("distribution start date must be specified")
+	}
+	if msg.DistributionEndDate == nil || *msg.DistributionEndDate == (time.Time{}) {
+		return errors.New("distribution end date must be specified")
+	}
+	if msg.ClawbackDate == nil || *msg.ClawbackDate == (time.Time{}) {
+		return errors.New("clawback date must be specified")
+	}
+	if msg.ClaimTypeDeadlineDate == nil || *msg.ClaimTypeDeadlineDate == (time.Time{}) {
+		return errors.New("claim type deadline date must be specified")
+	}
+
+	if !msg.DistributionEndDate.After(*msg.DistributionStartDate) {
+		return errors.New("distribution end date must be after the start date")
+	}
+	if !msg.ClaimTypeDeadlineDate.After(*msg.DistributionStartDate) {
+		return errors.New("claim type deadline date must be after the distribution start date")
+	}
+	if !msg.ClaimTypeDeadlineDate.Before(*msg.DistributionEndDate) {
+		return errors.New("claim type deadline date must be before the distribution end date")
+	}
+	if !msg.ClawbackDate.After(*msg.DistributionEndDate) {
+		return errors.New("clawback date must be after the distribution end date")
+	}
+
+	if msg.EarlyClaimPenalty.IsNil() {
+		return errors.New("early claim penalty must be specified")
+	}
+	if msg.ClaimAndStakeBonus.IsNil() {
+		return errors.New("claim and stake bonus must be specified")
+	}
+
+	if msg.EarlyClaimPenalty.LT(sdk.ZeroDec()) || msg.EarlyClaimPenalty.GT(sdk.OneDec()) {
+		return errors.New("early claim penalty must be between 0 and 1")
+	}
+	if msg.ClaimAndStakeBonus.LT(sdk.ZeroDec()) || msg.ClaimAndStakeBonus.GT(sdk.OneDec()) {
+		return errors.New("early claim penalty must be between 0 and 1")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(msg.DistributionAddress); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid distribution address (%s)", err)
+	}
+
+	return nil
+}
+
+// ----------------------------------------------
+//             MsgAddAllocations
+// ----------------------------------------------
+
+func NewMsgAddAllocations(admin string, airdropId string, allocations []RawAllocation) *MsgAddAllocations {
+	return &MsgAddAllocations{
+		Admin:       admin,
+		AirdropId:   airdropId,
+		Allocations: allocations,
+	}
+}
+
+func (msg MsgAddAllocations) Type() string {
+	return TypeMsgAddAllocations
+}
+
+func (msg MsgAddAllocations) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgAddAllocations) GetSigners() []sdk.AccAddress {
+	claimer, err := sdk.AccAddressFromBech32(msg.Admin)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{claimer}
+}
+
+func (msg *MsgAddAllocations) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgAddAllocations) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Admin); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
+	}
+	if err := utils.ValidateAdminAddress(msg.Admin); err != nil {
+		return err
+	}
+
+	if msg.AirdropId == "" {
+		return errors.New("airdrop-id must be specified")
+	}
+
+	addresses := map[string]bool{}
+	for _, allocation := range msg.Allocations {
+		if allocation.UserAddress == "" {
+			return errors.New("all addresses in allocations must be specified")
+		}
+
+		if _, ok := addresses[allocation.UserAddress]; ok {
+			return fmt.Errorf("address %s is specified more than once", allocation.UserAddress)
+		}
+		addresses[allocation.UserAddress] = true
+
+		for _, amount := range allocation.Allocations {
+			if amount.IsNil() || amount.LT(sdkmath.ZeroInt()) {
+				return errors.New("all allocation amounts must be specified and positive")
+			}
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------
+//             MsgUpdateUserAllocation
+// ----------------------------------------------
+
+func NewMsgUpdateUserAllocation(admin, airdropId, userAddress string, allocations []sdkmath.Int) *MsgUpdateUserAllocation {
+	return &MsgUpdateUserAllocation{
+		Admin:       admin,
+		AirdropId:   airdropId,
+		UserAddress: userAddress,
+		Allocations: allocations,
+	}
+}
+
+func (msg MsgUpdateUserAllocation) Type() string {
+	return TypeMsgUpdateUserAllocation
+}
+
+func (msg MsgUpdateUserAllocation) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgUpdateUserAllocation) GetSigners() []sdk.AccAddress {
+	claimer, err := sdk.AccAddressFromBech32(msg.Admin)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{claimer}
+}
+
+func (msg *MsgUpdateUserAllocation) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgUpdateUserAllocation) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Admin); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
+	}
+	if err := utils.ValidateAdminAddress(msg.Admin); err != nil {
+		return err
+	}
+
+	if msg.AirdropId == "" {
+		return errors.New("airdrop-id must be specified")
+	}
+	if msg.UserAddress == "" {
+		return errors.New("user address must be specified")
+	}
+
+	for _, allocation := range msg.Allocations {
+		if allocation.IsNil() || allocation.LT(sdk.ZeroInt()) {
+			return errors.New("all allocation amounts must be specified and positive")
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------
+//             MsgLinkAddresses
+// ----------------------------------------------
+
+func NewMsgLinkAddresses(admin, airdropId, strideAddress, hostAddress string) *MsgLinkAddresses {
+	return &MsgLinkAddresses{
+		Admin:         admin,
+		AirdropId:     airdropId,
+		StrideAddress: strideAddress,
+		HostAddress:   hostAddress,
+	}
+}
+
+func (msg MsgLinkAddresses) Type() string {
+	return TypeMsgLinkAddresses
+}
+
+func (msg MsgLinkAddresses) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgLinkAddresses) GetSigners() []sdk.AccAddress {
+	claimer, err := sdk.AccAddressFromBech32(msg.Admin)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{claimer}
+}
+
+func (msg *MsgLinkAddresses) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgLinkAddresses) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.Admin); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address (%s)", err)
+	}
+	if err := utils.ValidateAdminAddress(msg.Admin); err != nil {
+		return err
+	}
+
+	if _, err := sdk.AccAddressFromBech32(msg.StrideAddress); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid stride address (%s)", err)
+	}
+	if msg.AirdropId == "" {
+		return errors.New("airdrop-id must be specified")
+	}
+	if msg.HostAddress == "" {
+		return errors.New("host address must be specified")
 	}
 
 	return nil

--- a/x/airdrop/types/msgs_test.go
+++ b/x/airdrop/types/msgs_test.go
@@ -1140,7 +1140,7 @@ func TestMsgAddAllocations_ValidateBasic(t *testing.T) {
 		},
 		{
 			UserAddress: "user-3",
-			Allocations: []sdkmath.Int{sdkmath.NewInt(1), sdkmath.NewInt(2)},
+			Allocations: []sdkmath.Int{sdkmath.NewInt(2)},
 		},
 	}
 
@@ -1255,6 +1255,28 @@ func TestMsgAddAllocations_ValidateBasic(t *testing.T) {
 				},
 			},
 			expectedError: "address user-1 is specified more than once",
+		},
+		{
+			name: "inconsistent allocations length",
+			msg: types.MsgAddAllocations{
+				Admin:     adminAddress,
+				AirdropId: validAirdropId,
+				Allocations: []types.RawAllocation{
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+					},
+					{
+						UserAddress: "user-2",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(1)},
+					},
+					{
+						UserAddress: "user-3",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(1), sdkmath.NewInt(2)},
+					},
+				},
+			},
+			expectedError: "address user-3 has an inconsistent number of allocations",
 		},
 	}
 	for _, tc := range tests {

--- a/x/airdrop/types/msgs_test.go
+++ b/x/airdrop/types/msgs_test.go
@@ -1,8 +1,13 @@
 package types_test
 
 import (
+	"regexp"
+	"strings"
 	"testing"
+	"time"
 
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/Stride-Labs/stride/v22/app/apptesting"
@@ -75,8 +80,6 @@ func TestMsgClaimDaily_GetSignBytes(t *testing.T) {
 // ----------------------------------------------
 
 func TestMsgClaimEarly_ValidateBasic(t *testing.T) {
-	apptesting.SetupConfig()
-
 	validAddress, invalidAddress := apptesting.GenerateTestAddrs()
 	validAirdropId := "airdrop-1"
 
@@ -136,8 +139,6 @@ func TestMsgClaimEarly_GetSignBytes(t *testing.T) {
 // ----------------------------------------------
 
 func TestMsgClaimAndStake_ValidateBasic(t *testing.T) {
-	apptesting.SetupConfig()
-
 	validAddress, invalidAddress := apptesting.GenerateTestAddrs()
 	validAirdropId := "airdrop-1"
 	validValidatorAddress := "stridevaloper17kht2x2ped6qytr2kklevtvmxpw7wq9rcfud5c"
@@ -203,5 +204,1327 @@ func TestMsgClaimAndStake_GetSignBytes(t *testing.T) {
 	res := msg.GetSignBytes()
 
 	expected := `{"type":"airdrop/MsgClaimAndStake","value":{"airdrop_id":"airdrop","claimer":"strideXXX","validator_address":"stridevaloperYYY"}}`
+	require.Equal(t, expected, string(res))
+}
+
+// ----------------------------------------------
+//               MsgCreateAirdrop
+// ----------------------------------------------
+
+func TestMsgCreateAirdrop_ValidateBasic(t *testing.T) {
+	validNonAdminAddress, invalidAddress := apptesting.GenerateTestAddrs()
+	adminAddress, ok := apptesting.GetAdminAddress()
+	require.True(t, ok)
+
+	validAirdropId := "airdrop-1"
+	validDistributionAddress := validNonAdminAddress
+
+	validDistributionStartDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	validDistributionEndDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	validClawbackDate := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	validDeadlineDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	startDateMinusDelta := validDistributionStartDate.Add(-1 * time.Hour)
+	endDatePlusDelta := validDistributionEndDate.Add(time.Hour)
+	endDateMinusDelta := validDistributionEndDate.Add(-1 * time.Hour)
+
+	validEarlyClaimPenalty := sdk.MustNewDecFromStr("0.5")
+	validClaimAndStakeBonus := sdk.MustNewDecFromStr("0.05")
+
+	tests := []struct {
+		name          string
+		msg           types.MsgCreateAirdrop
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+		},
+		{
+			name: "invalid admin address",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 invalidAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "invalid address",
+		},
+		{
+			name: "not admin address",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 validNonAdminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "is not an admin",
+		},
+
+		{
+			name: "nil distribution start date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution start date must be specified",
+		},
+		{
+			name: "nil distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be specified",
+		},
+		{
+			name: "nil clawback date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be specified",
+		},
+		{
+			name: "nil deadline date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "deadline date must be specified",
+		},
+
+		{
+			name: "empty distribution start date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &(time.Time{}),
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution start date must be specified",
+		},
+		{
+			name: "empty distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &(time.Time{}),
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be specified",
+		},
+		{
+			name: "empty clawback date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &(time.Time{}),
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be specified",
+		},
+		{
+			name: "empty deadline date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &(time.Time{}),
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "deadline date must be specified",
+		},
+
+		{
+			name: "distribution start date equals distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionStartDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be after the start date",
+		},
+		{
+			name: "distribution start date after distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &endDatePlusDelta,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be after the start date",
+		},
+		{
+			name: "claim type deadline date equals distribution start date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDistributionStartDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be after the distribution start date",
+		},
+		{
+			name: "claim type deadline date before distribution start date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &startDateMinusDelta,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be after the distribution start date",
+		},
+		{
+			name: "claim type deadline date equal distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDistributionEndDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be before the distribution end date",
+		},
+		{
+			name: "claim type deadline date after distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &endDatePlusDelta,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be before the distribution end date",
+		},
+		{
+			name: "clawback date equals distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validDistributionEndDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be after the distribution end date",
+		},
+		{
+			name: "clawback date before distribution end date",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &endDateMinusDelta,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be after the distribution end date",
+		},
+		{
+			name: "nil early claim penalty",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be specified",
+		},
+		{
+			name: "nil claim and stake bonus",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim and stake bonus must be specified",
+		},
+		{
+			name: "early claim penalty less than 0",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     sdk.NewDec(-1),
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "early claim penalty less than 0",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     sdk.NewDec(-1),
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "claim and stake bonus greater than 1",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    sdk.NewDec(2),
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "claim and stake bonus greater than 1",
+			msg: types.MsgCreateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    sdk.NewDec(2),
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.msg.ValidateBasic()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, actualError, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualError)
+		})
+	}
+}
+
+func TestMsgCreateAirdrop_GetSignBytes(t *testing.T) {
+	admin := "admin"
+	airdropId := "airdrop"
+	distributionAddress := "distributor"
+
+	distributionStartDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	distributionEndDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	clawbackDate := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	deadlineDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	earlyClaimPenalty := sdk.MustNewDecFromStr("0.5")
+	claimAndStakeBonus := sdk.MustNewDecFromStr("0.05")
+
+	msg := types.NewMsgCreateAirdrop(
+		admin,
+		airdropId,
+		&distributionStartDate,
+		&distributionEndDate,
+		&clawbackDate,
+		&deadlineDate,
+		earlyClaimPenalty,
+		claimAndStakeBonus,
+		distributionAddress,
+	)
+	res := msg.GetSignBytes()
+
+	expected := strings.TrimSpace(`
+		{"type":"airdrop/MsgCreateAirdrop",
+		"value":{"admin":"admin",
+		"airdrop_id":"airdrop",
+		"claim_and_stake_bonus":"0.050000000000000000",
+		"claim_type_deadline_date":"2024-02-01T00:00:00Z",
+		"clawback_date":"2024-07-01T00:00:00Z",
+		"distribution_address":"distributor",
+		"distribution_end_date":"2024-06-01T00:00:00Z",
+		"distribution_start_date":"2024-01-01T00:00:00Z",
+		"early_claim_penalty":"0.500000000000000000"}}`)
+
+	re := regexp.MustCompile(`\s+`)
+	expected = re.ReplaceAllString(expected, "")
+	require.Equal(t, expected, string(res))
+}
+
+// ----------------------------------------------
+//               MsgUpdateAirdrop
+// ----------------------------------------------
+
+func TestMsgUpdateAirdrop_ValidateBasic(t *testing.T) {
+	validNonAdminAddress, invalidAddress := apptesting.GenerateTestAddrs()
+	adminAddress, ok := apptesting.GetAdminAddress()
+	require.True(t, ok)
+
+	validAirdropId := "airdrop-1"
+	validDistributionAddress := validNonAdminAddress
+
+	validDistributionStartDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	validDistributionEndDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	validClawbackDate := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	validDeadlineDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	startDateMinusDelta := validDistributionStartDate.Add(-1 * time.Hour)
+	endDatePlusDelta := validDistributionEndDate.Add(time.Hour)
+	endDateMinusDelta := validDistributionEndDate.Add(-1 * time.Hour)
+
+	validEarlyClaimPenalty := sdk.MustNewDecFromStr("0.5")
+	validClaimAndStakeBonus := sdk.MustNewDecFromStr("0.05")
+
+	tests := []struct {
+		name          string
+		msg           types.MsgUpdateAirdrop
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+		},
+		{
+			name: "invalid admin address",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 invalidAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "invalid address",
+		},
+		{
+			name: "not admin address",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 validNonAdminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "is not an admin",
+		},
+
+		{
+			name: "nil distribution start date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution start date must be specified",
+		},
+		{
+			name: "nil distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be specified",
+		},
+		{
+			name: "nil clawback date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be specified",
+		},
+		{
+			name: "nil deadline date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "deadline date must be specified",
+		},
+
+		{
+			name: "empty distribution start date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &(time.Time{}),
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution start date must be specified",
+		},
+		{
+			name: "empty distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &(time.Time{}),
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be specified",
+		},
+		{
+			name: "empty clawback date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &(time.Time{}),
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be specified",
+		},
+		{
+			name: "empty deadline date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &(time.Time{}),
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "deadline date must be specified",
+		},
+
+		{
+			name: "distribution start date equals distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionStartDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be after the start date",
+		},
+		{
+			name: "distribution start date after distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &endDatePlusDelta,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "distribution end date must be after the start date",
+		},
+		{
+			name: "claim type deadline date equals distribution start date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDistributionStartDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be after the distribution start date",
+		},
+		{
+			name: "claim type deadline date before distribution start date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &startDateMinusDelta,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be after the distribution start date",
+		},
+		{
+			name: "claim type deadline date equal distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDistributionEndDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be before the distribution end date",
+		},
+		{
+			name: "claim type deadline date after distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &endDatePlusDelta,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim type deadline date must be before the distribution end date",
+		},
+		{
+			name: "clawback date equals distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validDistributionEndDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be after the distribution end date",
+		},
+		{
+			name: "clawback date before distribution end date",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &endDateMinusDelta,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "clawback date must be after the distribution end date",
+		},
+		{
+			name: "nil early claim penalty",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be specified",
+		},
+		{
+			name: "nil claim and stake bonus",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "claim and stake bonus must be specified",
+		},
+		{
+			name: "early claim penalty less than 0",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     sdk.NewDec(-1),
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "early claim penalty less than 0",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     sdk.NewDec(-1),
+				ClaimAndStakeBonus:    validClaimAndStakeBonus,
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "claim and stake bonus greater than 1",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    sdk.NewDec(2),
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+		{
+			name: "claim and stake bonus greater than 1",
+			msg: types.MsgUpdateAirdrop{
+				Admin:                 adminAddress,
+				AirdropId:             validAirdropId,
+				DistributionStartDate: &validDistributionStartDate,
+				DistributionEndDate:   &validDistributionEndDate,
+				ClawbackDate:          &validClawbackDate,
+				ClaimTypeDeadlineDate: &validDeadlineDate,
+				EarlyClaimPenalty:     validEarlyClaimPenalty,
+				ClaimAndStakeBonus:    sdk.NewDec(2),
+				DistributionAddress:   validDistributionAddress,
+			},
+			expectedError: "early claim penalty must be between 0 and 1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.msg.ValidateBasic()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, actualError, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualError)
+		})
+	}
+}
+
+func TestMsgUpdateAirdrop_GetSignBytes(t *testing.T) {
+	admin := "admin"
+	airdropId := "airdrop"
+	distributionAddress := "distributor"
+
+	distributionStartDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	distributionEndDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	clawbackDate := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	deadlineDate := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	earlyClaimPenalty := sdk.MustNewDecFromStr("0.5")
+	claimAndStakeBonus := sdk.MustNewDecFromStr("0.05")
+
+	msg := types.NewMsgUpdateAirdrop(
+		admin,
+		airdropId,
+		&distributionStartDate,
+		&distributionEndDate,
+		&clawbackDate,
+		&deadlineDate,
+		earlyClaimPenalty,
+		claimAndStakeBonus,
+		distributionAddress,
+	)
+	res := msg.GetSignBytes()
+
+	expected := strings.TrimSpace(`
+		{"type":"airdrop/MsgUpdateAirdrop",
+		"value":{"admin":"admin",
+		"airdrop_id":"airdrop",
+		"claim_and_stake_bonus":"0.050000000000000000",
+		"claim_type_deadline_date":"2024-02-01T00:00:00Z",
+		"clawback_date":"2024-07-01T00:00:00Z",
+		"distribution_address":"distributor",
+		"distribution_end_date":"2024-06-01T00:00:00Z",
+		"distribution_start_date":"2024-01-01T00:00:00Z",
+		"early_claim_penalty":"0.500000000000000000"}}`)
+
+	re := regexp.MustCompile(`\s+`)
+	expected = re.ReplaceAllString(expected, "")
+	require.Equal(t, expected, string(res))
+}
+
+// ----------------------------------------------
+//               MsgAddAllocations
+// ----------------------------------------------
+
+func TestMsgAddAllocations_ValidateBasic(t *testing.T) {
+	validNonAdminAddress, invalidAddress := apptesting.GenerateTestAddrs()
+	adminAddress, ok := apptesting.GetAdminAddress()
+	require.True(t, ok)
+
+	validAirdropId := "airdrop-1"
+	validAllocations := []types.RawAllocation{
+		{
+			UserAddress: "user-1",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+		},
+		{
+			UserAddress: "user-2",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(1)},
+		},
+		{
+			UserAddress: "user-3",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(1), sdkmath.NewInt(2)},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		msg           types.MsgAddAllocations
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: types.MsgAddAllocations{
+				Admin:       adminAddress,
+				AirdropId:   validAirdropId,
+				Allocations: validAllocations,
+			},
+		},
+		{
+			name: "invalid address",
+			msg: types.MsgAddAllocations{
+				Admin:       invalidAddress,
+				AirdropId:   validAirdropId,
+				Allocations: validAllocations,
+			},
+			expectedError: "invalid address",
+		},
+		{
+			name: "not admin address",
+			msg: types.MsgAddAllocations{
+				Admin:       validNonAdminAddress,
+				AirdropId:   validAirdropId,
+				Allocations: validAllocations,
+			},
+			expectedError: "is not an admin",
+		},
+		{
+			name: "missing airdrop id",
+			msg: types.MsgAddAllocations{
+				Admin:       adminAddress,
+				AirdropId:   "",
+				Allocations: validAllocations,
+			},
+			expectedError: "airdrop-id must be specified",
+		},
+		{
+			name: "missing address",
+			msg: types.MsgAddAllocations{
+				Admin:     adminAddress,
+				AirdropId: validAirdropId,
+				Allocations: []types.RawAllocation{
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+					},
+					{
+						UserAddress: "",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(1)},
+					},
+				},
+			},
+			expectedError: "all addresses in allocations must be specified",
+		},
+		{
+			name: "nil allocation",
+			msg: types.MsgAddAllocations{
+				Admin:     adminAddress,
+				AirdropId: validAirdropId,
+				Allocations: []types.RawAllocation{
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{{}},
+					},
+					{
+						UserAddress: "user-2",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(-1)},
+					},
+				},
+			},
+			expectedError: "all allocation amounts must be specified and positive",
+		},
+		{
+			name: "negative allocation",
+			msg: types.MsgAddAllocations{
+				Admin:     adminAddress,
+				AirdropId: validAirdropId,
+				Allocations: []types.RawAllocation{
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+					},
+					{
+						UserAddress: "user-2",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(-1)},
+					},
+				},
+			},
+			expectedError: "all allocation amounts must be specified and positive",
+		},
+		{
+			name: "duplicate address",
+			msg: types.MsgAddAllocations{
+				Admin:     adminAddress,
+				AirdropId: validAirdropId,
+				Allocations: []types.RawAllocation{
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+					},
+					{
+						UserAddress: "user-1",
+						Allocations: []sdkmath.Int{sdkmath.NewInt(-1)},
+					},
+				},
+			},
+			expectedError: "address user-1 is specified more than once",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.msg.ValidateBasic()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, actualError, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualError)
+		})
+	}
+}
+
+func TestMsgAddAllocations_GetSignBytes(t *testing.T) {
+	admin := "admin"
+	airdropId := "airdrop"
+	allocations := []types.RawAllocation{
+		{
+			UserAddress: "user-1",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(0)},
+		},
+		{
+			UserAddress: "user-2",
+			Allocations: []sdkmath.Int{sdkmath.NewInt(1)},
+		},
+	}
+
+	msg := types.NewMsgAddAllocations(admin, airdropId, allocations)
+	res := msg.GetSignBytes()
+
+	expected := strings.TrimSpace(`
+		{"type":"airdrop/MsgAddAllocations",
+		"value":{"admin":"admin",
+		"airdrop_id":"airdrop",
+		"allocations":[{"allocations":["0"],"user_address":"user-1"},{"allocations":["1"],"user_address":"user-2"}]}}`)
+
+	re := regexp.MustCompile(`\s+`)
+	expected = re.ReplaceAllString(expected, "")
+	require.Equal(t, expected, string(res))
+}
+
+// ----------------------------------------------
+//               MsgUpdateUserAllocation
+// ----------------------------------------------
+
+func TestMsgUpdateUserAllocation_ValidateBasic(t *testing.T) {
+	validNonAdminAddress, invalidAddress := apptesting.GenerateTestAddrs()
+	adminAddress, ok := apptesting.GetAdminAddress()
+	require.True(t, ok)
+
+	validAirdropId := "airdrop-1"
+	validUser := "user"
+	validAllocation := []sdkmath.Int{sdkmath.NewInt(0), sdkmath.NewInt(1)}
+
+	tests := []struct {
+		name          string
+		msg           types.MsgUpdateUserAllocation
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       adminAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: validUser,
+				Allocations: validAllocation,
+			},
+		},
+		{
+			name: "invalid address",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       invalidAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: validUser,
+				Allocations: validAllocation,
+			},
+			expectedError: "invalid address",
+		},
+		{
+			name: "not admin address",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       validNonAdminAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: validUser,
+				Allocations: validAllocation,
+			},
+			expectedError: "is not an admin",
+		},
+		{
+			name: "missing airdrop id",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       adminAddress,
+				AirdropId:   "",
+				UserAddress: validUser,
+				Allocations: validAllocation,
+			},
+			expectedError: "airdrop-id must be specified",
+		},
+		{
+			name: "missing address",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       adminAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: "",
+				Allocations: validAllocation,
+			},
+			expectedError: "user address must be specified",
+		},
+		{
+			name: "nil allocation",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       adminAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: validUser,
+				Allocations: []sdkmath.Int{{}},
+			},
+			expectedError: "all allocation amounts must be specified and positive",
+		},
+		{
+			name: "negative allocation",
+			msg: types.MsgUpdateUserAllocation{
+				Admin:       adminAddress,
+				AirdropId:   validAirdropId,
+				UserAddress: validUser,
+				Allocations: []sdkmath.Int{sdkmath.NewInt(-1)},
+			},
+			expectedError: "all allocation amounts must be specified and positive",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.msg.ValidateBasic()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, actualError, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualError)
+		})
+	}
+}
+
+func TestMsgUpdateUserAllocation_GetSignBytes(t *testing.T) {
+	admin := "admin"
+	airdropId := "airdrop"
+	userAddress := "user"
+	allocation := []sdkmath.Int{sdkmath.NewInt(0)}
+
+	msg := types.NewMsgUpdateUserAllocation(admin, airdropId, userAddress, allocation)
+	res := msg.GetSignBytes()
+
+	expected := strings.TrimSpace(`
+		{"type":"airdrop/MsgUpdateUserAllocation",
+		"value":{"admin":"admin",
+		"airdrop_id":"airdrop",
+		"allocations":["0"],
+		"user_address": "user"}}`)
+
+	re := regexp.MustCompile(`\s+`)
+	expected = re.ReplaceAllString(expected, "")
+	require.Equal(t, expected, string(res))
+}
+
+// ----------------------------------------------
+//               MsgLinkAddresses
+// ----------------------------------------------
+
+func TestMsgLinkAddresses_ValidateBasic(t *testing.T) {
+	validNonAdminAddress, invalidAddress := apptesting.GenerateTestAddrs()
+	adminAddress, ok := apptesting.GetAdminAddress()
+	require.True(t, ok)
+
+	validAirdropId := "airdrop-1"
+	validStrideAddress := validNonAdminAddress
+	validHostAddress := "hostXXX"
+
+	tests := []struct {
+		name          string
+		msg           types.MsgLinkAddresses
+		expectedError string
+	}{
+		{
+			name: "valid message",
+			msg: types.MsgLinkAddresses{
+				Admin:         adminAddress,
+				AirdropId:     validAirdropId,
+				StrideAddress: validStrideAddress,
+				HostAddress:   validHostAddress,
+			},
+		},
+		{
+			name: "invalid address",
+			msg: types.MsgLinkAddresses{
+				Admin:         invalidAddress,
+				AirdropId:     validAirdropId,
+				StrideAddress: validStrideAddress,
+				HostAddress:   validHostAddress,
+			},
+			expectedError: "invalid address",
+		},
+		{
+			name: "not admin address",
+			msg: types.MsgLinkAddresses{
+				Admin:         validNonAdminAddress,
+				AirdropId:     validAirdropId,
+				StrideAddress: validStrideAddress,
+				HostAddress:   validHostAddress,
+			},
+			expectedError: "is not an admin",
+		},
+		{
+			name: "missing airdrop id",
+			msg: types.MsgLinkAddresses{
+				Admin:         adminAddress,
+				AirdropId:     "",
+				StrideAddress: validStrideAddress,
+				HostAddress:   validHostAddress,
+			},
+			expectedError: "airdrop-id must be specified",
+		},
+		{
+			name: "invalid stride address",
+			msg: types.MsgLinkAddresses{
+				Admin:         adminAddress,
+				AirdropId:     validAirdropId,
+				StrideAddress: invalidAddress,
+				HostAddress:   validHostAddress,
+			},
+			expectedError: "invalid stride address",
+		},
+		{
+			name: "invalid host address",
+			msg: types.MsgLinkAddresses{
+				Admin:         adminAddress,
+				AirdropId:     validAirdropId,
+				StrideAddress: validStrideAddress,
+				HostAddress:   "",
+			},
+			expectedError: "host address must be specified",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.msg.ValidateBasic()
+			if tc.expectedError != "" {
+				require.ErrorContains(t, actualError, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualError)
+		})
+	}
+}
+
+func TestMsgLinkAddresses_GetSignBytes(t *testing.T) {
+	admin := "admin"
+	airdropId := "airdrop"
+	strideAddress := "stride"
+	hostAddress := "host"
+
+	msg := types.NewMsgLinkAddresses(admin, airdropId, strideAddress, hostAddress)
+	res := msg.GetSignBytes()
+
+	expected := strings.TrimSpace(`
+		{"type":"airdrop/MsgLinkAddresses",
+		"value":{"admin":"admin",
+		"airdrop_id":"airdrop",
+		"host_address":"host",
+		"stride_address": "stride"}}`)
+
+	re := regexp.MustCompile(`\s+`)
+	expected = re.ReplaceAllString(expected, "")
 	require.Equal(t, expected, string(res))
 }

--- a/x/airdrop/types/tx.pb.go
+++ b/x/airdrop/types/tx.pb.go
@@ -7,22 +7,28 @@ import (
 	context "context"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
+	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/cosmos/cosmos-sdk/types/msgservice"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
+	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
+	_ "github.com/cosmos/gogoproto/types"
+	github_com_cosmos_gogoproto_types "github.com/cosmos/gogoproto/types"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
+var _ = time.Kitchen
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -312,6 +318,654 @@ func (m *MsgClaimAndStakeResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgClaimAndStakeResponse proto.InternalMessageInfo
 
+// CreateAirdrop
+type MsgCreateAirdrop struct {
+	// Airdrop admin address
+	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
+	// Airdrop ID
+	AirdropId string `protobuf:"bytes,2,opt,name=airdrop_id,json=airdropId,proto3" json:"airdrop_id,omitempty"`
+	// The first date that claiming begins and rewards are distributed
+	DistributionStartDate *time.Time `protobuf:"bytes,3,opt,name=distribution_start_date,json=distributionStartDate,proto3,stdtime" json:"distribution_start_date,omitempty"`
+	// The last date for rewards to be distributed. Immediately after this date
+	// the rewards can no longer be claimed, but rewards have not been clawed back
+	// yet
+	DistributionEndDate *time.Time `protobuf:"bytes,4,opt,name=distribution_end_date,json=distributionEndDate,proto3,stdtime" json:"distribution_end_date,omitempty"`
+	// Date with which the rewards are clawed back (occurs after the distribution
+	// end date)
+	ClawbackDate *time.Time `protobuf:"bytes,5,opt,name=clawback_date,json=clawbackDate,proto3,stdtime" json:"clawback_date,omitempty"`
+	// Deadline for the user to make a decision on their claim type
+	ClaimTypeDeadlineDate *time.Time `protobuf:"bytes,6,opt,name=claim_type_deadline_date,json=claimTypeDeadlineDate,proto3,stdtime" json:"claim_type_deadline_date,omitempty"`
+	// Penalty for claiming rewards early - e.g. 0.5 means claiming early will
+	// result in losing 50% of rewards
+	EarlyClaimPenalty github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,7,opt,name=early_claim_penalty,json=earlyClaimPenalty,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"early_claim_penalty"`
+	// Bonus rewards for choosing to claim and stake - e.g. 0.05 means stakers
+	// will receive a 5% bonus
+	ClaimAndStakeBonus github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,8,opt,name=claim_and_stake_bonus,json=claimAndStakeBonus,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"claim_and_stake_bonus"`
+	// Address that holds the total reward balance and distributes to users
+	DistributionAddress string `protobuf:"bytes,9,opt,name=distribution_address,json=distributionAddress,proto3" json:"distribution_address,omitempty"`
+}
+
+func (m *MsgCreateAirdrop) Reset()         { *m = MsgCreateAirdrop{} }
+func (m *MsgCreateAirdrop) String() string { return proto.CompactTextString(m) }
+func (*MsgCreateAirdrop) ProtoMessage()    {}
+func (*MsgCreateAirdrop) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{6}
+}
+func (m *MsgCreateAirdrop) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgCreateAirdrop) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgCreateAirdrop.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgCreateAirdrop) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCreateAirdrop.Merge(m, src)
+}
+func (m *MsgCreateAirdrop) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgCreateAirdrop) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCreateAirdrop.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgCreateAirdrop proto.InternalMessageInfo
+
+func (m *MsgCreateAirdrop) GetAdmin() string {
+	if m != nil {
+		return m.Admin
+	}
+	return ""
+}
+
+func (m *MsgCreateAirdrop) GetAirdropId() string {
+	if m != nil {
+		return m.AirdropId
+	}
+	return ""
+}
+
+func (m *MsgCreateAirdrop) GetDistributionStartDate() *time.Time {
+	if m != nil {
+		return m.DistributionStartDate
+	}
+	return nil
+}
+
+func (m *MsgCreateAirdrop) GetDistributionEndDate() *time.Time {
+	if m != nil {
+		return m.DistributionEndDate
+	}
+	return nil
+}
+
+func (m *MsgCreateAirdrop) GetClawbackDate() *time.Time {
+	if m != nil {
+		return m.ClawbackDate
+	}
+	return nil
+}
+
+func (m *MsgCreateAirdrop) GetClaimTypeDeadlineDate() *time.Time {
+	if m != nil {
+		return m.ClaimTypeDeadlineDate
+	}
+	return nil
+}
+
+func (m *MsgCreateAirdrop) GetDistributionAddress() string {
+	if m != nil {
+		return m.DistributionAddress
+	}
+	return ""
+}
+
+type MsgCreateAirdropResponse struct {
+}
+
+func (m *MsgCreateAirdropResponse) Reset()         { *m = MsgCreateAirdropResponse{} }
+func (m *MsgCreateAirdropResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgCreateAirdropResponse) ProtoMessage()    {}
+func (*MsgCreateAirdropResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{7}
+}
+func (m *MsgCreateAirdropResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgCreateAirdropResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgCreateAirdropResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgCreateAirdropResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgCreateAirdropResponse.Merge(m, src)
+}
+func (m *MsgCreateAirdropResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgCreateAirdropResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgCreateAirdropResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgCreateAirdropResponse proto.InternalMessageInfo
+
+// UpdateAirdrop
+type MsgUpdateAirdrop struct {
+	// Airdrop admin address
+	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
+	// Airdrop ID
+	AirdropId string `protobuf:"bytes,2,opt,name=airdrop_id,json=airdropId,proto3" json:"airdrop_id,omitempty"`
+	// The first date that claiming begins and rewards are distributed
+	DistributionStartDate *time.Time `protobuf:"bytes,3,opt,name=distribution_start_date,json=distributionStartDate,proto3,stdtime" json:"distribution_start_date,omitempty"`
+	// The last date for rewards to be distributed. Immediately after this date
+	// the rewards can no longer be claimed, but rewards have not been clawed back
+	// yet
+	DistributionEndDate *time.Time `protobuf:"bytes,4,opt,name=distribution_end_date,json=distributionEndDate,proto3,stdtime" json:"distribution_end_date,omitempty"`
+	// Date with which the rewards are clawed back (occurs after the distribution
+	// end date)
+	ClawbackDate *time.Time `protobuf:"bytes,5,opt,name=clawback_date,json=clawbackDate,proto3,stdtime" json:"clawback_date,omitempty"`
+	// Deadline for the user to make a decision on their claim type
+	ClaimTypeDeadlineDate *time.Time `protobuf:"bytes,6,opt,name=claim_type_deadline_date,json=claimTypeDeadlineDate,proto3,stdtime" json:"claim_type_deadline_date,omitempty"`
+	// Penalty for claiming rewards early - e.g. 0.5 means claiming early will
+	// result in losing 50% of rewards
+	EarlyClaimPenalty github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,7,opt,name=early_claim_penalty,json=earlyClaimPenalty,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"early_claim_penalty"`
+	// Bonus rewards for choosing to claim and stake - e.g. 0.05 means stakers
+	// will receive a 5% bonus
+	ClaimAndStakeBonus github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,8,opt,name=claim_and_stake_bonus,json=claimAndStakeBonus,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"claim_and_stake_bonus"`
+	// Address that holds the total reward balance and distributes to users
+	DistributionAddress string `protobuf:"bytes,9,opt,name=distribution_address,json=distributionAddress,proto3" json:"distribution_address,omitempty"`
+}
+
+func (m *MsgUpdateAirdrop) Reset()         { *m = MsgUpdateAirdrop{} }
+func (m *MsgUpdateAirdrop) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateAirdrop) ProtoMessage()    {}
+func (*MsgUpdateAirdrop) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{8}
+}
+func (m *MsgUpdateAirdrop) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateAirdrop) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateAirdrop.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateAirdrop) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateAirdrop.Merge(m, src)
+}
+func (m *MsgUpdateAirdrop) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateAirdrop) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateAirdrop.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateAirdrop proto.InternalMessageInfo
+
+func (m *MsgUpdateAirdrop) GetAdmin() string {
+	if m != nil {
+		return m.Admin
+	}
+	return ""
+}
+
+func (m *MsgUpdateAirdrop) GetAirdropId() string {
+	if m != nil {
+		return m.AirdropId
+	}
+	return ""
+}
+
+func (m *MsgUpdateAirdrop) GetDistributionStartDate() *time.Time {
+	if m != nil {
+		return m.DistributionStartDate
+	}
+	return nil
+}
+
+func (m *MsgUpdateAirdrop) GetDistributionEndDate() *time.Time {
+	if m != nil {
+		return m.DistributionEndDate
+	}
+	return nil
+}
+
+func (m *MsgUpdateAirdrop) GetClawbackDate() *time.Time {
+	if m != nil {
+		return m.ClawbackDate
+	}
+	return nil
+}
+
+func (m *MsgUpdateAirdrop) GetClaimTypeDeadlineDate() *time.Time {
+	if m != nil {
+		return m.ClaimTypeDeadlineDate
+	}
+	return nil
+}
+
+func (m *MsgUpdateAirdrop) GetDistributionAddress() string {
+	if m != nil {
+		return m.DistributionAddress
+	}
+	return ""
+}
+
+type MsgUpdateAirdropResponse struct {
+}
+
+func (m *MsgUpdateAirdropResponse) Reset()         { *m = MsgUpdateAirdropResponse{} }
+func (m *MsgUpdateAirdropResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateAirdropResponse) ProtoMessage()    {}
+func (*MsgUpdateAirdropResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{9}
+}
+func (m *MsgUpdateAirdropResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateAirdropResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateAirdropResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateAirdropResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateAirdropResponse.Merge(m, src)
+}
+func (m *MsgUpdateAirdropResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateAirdropResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateAirdropResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateAirdropResponse proto.InternalMessageInfo
+
+// Allocation specification when bootstrapping reward data
+type RawAllocation struct {
+	UserAddress string                                   `protobuf:"bytes,1,opt,name=user_address,json=userAddress,proto3" json:"user_address,omitempty"`
+	Allocations []github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,4,rep,name=allocations,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"allocations"`
+}
+
+func (m *RawAllocation) Reset()         { *m = RawAllocation{} }
+func (m *RawAllocation) String() string { return proto.CompactTextString(m) }
+func (*RawAllocation) ProtoMessage()    {}
+func (*RawAllocation) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{10}
+}
+func (m *RawAllocation) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RawAllocation) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RawAllocation.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RawAllocation) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RawAllocation.Merge(m, src)
+}
+func (m *RawAllocation) XXX_Size() int {
+	return m.Size()
+}
+func (m *RawAllocation) XXX_DiscardUnknown() {
+	xxx_messageInfo_RawAllocation.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RawAllocation proto.InternalMessageInfo
+
+func (m *RawAllocation) GetUserAddress() string {
+	if m != nil {
+		return m.UserAddress
+	}
+	return ""
+}
+
+// AddAllocations
+type MsgAddAllocations struct {
+	// Airdrop admin address
+	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
+	// Airdrop ID
+	AirdropId string `protobuf:"bytes,2,opt,name=airdrop_id,json=airdropId,proto3" json:"airdrop_id,omitempty"`
+	// List of address/allocation pairs for each user
+	Allocations []RawAllocation `protobuf:"bytes,3,rep,name=allocations,proto3" json:"allocations"`
+}
+
+func (m *MsgAddAllocations) Reset()         { *m = MsgAddAllocations{} }
+func (m *MsgAddAllocations) String() string { return proto.CompactTextString(m) }
+func (*MsgAddAllocations) ProtoMessage()    {}
+func (*MsgAddAllocations) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{11}
+}
+func (m *MsgAddAllocations) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgAddAllocations) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgAddAllocations.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgAddAllocations) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgAddAllocations.Merge(m, src)
+}
+func (m *MsgAddAllocations) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgAddAllocations) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgAddAllocations.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgAddAllocations proto.InternalMessageInfo
+
+func (m *MsgAddAllocations) GetAdmin() string {
+	if m != nil {
+		return m.Admin
+	}
+	return ""
+}
+
+func (m *MsgAddAllocations) GetAirdropId() string {
+	if m != nil {
+		return m.AirdropId
+	}
+	return ""
+}
+
+func (m *MsgAddAllocations) GetAllocations() []RawAllocation {
+	if m != nil {
+		return m.Allocations
+	}
+	return nil
+}
+
+type MsgAddAllocationsResponse struct {
+}
+
+func (m *MsgAddAllocationsResponse) Reset()         { *m = MsgAddAllocationsResponse{} }
+func (m *MsgAddAllocationsResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgAddAllocationsResponse) ProtoMessage()    {}
+func (*MsgAddAllocationsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{12}
+}
+func (m *MsgAddAllocationsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgAddAllocationsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgAddAllocationsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgAddAllocationsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgAddAllocationsResponse.Merge(m, src)
+}
+func (m *MsgAddAllocationsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgAddAllocationsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgAddAllocationsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgAddAllocationsResponse proto.InternalMessageInfo
+
+// UpdateUserAllocation
+type MsgUpdateUserAllocation struct {
+	// Airdrop admin address
+	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
+	// Airdrop ID
+	AirdropId string `protobuf:"bytes,2,opt,name=airdrop_id,json=airdropId,proto3" json:"airdrop_id,omitempty"`
+	// Address of the airdrop recipient
+	UserAddress string `protobuf:"bytes,3,opt,name=user_address,json=userAddress,proto3" json:"user_address,omitempty"`
+	// Allocations - as an array where each element represents the rewards for a
+	// day
+	Allocations []github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,4,rep,name=allocations,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"allocations"`
+}
+
+func (m *MsgUpdateUserAllocation) Reset()         { *m = MsgUpdateUserAllocation{} }
+func (m *MsgUpdateUserAllocation) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateUserAllocation) ProtoMessage()    {}
+func (*MsgUpdateUserAllocation) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{13}
+}
+func (m *MsgUpdateUserAllocation) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateUserAllocation) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateUserAllocation.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateUserAllocation) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateUserAllocation.Merge(m, src)
+}
+func (m *MsgUpdateUserAllocation) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateUserAllocation) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateUserAllocation.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateUserAllocation proto.InternalMessageInfo
+
+func (m *MsgUpdateUserAllocation) GetAdmin() string {
+	if m != nil {
+		return m.Admin
+	}
+	return ""
+}
+
+func (m *MsgUpdateUserAllocation) GetAirdropId() string {
+	if m != nil {
+		return m.AirdropId
+	}
+	return ""
+}
+
+func (m *MsgUpdateUserAllocation) GetUserAddress() string {
+	if m != nil {
+		return m.UserAddress
+	}
+	return ""
+}
+
+type MsgUpdateUserAllocationResponse struct {
+}
+
+func (m *MsgUpdateUserAllocationResponse) Reset()         { *m = MsgUpdateUserAllocationResponse{} }
+func (m *MsgUpdateUserAllocationResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgUpdateUserAllocationResponse) ProtoMessage()    {}
+func (*MsgUpdateUserAllocationResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{14}
+}
+func (m *MsgUpdateUserAllocationResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgUpdateUserAllocationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgUpdateUserAllocationResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgUpdateUserAllocationResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgUpdateUserAllocationResponse.Merge(m, src)
+}
+func (m *MsgUpdateUserAllocationResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgUpdateUserAllocationResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgUpdateUserAllocationResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgUpdateUserAllocationResponse proto.InternalMessageInfo
+
+// LinkAddresses
+type MsgLinkAddresses struct {
+	// Airdrop admin address
+	Admin string `protobuf:"bytes,1,opt,name=admin,proto3" json:"admin,omitempty"`
+	// Airdrop ID
+	AirdropId string `protobuf:"bytes,2,opt,name=airdrop_id,json=airdropId,proto3" json:"airdrop_id,omitempty"`
+	// Stride address - this address may or may not exist in allocations yet
+	StrideAddress string `protobuf:"bytes,3,opt,name=stride_address,json=strideAddress,proto3" json:"stride_address,omitempty"`
+	// Host address - this address must exist
+	HostAddress string `protobuf:"bytes,4,opt,name=host_address,json=hostAddress,proto3" json:"host_address,omitempty"`
+}
+
+func (m *MsgLinkAddresses) Reset()         { *m = MsgLinkAddresses{} }
+func (m *MsgLinkAddresses) String() string { return proto.CompactTextString(m) }
+func (*MsgLinkAddresses) ProtoMessage()    {}
+func (*MsgLinkAddresses) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{15}
+}
+func (m *MsgLinkAddresses) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgLinkAddresses) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgLinkAddresses.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgLinkAddresses) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgLinkAddresses.Merge(m, src)
+}
+func (m *MsgLinkAddresses) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgLinkAddresses) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgLinkAddresses.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgLinkAddresses proto.InternalMessageInfo
+
+func (m *MsgLinkAddresses) GetAdmin() string {
+	if m != nil {
+		return m.Admin
+	}
+	return ""
+}
+
+func (m *MsgLinkAddresses) GetAirdropId() string {
+	if m != nil {
+		return m.AirdropId
+	}
+	return ""
+}
+
+func (m *MsgLinkAddresses) GetStrideAddress() string {
+	if m != nil {
+		return m.StrideAddress
+	}
+	return ""
+}
+
+func (m *MsgLinkAddresses) GetHostAddress() string {
+	if m != nil {
+		return m.HostAddress
+	}
+	return ""
+}
+
+type MsgLinkAddressesResponse struct {
+}
+
+func (m *MsgLinkAddressesResponse) Reset()         { *m = MsgLinkAddressesResponse{} }
+func (m *MsgLinkAddressesResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgLinkAddressesResponse) ProtoMessage()    {}
+func (*MsgLinkAddressesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_40a6837f542f43b8, []int{16}
+}
+func (m *MsgLinkAddressesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgLinkAddressesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgLinkAddressesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgLinkAddressesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgLinkAddressesResponse.Merge(m, src)
+}
+func (m *MsgLinkAddressesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgLinkAddressesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgLinkAddressesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgLinkAddressesResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgClaimDaily)(nil), "stride.airdrop.MsgClaimDaily")
 	proto.RegisterType((*MsgClaimDailyResponse)(nil), "stride.airdrop.MsgClaimDailyResponse")
@@ -319,38 +973,86 @@ func init() {
 	proto.RegisterType((*MsgClaimEarlyResponse)(nil), "stride.airdrop.MsgClaimEarlyResponse")
 	proto.RegisterType((*MsgClaimAndStake)(nil), "stride.airdrop.MsgClaimAndStake")
 	proto.RegisterType((*MsgClaimAndStakeResponse)(nil), "stride.airdrop.MsgClaimAndStakeResponse")
+	proto.RegisterType((*MsgCreateAirdrop)(nil), "stride.airdrop.MsgCreateAirdrop")
+	proto.RegisterType((*MsgCreateAirdropResponse)(nil), "stride.airdrop.MsgCreateAirdropResponse")
+	proto.RegisterType((*MsgUpdateAirdrop)(nil), "stride.airdrop.MsgUpdateAirdrop")
+	proto.RegisterType((*MsgUpdateAirdropResponse)(nil), "stride.airdrop.MsgUpdateAirdropResponse")
+	proto.RegisterType((*RawAllocation)(nil), "stride.airdrop.RawAllocation")
+	proto.RegisterType((*MsgAddAllocations)(nil), "stride.airdrop.MsgAddAllocations")
+	proto.RegisterType((*MsgAddAllocationsResponse)(nil), "stride.airdrop.MsgAddAllocationsResponse")
+	proto.RegisterType((*MsgUpdateUserAllocation)(nil), "stride.airdrop.MsgUpdateUserAllocation")
+	proto.RegisterType((*MsgUpdateUserAllocationResponse)(nil), "stride.airdrop.MsgUpdateUserAllocationResponse")
+	proto.RegisterType((*MsgLinkAddresses)(nil), "stride.airdrop.MsgLinkAddresses")
+	proto.RegisterType((*MsgLinkAddressesResponse)(nil), "stride.airdrop.MsgLinkAddressesResponse")
 }
 
 func init() { proto.RegisterFile("stride/airdrop/tx.proto", fileDescriptor_40a6837f542f43b8) }
 
 var fileDescriptor_40a6837f542f43b8 = []byte{
-	// 412 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2f, 0x2e, 0x29, 0xca,
-	0x4c, 0x49, 0xd5, 0x4f, 0xcc, 0x2c, 0x4a, 0x29, 0xca, 0x2f, 0xd0, 0x2f, 0xa9, 0xd0, 0x2b, 0x28,
-	0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x83, 0x48, 0xe8, 0x41, 0x25, 0xa4, 0xc4, 0x93, 0xf3, 0x8b, 0x73,
-	0xf3, 0x8b, 0xf5, 0x73, 0x8b, 0xd3, 0xf5, 0xcb, 0x0c, 0x41, 0x14, 0x44, 0xa1, 0x94, 0x60, 0x62,
-	0x6e, 0x66, 0x5e, 0xbe, 0x3e, 0x98, 0x84, 0x0a, 0x49, 0x42, 0xd4, 0xc6, 0x83, 0x79, 0xfa, 0x10,
-	0x0e, 0x44, 0x4a, 0xa9, 0x8b, 0x91, 0x8b, 0xd7, 0xb7, 0x38, 0xdd, 0x39, 0x27, 0x31, 0x33, 0xd7,
-	0x25, 0x31, 0x33, 0xa7, 0x52, 0xc8, 0x88, 0x8b, 0x3d, 0x19, 0xc4, 0x4b, 0x2d, 0x92, 0x60, 0x54,
-	0x60, 0xd4, 0xe0, 0x74, 0x92, 0xb8, 0xb4, 0x45, 0x57, 0x04, 0xaa, 0xc9, 0x31, 0x25, 0xa5, 0x28,
-	0xb5, 0xb8, 0x38, 0xb8, 0xa4, 0x28, 0x33, 0x2f, 0x3d, 0x08, 0xa6, 0x50, 0x48, 0x96, 0x8b, 0x0b,
-	0xea, 0xae, 0xf8, 0xcc, 0x14, 0x09, 0x26, 0x90, 0xb6, 0x20, 0x4e, 0xa8, 0x88, 0x67, 0x8a, 0x95,
-	0x5a, 0xd3, 0xf3, 0x0d, 0x5a, 0x30, 0xc5, 0x5d, 0xcf, 0x37, 0x68, 0x89, 0xc2, 0xbc, 0x87, 0x62,
-	0xb5, 0x92, 0x38, 0x97, 0x28, 0x8a, 0x40, 0x50, 0x6a, 0x71, 0x41, 0x7e, 0x5e, 0x71, 0x2a, 0x8a,
-	0x2b, 0x5d, 0x13, 0x8b, 0x06, 0xca, 0x95, 0x60, 0xab, 0x91, 0x5d, 0x09, 0x16, 0x80, 0xbb, 0x72,
-	0x2f, 0x23, 0x97, 0x00, 0x4c, 0xc6, 0x31, 0x2f, 0x25, 0xb8, 0x24, 0x31, 0x3b, 0x95, 0x06, 0x0e,
-	0x15, 0xd2, 0xe6, 0x12, 0x2c, 0x4b, 0xcc, 0xc9, 0x4c, 0x49, 0x2c, 0xc9, 0x2f, 0x8a, 0x4f, 0x84,
-	0x18, 0x21, 0xc1, 0x0c, 0x56, 0x25, 0x00, 0x97, 0x80, 0x1a, 0x6d, 0xa5, 0x89, 0xee, 0x2b, 0x09,
-	0x74, 0x5f, 0xc1, 0x9c, 0xaa, 0x24, 0xc5, 0x25, 0x81, 0x2e, 0x06, 0xf3, 0x9b, 0x51, 0x17, 0x13,
-	0x17, 0xb3, 0x6f, 0x71, 0xba, 0x50, 0x10, 0x17, 0x17, 0x52, 0x5a, 0x91, 0xd5, 0x43, 0x4d, 0x95,
-	0x7a, 0x28, 0xd1, 0x27, 0xa5, 0x8a, 0x57, 0x1a, 0x66, 0x36, 0xdc, 0x4c, 0x48, 0xcc, 0xe2, 0x34,
-	0x13, 0x2c, 0x8d, 0xdb, 0x4c, 0x94, 0xb8, 0x10, 0x8a, 0xe6, 0xe2, 0x45, 0x8d, 0x07, 0x05, 0x5c,
-	0xfa, 0x60, 0x2a, 0xa4, 0x34, 0x08, 0xa9, 0x80, 0x19, 0xee, 0xe4, 0x7d, 0xe2, 0x91, 0x1c, 0xe3,
-	0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70, 0xe1, 0xb1, 0x1c,
-	0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x51, 0x86, 0xe9, 0x99, 0x25, 0x19, 0xa5, 0x49, 0x7a, 0xc9, 0xf9,
-	0xb9, 0xfa, 0xc1, 0x60, 0xd3, 0x74, 0x7d, 0x12, 0x93, 0x8a, 0xf5, 0xa1, 0xb9, 0xba, 0xcc, 0xc8,
-	0x48, 0xbf, 0x02, 0x91, 0xb7, 0x2b, 0x0b, 0x52, 0x8b, 0x93, 0xd8, 0xc0, 0x19, 0xd1, 0x18, 0x10,
-	0x00, 0x00, 0xff, 0xff, 0xcd, 0xdb, 0xb1, 0x0e, 0xfa, 0x03, 0x00, 0x00,
+	// 995 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x57, 0xbd, 0x6f, 0xdb, 0x46,
+	0x14, 0x37, 0x23, 0x39, 0xa9, 0xcf, 0x56, 0x10, 0x33, 0x36, 0x44, 0xab, 0x88, 0x64, 0x0b, 0x48,
+	0xe2, 0xa4, 0x30, 0x89, 0xa8, 0x9b, 0x33, 0x49, 0xb5, 0x87, 0x20, 0x31, 0x10, 0xd0, 0x0e, 0xd0,
+	0x0f, 0x20, 0xc4, 0x49, 0x77, 0x65, 0x08, 0x91, 0x3c, 0x82, 0x77, 0x72, 0xe2, 0xb5, 0xe8, 0x94,
+	0x29, 0xff, 0x45, 0xd7, 0x0c, 0x5d, 0xbb, 0x67, 0x0c, 0xda, 0xa5, 0xe8, 0x90, 0x16, 0xf6, 0x90,
+	0xa5, 0xe8, 0xd2, 0x7f, 0xa0, 0xb8, 0x0f, 0xd2, 0x3c, 0x99, 0xaa, 0xd4, 0xc2, 0x41, 0x81, 0xc2,
+	0x8b, 0x69, 0xbe, 0xf7, 0x7b, 0xbf, 0x7b, 0x9f, 0xa7, 0x47, 0x50, 0xa7, 0x2c, 0x0d, 0x10, 0x76,
+	0x60, 0x90, 0xa2, 0x94, 0x24, 0x0e, 0x7b, 0x61, 0x27, 0x29, 0x61, 0xc4, 0xbc, 0x2a, 0x15, 0xb6,
+	0x52, 0x34, 0xea, 0x03, 0x42, 0x23, 0x42, 0x9d, 0x88, 0xfa, 0xce, 0xe1, 0x3d, 0xfe, 0x90, 0xc0,
+	0xc6, 0x32, 0x8c, 0x82, 0x98, 0x38, 0xe2, 0xaf, 0x12, 0xad, 0x49, 0xac, 0x27, 0xde, 0x1c, 0xf9,
+	0xa2, 0x54, 0x2b, 0x3e, 0xf1, 0x89, 0x94, 0xf3, 0xff, 0x94, 0xb4, 0xe5, 0x13, 0xe2, 0x87, 0xd8,
+	0x11, 0x6f, 0xfd, 0xd1, 0xd7, 0x0e, 0x0b, 0x22, 0x4c, 0x19, 0x8c, 0x12, 0x09, 0x68, 0xbf, 0x34,
+	0x40, 0x6d, 0x8f, 0xfa, 0x9f, 0x85, 0x30, 0x88, 0x76, 0x60, 0x10, 0x1e, 0x99, 0x1d, 0x70, 0x65,
+	0xc0, 0xdf, 0x70, 0x6a, 0x19, 0xeb, 0xc6, 0xe6, 0x42, 0xcf, 0xfa, 0xf1, 0xfb, 0xad, 0x15, 0x75,
+	0x56, 0x17, 0xa1, 0x14, 0x53, 0xba, 0xcf, 0xd2, 0x20, 0xf6, 0xdd, 0x0c, 0x68, 0xde, 0x00, 0x40,
+	0x85, 0xe3, 0x05, 0xc8, 0xba, 0xc4, 0xcd, 0xdc, 0x05, 0x25, 0x79, 0x80, 0xb6, 0x6f, 0x7d, 0xf3,
+	0xfe, 0xf5, 0xdd, 0x0c, 0xfc, 0xf2, 0xfd, 0xeb, 0xbb, 0xab, 0x59, 0x56, 0xb4, 0xa3, 0xdb, 0x75,
+	0xb0, 0xaa, 0x09, 0x5c, 0x4c, 0x13, 0x12, 0x53, 0xac, 0x79, 0xb9, 0x0b, 0xd3, 0xff, 0xca, 0x4b,
+	0x71, 0x74, 0xd1, 0x4b, 0x21, 0xc8, 0xbd, 0xfc, 0xc1, 0x00, 0xd7, 0x32, 0x4d, 0x37, 0x46, 0xfb,
+	0x0c, 0x0e, 0xf1, 0x07, 0x70, 0xd4, 0xfc, 0x04, 0x2c, 0x1f, 0xc2, 0x30, 0x40, 0x90, 0x91, 0xd4,
+	0x83, 0x92, 0xc2, 0xaa, 0x08, 0xd4, 0xb5, 0x5c, 0xa1, 0xa8, 0xb7, 0xef, 0x8c, 0x47, 0x65, 0x8d,
+	0x47, 0x95, 0xb9, 0xda, 0x6e, 0x00, 0x6b, 0x5c, 0x96, 0xc7, 0xf6, 0xfb, 0xbc, 0x8c, 0x2d, 0xc5,
+	0x90, 0xe1, 0xae, 0x64, 0x30, 0x6d, 0x30, 0x0f, 0x51, 0x14, 0xc4, 0x53, 0x23, 0x93, 0xb0, 0x69,
+	0x71, 0x7d, 0x0e, 0xea, 0x28, 0xe0, 0xd3, 0xd1, 0x1f, 0xb1, 0x80, 0xc4, 0x1e, 0x65, 0x30, 0x65,
+	0x1e, 0x82, 0x0c, 0x8b, 0xe8, 0x16, 0x3b, 0x0d, 0x5b, 0xb6, 0xb3, 0x9d, 0xb5, 0xb3, 0x7d, 0x90,
+	0xb5, 0x73, 0xaf, 0xfa, 0xea, 0xd7, 0x96, 0xe1, 0xae, 0x16, 0x09, 0xf6, 0xb9, 0xfd, 0x0e, 0x64,
+	0xd8, 0x3c, 0x00, 0x9a, 0xc2, 0xc3, 0x31, 0x92, 0xbc, 0xd5, 0x19, 0x79, 0xaf, 0x17, 0xcd, 0x77,
+	0x63, 0x24, 0x58, 0x77, 0x41, 0x6d, 0x10, 0xc2, 0xe7, 0x7d, 0x38, 0x18, 0x4a, 0xb6, 0xf9, 0x19,
+	0xd9, 0x96, 0x32, 0x33, 0x41, 0xf3, 0x05, 0xb0, 0x44, 0x79, 0x3c, 0x76, 0x94, 0x60, 0x0f, 0x61,
+	0x88, 0xc2, 0x20, 0xc6, 0x92, 0xf1, 0xf2, 0xac, 0x71, 0x0b, 0x86, 0x83, 0xa3, 0x04, 0xef, 0x28,
+	0x7b, 0x41, 0xfd, 0x14, 0x5c, 0xc7, 0xbc, 0x45, 0x3d, 0x79, 0x40, 0x82, 0x63, 0x18, 0xb2, 0x23,
+	0xeb, 0x8a, 0x28, 0x97, 0xfd, 0xe6, 0x5d, 0x6b, 0xee, 0x97, 0x77, 0xad, 0x5b, 0x7e, 0xc0, 0x9e,
+	0x8d, 0xfa, 0xf6, 0x80, 0x44, 0xea, 0x4a, 0x51, 0x8f, 0x2d, 0x8a, 0x86, 0x0e, 0x77, 0x8a, 0xda,
+	0x3b, 0x78, 0xe0, 0x2e, 0x0b, 0x2a, 0xd1, 0x1e, 0x8f, 0x25, 0x91, 0x09, 0x81, 0x3c, 0xd8, 0x83,
+	0x31, 0xe2, 0xe5, 0x1a, 0x62, 0xaf, 0x4f, 0xe2, 0x11, 0xb5, 0x3e, 0xfa, 0x57, 0x27, 0x98, 0x83,
+	0x62, 0xef, 0xf5, 0x38, 0x93, 0xf9, 0x10, 0xac, 0x68, 0xa5, 0xcb, 0xfa, 0x7d, 0x61, 0x4a, 0xcb,
+	0x69, 0x15, 0xcb, 0x86, 0xe1, 0x36, 0x1f, 0x06, 0xd9, 0x8c, 0x67, 0x46, 0xa1, 0xd8, 0xd9, 0xd9,
+	0x28, 0x14, 0x65, 0xe3, 0xa3, 0xf0, 0x24, 0x41, 0x17, 0xa3, 0x70, 0x31, 0x0a, 0xff, 0xc3, 0x51,
+	0xd0, 0x3a, 0x5b, 0x8d, 0x82, 0x26, 0xcb, 0x47, 0xe1, 0x5b, 0x03, 0xd4, 0x5c, 0xf8, 0xbc, 0x1b,
+	0x86, 0x64, 0x00, 0x39, 0xbb, 0xb9, 0x01, 0x96, 0x46, 0x14, 0x9f, 0xfe, 0x2c, 0x89, 0x71, 0x70,
+	0x17, 0xb9, 0x4c, 0x9d, 0x6c, 0x3e, 0x06, 0x8b, 0x30, 0x37, 0xa0, 0x56, 0x75, 0xbd, 0xf2, 0x0f,
+	0xf3, 0xf3, 0x20, 0x66, 0x6e, 0x91, 0xa2, 0xfd, 0x93, 0x01, 0x96, 0xf7, 0xa8, 0xdf, 0x45, 0xe8,
+	0xd4, 0x13, 0x7a, 0xde, 0x23, 0xb9, 0xab, 0xbb, 0x5d, 0x59, 0xaf, 0x6c, 0x2e, 0x76, 0x6e, 0xd8,
+	0xfa, 0x36, 0x67, 0x6b, 0xd9, 0xe8, 0x55, 0x79, 0x54, 0x9a, 0xaf, 0xdb, 0x9b, 0x7a, 0xde, 0xd7,
+	0x0a, 0x79, 0xd7, 0xfd, 0x6f, 0x7f, 0x0c, 0xd6, 0xce, 0x08, 0xf3, 0xcc, 0x7f, 0x77, 0x09, 0xd4,
+	0xf3, 0xb2, 0x3c, 0xe1, 0xd9, 0x3d, 0xad, 0xc1, 0x39, 0x07, 0x7e, 0x7f, 0xac, 0xa4, 0x95, 0x29,
+	0xac, 0x1f, 0xb6, 0xd8, 0xdb, 0xb6, 0x9e, 0xc0, 0xd6, 0x99, 0xc6, 0xd5, 0xb3, 0xd1, 0xde, 0x00,
+	0xad, 0x09, 0xaa, 0x3c, 0x99, 0x7f, 0xc8, 0xc5, 0xed, 0x51, 0x10, 0x0f, 0x95, 0xdf, 0xf8, 0xdc,
+	0xdb, 0xe7, 0x26, 0x50, 0x8b, 0xff, 0xd8, 0xc6, 0x56, 0x93, 0xd2, 0x2c, 0x5f, 0xf7, 0xc1, 0xd2,
+	0x33, 0x42, 0x59, 0x0e, 0xaa, 0x4e, 0x4b, 0x36, 0x47, 0xcf, 0x30, 0xd3, 0x5a, 0x6c, 0x6a, 0xa6,
+	0x35, 0x59, 0x96, 0x8c, 0xce, 0x9f, 0xf3, 0xa0, 0xb2, 0x47, 0x7d, 0xd3, 0x05, 0xa0, 0xf0, 0x55,
+	0x70, 0xa6, 0xd1, 0xb5, 0x45, 0xbd, 0x71, 0xf3, 0x6f, 0xd5, 0x19, 0x77, 0xce, 0x29, 0x77, 0xf8,
+	0x89, 0x9c, 0x42, 0x3d, 0x99, 0x53, 0xdb, 0xba, 0xcd, 0xaf, 0x40, 0x4d, 0xdf, 0xb8, 0xd7, 0x27,
+	0xd9, 0x65, 0x88, 0xc6, 0xe6, 0x34, 0x84, 0x46, 0xae, 0xad, 0xbc, 0xa5, 0xe4, 0x45, 0x44, 0x39,
+	0x79, 0xd9, 0x22, 0xc1, 0xc9, 0xf5, 0x25, 0xa2, 0x8c, 0x5c, 0x43, 0x94, 0x92, 0x97, 0x5e, 0xcd,
+	0xe6, 0x53, 0x70, 0x75, 0xec, 0x3e, 0xdc, 0x28, 0xb1, 0xd5, 0x21, 0x8d, 0x3b, 0x53, 0x21, 0x39,
+	0x7f, 0x02, 0x56, 0x4a, 0x2f, 0x9f, 0xdb, 0x13, 0x3d, 0xd4, 0x81, 0x0d, 0x67, 0x46, 0x60, 0x31,
+	0x5d, 0xfa, 0x84, 0x96, 0xa5, 0x4b, 0x43, 0x94, 0xa6, 0xab, 0xb4, 0xeb, 0x7b, 0x0f, 0xdf, 0x1c,
+	0x37, 0x8d, 0xb7, 0xc7, 0x4d, 0xe3, 0xb7, 0xe3, 0xa6, 0xf1, 0xea, 0xa4, 0x39, 0xf7, 0xf6, 0xa4,
+	0x39, 0xf7, 0xf3, 0x49, 0x73, 0xee, 0xcb, 0x7b, 0x85, 0x4b, 0x6a, 0x5f, 0xb0, 0x6d, 0x3d, 0x82,
+	0x7d, 0xea, 0xa8, 0xef, 0xfb, 0xc3, 0x4e, 0xc7, 0x79, 0x71, 0xfa, 0x95, 0xcf, 0xef, 0xac, 0xfe,
+	0x65, 0xb1, 0x9c, 0x7c, 0xfa, 0x57, 0x00, 0x00, 0x00, 0xff, 0xff, 0x18, 0x5b, 0x55, 0x65, 0x04,
+	0x10, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -373,6 +1075,17 @@ type MsgClient interface {
 	// User transaction to claim and automatically lock stake their whole airdrop
 	// amount now. The funds can be unstaked by the user once the airdrop is over
 	ClaimAndStake(ctx context.Context, in *MsgClaimAndStake, opts ...grpc.CallOption) (*MsgClaimAndStakeResponse, error)
+	// Admin transaction to create a new airdrop
+	CreateAirdrop(ctx context.Context, in *MsgCreateAirdrop, opts ...grpc.CallOption) (*MsgCreateAirdropResponse, error)
+	// Admin transaction to update an existing airdrop
+	UpdateAirdrop(ctx context.Context, in *MsgUpdateAirdrop, opts ...grpc.CallOption) (*MsgUpdateAirdropResponse, error)
+	// Admin transaction to add multiple user allocations for a given airdrop
+	AddAllocations(ctx context.Context, in *MsgAddAllocations, opts ...grpc.CallOption) (*MsgAddAllocationsResponse, error)
+	// Admin transaction to update a user's allocation to an airdrop
+	UpdateUserAllocation(ctx context.Context, in *MsgUpdateUserAllocation, opts ...grpc.CallOption) (*MsgUpdateUserAllocationResponse, error)
+	// Admin address to link a stride and non-stride address, merging their
+	// allocations
+	LinkAddresses(ctx context.Context, in *MsgLinkAddresses, opts ...grpc.CallOption) (*MsgLinkAddressesResponse, error)
 }
 
 type msgClient struct {
@@ -410,6 +1123,51 @@ func (c *msgClient) ClaimAndStake(ctx context.Context, in *MsgClaimAndStake, opt
 	return out, nil
 }
 
+func (c *msgClient) CreateAirdrop(ctx context.Context, in *MsgCreateAirdrop, opts ...grpc.CallOption) (*MsgCreateAirdropResponse, error) {
+	out := new(MsgCreateAirdropResponse)
+	err := c.cc.Invoke(ctx, "/stride.airdrop.Msg/CreateAirdrop", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) UpdateAirdrop(ctx context.Context, in *MsgUpdateAirdrop, opts ...grpc.CallOption) (*MsgUpdateAirdropResponse, error) {
+	out := new(MsgUpdateAirdropResponse)
+	err := c.cc.Invoke(ctx, "/stride.airdrop.Msg/UpdateAirdrop", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) AddAllocations(ctx context.Context, in *MsgAddAllocations, opts ...grpc.CallOption) (*MsgAddAllocationsResponse, error) {
+	out := new(MsgAddAllocationsResponse)
+	err := c.cc.Invoke(ctx, "/stride.airdrop.Msg/AddAllocations", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) UpdateUserAllocation(ctx context.Context, in *MsgUpdateUserAllocation, opts ...grpc.CallOption) (*MsgUpdateUserAllocationResponse, error) {
+	out := new(MsgUpdateUserAllocationResponse)
+	err := c.cc.Invoke(ctx, "/stride.airdrop.Msg/UpdateUserAllocation", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *msgClient) LinkAddresses(ctx context.Context, in *MsgLinkAddresses, opts ...grpc.CallOption) (*MsgLinkAddressesResponse, error) {
+	out := new(MsgLinkAddressesResponse)
+	err := c.cc.Invoke(ctx, "/stride.airdrop.Msg/LinkAddresses", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// User transaction to claim all the pending daily airdrop rewards
@@ -420,6 +1178,17 @@ type MsgServer interface {
 	// User transaction to claim and automatically lock stake their whole airdrop
 	// amount now. The funds can be unstaked by the user once the airdrop is over
 	ClaimAndStake(context.Context, *MsgClaimAndStake) (*MsgClaimAndStakeResponse, error)
+	// Admin transaction to create a new airdrop
+	CreateAirdrop(context.Context, *MsgCreateAirdrop) (*MsgCreateAirdropResponse, error)
+	// Admin transaction to update an existing airdrop
+	UpdateAirdrop(context.Context, *MsgUpdateAirdrop) (*MsgUpdateAirdropResponse, error)
+	// Admin transaction to add multiple user allocations for a given airdrop
+	AddAllocations(context.Context, *MsgAddAllocations) (*MsgAddAllocationsResponse, error)
+	// Admin transaction to update a user's allocation to an airdrop
+	UpdateUserAllocation(context.Context, *MsgUpdateUserAllocation) (*MsgUpdateUserAllocationResponse, error)
+	// Admin address to link a stride and non-stride address, merging their
+	// allocations
+	LinkAddresses(context.Context, *MsgLinkAddresses) (*MsgLinkAddressesResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -434,6 +1203,21 @@ func (*UnimplementedMsgServer) ClaimEarly(ctx context.Context, req *MsgClaimEarl
 }
 func (*UnimplementedMsgServer) ClaimAndStake(ctx context.Context, req *MsgClaimAndStake) (*MsgClaimAndStakeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ClaimAndStake not implemented")
+}
+func (*UnimplementedMsgServer) CreateAirdrop(ctx context.Context, req *MsgCreateAirdrop) (*MsgCreateAirdropResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateAirdrop not implemented")
+}
+func (*UnimplementedMsgServer) UpdateAirdrop(ctx context.Context, req *MsgUpdateAirdrop) (*MsgUpdateAirdropResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateAirdrop not implemented")
+}
+func (*UnimplementedMsgServer) AddAllocations(ctx context.Context, req *MsgAddAllocations) (*MsgAddAllocationsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddAllocations not implemented")
+}
+func (*UnimplementedMsgServer) UpdateUserAllocation(ctx context.Context, req *MsgUpdateUserAllocation) (*MsgUpdateUserAllocationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateUserAllocation not implemented")
+}
+func (*UnimplementedMsgServer) LinkAddresses(ctx context.Context, req *MsgLinkAddresses) (*MsgLinkAddressesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LinkAddresses not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -494,6 +1278,96 @@ func _Msg_ClaimAndStake_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_CreateAirdrop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgCreateAirdrop)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).CreateAirdrop(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stride.airdrop.Msg/CreateAirdrop",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).CreateAirdrop(ctx, req.(*MsgCreateAirdrop))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_UpdateAirdrop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgUpdateAirdrop)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).UpdateAirdrop(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stride.airdrop.Msg/UpdateAirdrop",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).UpdateAirdrop(ctx, req.(*MsgUpdateAirdrop))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_AddAllocations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgAddAllocations)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).AddAllocations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stride.airdrop.Msg/AddAllocations",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).AddAllocations(ctx, req.(*MsgAddAllocations))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_UpdateUserAllocation_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgUpdateUserAllocation)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).UpdateUserAllocation(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stride.airdrop.Msg/UpdateUserAllocation",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).UpdateUserAllocation(ctx, req.(*MsgUpdateUserAllocation))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Msg_LinkAddresses_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgLinkAddresses)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).LinkAddresses(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stride.airdrop.Msg/LinkAddresses",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).LinkAddresses(ctx, req.(*MsgLinkAddresses))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "stride.airdrop.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -509,6 +1383,26 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ClaimAndStake",
 			Handler:    _Msg_ClaimAndStake_Handler,
+		},
+		{
+			MethodName: "CreateAirdrop",
+			Handler:    _Msg_CreateAirdrop_Handler,
+		},
+		{
+			MethodName: "UpdateAirdrop",
+			Handler:    _Msg_UpdateAirdrop_Handler,
+		},
+		{
+			MethodName: "AddAllocations",
+			Handler:    _Msg_AddAllocations_Handler,
+		},
+		{
+			MethodName: "UpdateUserAllocation",
+			Handler:    _Msg_UpdateUserAllocation_Handler,
+		},
+		{
+			MethodName: "LinkAddresses",
+			Handler:    _Msg_LinkAddresses_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -702,6 +1596,533 @@ func (m *MsgClaimAndStakeResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgCreateAirdrop) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgCreateAirdrop) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgCreateAirdrop) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DistributionAddress) > 0 {
+		i -= len(m.DistributionAddress)
+		copy(dAtA[i:], m.DistributionAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.DistributionAddress)))
+		i--
+		dAtA[i] = 0x4a
+	}
+	{
+		size := m.ClaimAndStakeBonus.Size()
+		i -= size
+		if _, err := m.ClaimAndStakeBonus.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x42
+	{
+		size := m.EarlyClaimPenalty.Size()
+		i -= size
+		if _, err := m.EarlyClaimPenalty.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x3a
+	if m.ClaimTypeDeadlineDate != nil {
+		n1, err1 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.ClaimTypeDeadlineDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClaimTypeDeadlineDate):])
+		if err1 != nil {
+			return 0, err1
+		}
+		i -= n1
+		i = encodeVarintTx(dAtA, i, uint64(n1))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.ClawbackDate != nil {
+		n2, err2 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.ClawbackDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClawbackDate):])
+		if err2 != nil {
+			return 0, err2
+		}
+		i -= n2
+		i = encodeVarintTx(dAtA, i, uint64(n2))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.DistributionEndDate != nil {
+		n3, err3 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.DistributionEndDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionEndDate):])
+		if err3 != nil {
+			return 0, err3
+		}
+		i -= n3
+		i = encodeVarintTx(dAtA, i, uint64(n3))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.DistributionStartDate != nil {
+		n4, err4 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.DistributionStartDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionStartDate):])
+		if err4 != nil {
+			return 0, err4
+		}
+		i -= n4
+		i = encodeVarintTx(dAtA, i, uint64(n4))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AirdropId) > 0 {
+		i -= len(m.AirdropId)
+		copy(dAtA[i:], m.AirdropId)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.AirdropId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Admin) > 0 {
+		i -= len(m.Admin)
+		copy(dAtA[i:], m.Admin)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Admin)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgCreateAirdropResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgCreateAirdropResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgCreateAirdropResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateAirdrop) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateAirdrop) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateAirdrop) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DistributionAddress) > 0 {
+		i -= len(m.DistributionAddress)
+		copy(dAtA[i:], m.DistributionAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.DistributionAddress)))
+		i--
+		dAtA[i] = 0x4a
+	}
+	{
+		size := m.ClaimAndStakeBonus.Size()
+		i -= size
+		if _, err := m.ClaimAndStakeBonus.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x42
+	{
+		size := m.EarlyClaimPenalty.Size()
+		i -= size
+		if _, err := m.EarlyClaimPenalty.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x3a
+	if m.ClaimTypeDeadlineDate != nil {
+		n5, err5 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.ClaimTypeDeadlineDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClaimTypeDeadlineDate):])
+		if err5 != nil {
+			return 0, err5
+		}
+		i -= n5
+		i = encodeVarintTx(dAtA, i, uint64(n5))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.ClawbackDate != nil {
+		n6, err6 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.ClawbackDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClawbackDate):])
+		if err6 != nil {
+			return 0, err6
+		}
+		i -= n6
+		i = encodeVarintTx(dAtA, i, uint64(n6))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.DistributionEndDate != nil {
+		n7, err7 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.DistributionEndDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionEndDate):])
+		if err7 != nil {
+			return 0, err7
+		}
+		i -= n7
+		i = encodeVarintTx(dAtA, i, uint64(n7))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.DistributionStartDate != nil {
+		n8, err8 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.DistributionStartDate, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionStartDate):])
+		if err8 != nil {
+			return 0, err8
+		}
+		i -= n8
+		i = encodeVarintTx(dAtA, i, uint64(n8))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AirdropId) > 0 {
+		i -= len(m.AirdropId)
+		copy(dAtA[i:], m.AirdropId)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.AirdropId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Admin) > 0 {
+		i -= len(m.Admin)
+		copy(dAtA[i:], m.Admin)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Admin)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateAirdropResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateAirdropResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateAirdropResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *RawAllocation) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RawAllocation) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RawAllocation) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Allocations) > 0 {
+		for iNdEx := len(m.Allocations) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size := m.Allocations[iNdEx].Size()
+				i -= size
+				if _, err := m.Allocations[iNdEx].MarshalTo(dAtA[i:]); err != nil {
+					return 0, err
+				}
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.UserAddress) > 0 {
+		i -= len(m.UserAddress)
+		copy(dAtA[i:], m.UserAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.UserAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgAddAllocations) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgAddAllocations) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgAddAllocations) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Allocations) > 0 {
+		for iNdEx := len(m.Allocations) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Allocations[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.AirdropId) > 0 {
+		i -= len(m.AirdropId)
+		copy(dAtA[i:], m.AirdropId)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.AirdropId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Admin) > 0 {
+		i -= len(m.Admin)
+		copy(dAtA[i:], m.Admin)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Admin)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgAddAllocationsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgAddAllocationsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgAddAllocationsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateUserAllocation) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateUserAllocation) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateUserAllocation) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Allocations) > 0 {
+		for iNdEx := len(m.Allocations) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size := m.Allocations[iNdEx].Size()
+				i -= size
+				if _, err := m.Allocations[iNdEx].MarshalTo(dAtA[i:]); err != nil {
+					return 0, err
+				}
+				i = encodeVarintTx(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.UserAddress) > 0 {
+		i -= len(m.UserAddress)
+		copy(dAtA[i:], m.UserAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.UserAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AirdropId) > 0 {
+		i -= len(m.AirdropId)
+		copy(dAtA[i:], m.AirdropId)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.AirdropId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Admin) > 0 {
+		i -= len(m.Admin)
+		copy(dAtA[i:], m.Admin)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Admin)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgUpdateUserAllocationResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgUpdateUserAllocationResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgUpdateUserAllocationResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgLinkAddresses) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgLinkAddresses) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgLinkAddresses) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.HostAddress) > 0 {
+		i -= len(m.HostAddress)
+		copy(dAtA[i:], m.HostAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.HostAddress)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.StrideAddress) > 0 {
+		i -= len(m.StrideAddress)
+		copy(dAtA[i:], m.StrideAddress)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.StrideAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AirdropId) > 0 {
+		i -= len(m.AirdropId)
+		copy(dAtA[i:], m.AirdropId)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.AirdropId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Admin) > 0 {
+		i -= len(m.Admin)
+		copy(dAtA[i:], m.Admin)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Admin)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgLinkAddressesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgLinkAddressesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgLinkAddressesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -787,6 +2208,227 @@ func (m *MsgClaimAndStake) Size() (n int) {
 }
 
 func (m *MsgClaimAndStakeResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgCreateAirdrop) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Admin)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.AirdropId)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.DistributionStartDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionStartDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.DistributionEndDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionEndDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.ClawbackDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClawbackDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.ClaimTypeDeadlineDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClaimTypeDeadlineDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.EarlyClaimPenalty.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = m.ClaimAndStakeBonus.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = len(m.DistributionAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgCreateAirdropResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgUpdateAirdrop) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Admin)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.AirdropId)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.DistributionStartDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionStartDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.DistributionEndDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.DistributionEndDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.ClawbackDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClawbackDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.ClaimTypeDeadlineDate != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.ClaimTypeDeadlineDate)
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.EarlyClaimPenalty.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = m.ClaimAndStakeBonus.Size()
+	n += 1 + l + sovTx(uint64(l))
+	l = len(m.DistributionAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgUpdateAirdropResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RawAllocation) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.UserAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Allocations) > 0 {
+		for _, e := range m.Allocations {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *MsgAddAllocations) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Admin)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.AirdropId)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Allocations) > 0 {
+		for _, e := range m.Allocations {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *MsgAddAllocationsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgUpdateUserAllocation) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Admin)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.AirdropId)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.UserAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if len(m.Allocations) > 0 {
+		for _, e := range m.Allocations {
+			l = e.Size()
+			n += 1 + l + sovTx(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *MsgUpdateUserAllocationResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgLinkAddresses) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Admin)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.AirdropId)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.StrideAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.HostAddress)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgLinkAddressesResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1302,6 +2944,1598 @@ func (m *MsgClaimAndStakeResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgClaimAndStakeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgCreateAirdrop) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgCreateAirdrop: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgCreateAirdrop: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admin = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AirdropId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AirdropId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionStartDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DistributionStartDate == nil {
+				m.DistributionStartDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.DistributionStartDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionEndDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DistributionEndDate == nil {
+				m.DistributionEndDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.DistributionEndDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClawbackDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ClawbackDate == nil {
+				m.ClawbackDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.ClawbackDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClaimTypeDeadlineDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ClaimTypeDeadlineDate == nil {
+				m.ClaimTypeDeadlineDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.ClaimTypeDeadlineDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EarlyClaimPenalty", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.EarlyClaimPenalty.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClaimAndStakeBonus", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ClaimAndStakeBonus.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DistributionAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgCreateAirdropResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgCreateAirdropResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgCreateAirdropResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateAirdrop) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateAirdrop: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateAirdrop: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admin = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AirdropId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AirdropId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionStartDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DistributionStartDate == nil {
+				m.DistributionStartDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.DistributionStartDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionEndDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DistributionEndDate == nil {
+				m.DistributionEndDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.DistributionEndDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClawbackDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ClawbackDate == nil {
+				m.ClawbackDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.ClawbackDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClaimTypeDeadlineDate", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ClaimTypeDeadlineDate == nil {
+				m.ClaimTypeDeadlineDate = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.ClaimTypeDeadlineDate, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EarlyClaimPenalty", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.EarlyClaimPenalty.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClaimAndStakeBonus", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ClaimAndStakeBonus.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DistributionAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateAirdropResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateAirdropResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateAirdropResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RawAllocation) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RawAllocation: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RawAllocation: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UserAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Allocations", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v github_com_cosmos_cosmos_sdk_types.Int
+			m.Allocations = append(m.Allocations, v)
+			if err := m.Allocations[len(m.Allocations)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgAddAllocations) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgAddAllocations: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgAddAllocations: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admin = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AirdropId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AirdropId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Allocations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Allocations = append(m.Allocations, RawAllocation{})
+			if err := m.Allocations[len(m.Allocations)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgAddAllocationsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgAddAllocationsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgAddAllocationsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateUserAllocation) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateUserAllocation: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateUserAllocation: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admin = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AirdropId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AirdropId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UserAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Allocations", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var v github_com_cosmos_cosmos_sdk_types.Int
+			m.Allocations = append(m.Allocations, v)
+			if err := m.Allocations[len(m.Allocations)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgUpdateUserAllocationResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgUpdateUserAllocationResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgUpdateUserAllocationResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgLinkAddresses) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgLinkAddresses: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgLinkAddresses: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Admin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Admin = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AirdropId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AirdropId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StrideAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.StrideAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.HostAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgLinkAddressesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgLinkAddressesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgLinkAddressesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
## Context
Added the following admin CLI txs
* `CreateAirdrop`: creates a new airdrop
* `UpdateAirdrop`: updates an existing airdrop
* `AddAllocations`: adds multiple user allocations for a given airdrop
* `UpdateUserAllocation`: updates a single user's allocations
* `LinkAddresses`: links a stride and non-stride address 

## Brief Changelog
* Added admin tx protos
* Added admin tx messages, validate basic's and unit tests
* Added parser functions to parse a CSV of allocations into a message
* Added admin tx cli commands