### PR TITLE
Increase Memo, lower Receiver max char lengths

### DIFF
--- a/x/autopilot/README.md
+++ b/x/autopilot/README.md
@@ -49,6 +49,8 @@ Note: This will support more functions that can reduce number of users' operatio
 ### A Note on Parsing
 Since older versions of IBC do not have a `Memo` field, they must pass the routing information in the `Receiver` attribute of the IBC packet. To make autopilot backwards compatible with all older IBC versions, the receiver address must be specified in the JSON string. Before passing the packet down the stack to the transfer module, the address in the JSON string will replace the `Receiver` field in the packet data, regardless of the IBC version.
 
+The module also enforces a maximum length for both the `Memo` and `Receiver` fields of 4096 and 1024 characters respectively.
+
 ## Params
 
 ```

--- a/x/autopilot/module_ibc.go
+++ b/x/autopilot/module_ibc.go
@@ -17,7 +17,8 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 
-const MaxMemoCharLength = 2000
+const MaxMemoCharLength = 4096
+const MaxReceiverCharLength = 1024
 
 // IBC MODULE IMPLEMENTATION
 // IBCModule implements the ICS26 interface for transfer given the transfer keeper.
@@ -135,7 +136,7 @@ func (im IBCModule) OnRecvPacket(
 	if len(tokenPacketData.Memo) > MaxMemoCharLength {
 		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrapf(types.ErrInvalidMemoSize, "memo length: %d", len(tokenPacketData.Memo)))
 	}
-	if len(tokenPacketData.Receiver) > MaxMemoCharLength {
+	if len(tokenPacketData.Receiver) > MaxReceiverCharLength {
 		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrapf(types.ErrInvalidMemoSize, "receiver length: %d", len(tokenPacketData.Receiver)))
 	}
 


### PR DESCRIPTION
## Context and purpose of the change

The character limits for IBC packets are necessary, however the current size limit of 2000 chars is too small.
There are valid and reasonable [transactions](https://www.mintscan.io/stride/tx/2A9CE9643F9386525CAB715E38A01CBD11FA3B24EC1B4EECCDE541C994786502)using ibc:hooks that can exceed that limit.

On the other hand the receiver field limit is set too high as there is no real reason for addresses to even reach the 2000 char limit.

## Brief Changelog

- Increase max memo length 2000 -> 4096
- Decrease max receiver length 2000 -> 1024

## Author's Checklist

I have...

- [ ] Run and PASSED locally all GAIA integration tests
- [ ] If the change is contentful, I either:
    - [ ] Added a new unit test OR 
    - [ ] Added test cases to existing unit tests
- [ ] OR this change is a trivial rework / code cleanup without any test coverage

(Don't have a local test setup for these, would be nice if they could be ran by somebody else)

## Reviewers Checklist

I have...

- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] manually tested (if applicable)
- [ ] confirmed the author wrote unit tests for new logic
- [ ] reviewed documentation exists and is accurate


## Documentation and Release Note

  - [x] Does this pull request introduce a new feature or user-facing behavior changes? 
  - [ ] Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
  - [ ] This pull request updates existing proto field values (and require a backend and frontend migration)? 
  - [ ] Does this pull request change existing proto field names (and require a frontend migration)?
  How is the feature or change documented? 
      - [ ] not applicable
      - [ ] jira ticket `XXX` 
      - [ ] specification (`x/<module>/spec/`) 
      - [x] README.md 
      - [ ] not documented <!-- because ... EXPLAIN WHY! -->
