### PR TITLE
Update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Multichain Liquid Staking
 
-[Twitter](https://twitter.com/stride_zone) | [Discord](http://stride.zone/discord) | [Website](https://stride.zone/)
+[Twitter](https://twitter.com/stride_zone) | [Discord](https://discord.com/invite/stride-zone) | [Website](https://stride.zone/)
 ## What is Stride?
 
 


### PR DESCRIPTION
Since the link on the stride site goes 404. I fixed it by replacing the link with stride discord invitation link . :)
