### PR TITLE
x/stakeibc: Reduce distribución time

### DIFF
--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -25,12 +25,15 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 	if epochInfo.Identifier == epochstypes.DAY_EPOCH {
 		// Initiate unbondings from any hostZone where it's appropriate
 		k.InitiateAllHostZoneUnbondings(ctx, epochNumber)
-		// Check previous epochs to see if unbondings finished, and sweep the tokens if so
-		k.SweepAllUnbondedTokens(ctx)
 		// Cleanup any records that are no longer needed
 		k.CleanupEpochUnbondingRecords(ctx, epochNumber)
 		// Create an empty unbonding record for this epoch
 		k.CreateEpochUnbondingRecord(ctx, epochNumber)
+	}
+
+	if epochInfo.Identifier == epochstypes.HOUR_EPOCH {
+		// Check previous epochs to see if unbondings finished, and sweep the tokens if so
+		k.SweepAllUnbondedTokens(ctx)
 	}
 
 	// Stride Epoch - Process Deposits and Delegations


### PR DESCRIPTION
Currently token distribution occurs one day after the unbonding is completed. That makes the unbonding time (ATOM example) 22-25 days instead of 21-24 days.

This change updates the epoch to check if an unbonding is completed similar to stakeTIA.
https://github.com/Stride-Labs/stride/blob/d6e4e686e54a6a3c41d3ca0645f91ee1dc3ec441/x/staketia/keeper/hooks.go#L58-L63

