### PR TITLE
Updated dockernet hermes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "deps/hermes"]
-	# Commit: v1.5.1
-	path = deps/hermes
-	url = https://github.com/informalsystems/ibc-rs.git
 # TODO [LSM]: Revert to cosmos relayer once they've merged 
 # the fix for the unbonding time query
 [submodule "deps/relayer"]

--- a/dockernet/build.sh
+++ b/dockernet/build.sh
@@ -106,11 +106,5 @@ while getopts sgojtednhrz flag; do
       r) build_local_and_docker relayer deps/relayer ;;  
       h) echo "Building Hermes Docker... ";
          docker build --tag stridezone:hermes -f dockernet/dockerfiles/Dockerfile.hermes . ;
-
-         printf '%s' "Building Hermes Locally... ";
-         cd deps/hermes; 
-         cargo build --release --target-dir $BUILDDIR/hermes; 
-         cd ../..
-         echo "Done" ;;
    esac
 done

--- a/dockernet/config/hermes_config.toml
+++ b/dockernet/config/hermes_config.toml
@@ -29,28 +29,25 @@ port = 3001
 id = 'STRIDE'
 rpc_addr = 'http://stride1:26657'
 grpc_addr = 'http://stride1:9090'
-websocket_addr = 'ws://stride1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://stride1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'stride'
 key_name = 'rly1'
 store_prefix = 'ibc'
-default_gas = 100000
-max_gas = 5000000
 gas_price = { price = 0.000, denom = 'ustrd' }
-gas_multiplier = 1.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
+gas_multiplier = 1.3
+clock_drift = '10s'
 max_block_time = '10s'
+address_type = { derivation = 'cosmos' }
 trusting_period = '119s'
 trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+memo_prefix = 'stride-dockernet'
 
 [[chains]]
 id = 'GAIA'
 rpc_addr = 'http://gaia1:26657'
 grpc_addr = 'http://gaia1:9090'
-websocket_addr = 'ws://gaia1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://gaia1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'cosmos'
 key_name = 'rly2'
@@ -58,20 +55,19 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.000, denom = 'uatom' }
-gas_multiplier = 1.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
+gas_multiplier = 1.3
+clock_drift = '10s'
 max_block_time = '10s'
+address_type = { derivation = 'cosmos' }
 trusting_period = '119s'
 trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+memo_prefix = 'stride-dockernet'
 
 [[chains]]
 id = 'JUNO'
 rpc_addr = 'http://juno1:26657'
 grpc_addr = 'http://juno1:9090'
-websocket_addr = 'ws://juno1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://juno1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'juno'
 key_name = 'rly3'
@@ -79,20 +75,19 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.000, denom = 'ujuno' }
-gas_multiplier = 1.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
+gas_multiplier = 1.3
+clock_drift = '10s'
 max_block_time = '10s'
+address_type = { derivation = 'cosmos' }
 trusting_period = '119s'
 trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+memo_prefix = 'stride-dockernet'
 
 [[chains]]
 id = 'OSMO'
 rpc_addr = 'http://osmo1:26657'
 grpc_addr = 'http://osmo1:9090'
-websocket_addr = 'ws://osmo1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://osmo1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'osmo'
 key_name = 'rly4'
@@ -100,20 +95,19 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.000, denom = 'uosmo' }
-gas_multiplier = 1.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
+gas_multiplier = 1.3
+clock_drift = '10s'
 max_block_time = '10s'
+address_type = { derivation = 'cosmos' }
 trusting_period = '119s'
 trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+memo_prefix = 'stride-dockernet'
 
 [[chains]]
 id = 'STARS'
 rpc_addr = 'http://stars1:26657'
 grpc_addr = 'http://stars1:9090'
-websocket_addr = 'ws://stars1:26657/websocket'
+event_source = { mode = 'push', url = 'ws://stars1:26657/websocket', batch_delay = '500ms' }
 rpc_timeout = '10s'
 account_prefix = 'stars'
 key_name = 'rly5'
@@ -121,11 +115,10 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.000, denom = 'ustars' }
-gas_multiplier = 1.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
+gas_multiplier = 1.3
+clock_drift = '10s'
 max_block_time = '10s'
+address_type = { derivation = 'cosmos' }
 trusting_period = '119s'
 trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+memo_prefix = 'stride-dockernet'

--- a/dockernet/dockerfiles/Dockerfile.hermes
+++ b/dockernet/dockerfiles/Dockerfile.hermes
@@ -1,22 +1,14 @@
-FROM rust:1.65-buster as builder
+FROM rust:1.71-buster as builder
 
-WORKDIR /opt
+COPY --from=informalsystems/hermes:v1.9.0 /usr/bin/hermes /usr/bin/hermes
 
-RUN apt update && apt install git -y
-
-ENV COMMIT_HASH=v1.5.1
-RUN git clone https://github.com/informalsystems/ibc-rs \
-    && cd ibc-rs \
-    && git checkout $COMMIT_HASH \
-    && cargo build --release
-
-FROM debian:bullseye-slim
-
-COPY --from=builder /opt/ibc-rs/target/release/hermes /usr/local/bin/hermes
 RUN apt-get update \
-    && adduser --system --home /home/hermes --disabled-password --disabled-login hermes -u 1000
+    && apt-get install -y iputils-ping ca-certificates libssl-dev bash vim curl jq \
+    && addgroup --gid 1000 hermes \
+    && adduser --system --home /home/hermes --disabled-password --disabled-login \
+    --uid 1000 --ingroup hermes hermes
 
-USER 1000
+USER hermes
 WORKDIR /home/hermes
 
-CMD ["hermes", "start"]
+CMD hermes start

--- a/dockernet/src/start_hermes.sh
+++ b/dockernet/src/start_hermes.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eu 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source ${SCRIPT_DIR}/../config.sh
+
+for chain in ${HOST_CHAINS[@]:-}; do
+    chain_id=$(GET_VAR_VALUE     ${chain}_CHAIN_ID)
+    chain_name=$(printf "$chain" | awk '{ print tolower($0) }')
+    account_name=$(GET_VAR_VALUE RELAYER_${chain}_ACCT)
+    mnemonic=$(GET_VAR_VALUE     RELAYER_${chain}_MNEMONIC)
+
+    hermes_logs=${LOGS}/hermes-${chain_name}.log
+    hermes_config=$STATE/hermes-${chain_name}
+    hermes_exec="$DOCKER_COMPOSE run --rm hermes-$chain_name hermes"
+
+    mkdir -p $hermes_config
+    cp ${DOCKERNET_HOME}/config/hermes_config_stride.toml $hermes_config/config.toml
+    echo "$mnemonic" > $hermes_config/mnemonic.txt
+    chmod -R 777 $hermes_config
+
+    printf "STRIDE <> $chain - Adding hermes keys..."
+    $hermes_exec keys add --chain STRIDE --mnemonic-file .hermes/mnemonic.txt >> $hermes_logs 2>&1
+    $hermes_exec keys add --chain $chain_id --mnemonic-file .hermes/mnemonic.txt >> $hermes_logs 2>&1
+    echo "Done"
+
+    printf "STRIDE <> $chain - Creating client, connection, and transfer channel..." | tee -a $hermes_logs
+    $hermes_exec create channel --a-chain STRIDE --b-chain $chain_id \
+            --a-port transfer --b-port transfer --new-client-connection --yes >> $hermes_logs 2>&1
+    echo "Done"
+
+    $DOCKER_COMPOSE up -d hermes-${chain_name}
+    SAVE_DOCKER_LOGS hermes-${chain_name} $hermes_logs
+done


### PR DESCRIPTION
## Context
For context, hermes is no longer used in dockernet, but is sometimes needed when adding new host zones. As a result, I left the startup script and dockerflie in there, but removed the local binary

## Brief Changelog
* Removed submodule dependency
* Removed local build step
* Added hermes scripts and configs from #1334 (when we last ran hermes)