### PR TITLE
add txBytes support to `strided tx decode` in addition to signBytes

### DIFF
--- a/cmd/strided/root.go
+++ b/cmd/strided/root.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +34,7 @@ import (
 	snapshottypes "github.com/cosmos/cosmos-sdk/snapshots/types"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/version"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -149,7 +152,7 @@ func initAppConfig() (string, interface{}) {
 	srvCfg.GRPCWeb.EnableUnsafeCORS = true
 
 	// This ensures that upgraded nodes will use iavl fast node.
-	//srvCfg.IAVLDisableFastNode = false
+	// srvCfg.IAVLDisableFastNode = false
 
 	// TODO [CW]: Confirm these defaults are fine
 	customAppConfig := CustomAppConfig{
@@ -283,7 +286,7 @@ func txCommand() *cobra.Command {
 		flags.LineBreak,
 		authcmd.GetBroadcastCommand(),
 		authcmd.GetEncodeCommand(),
-		authcmd.GetDecodeCommand(),
+		GetDecodeCommand(),
 		flags.LineBreak,
 		vestingcli.GetTxCmd(),
 	)
@@ -291,6 +294,60 @@ func txCommand() *cobra.Command {
 	app.ModuleBasics.AddTxCommands(cmd)
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 	cmd.PersistentFlags().String(flags.FlagFrom, "", "Name or address of private key with which to sign")
+
+	return cmd
+}
+
+func decodeTxAndGetJSON(clientCtx client.Context, txBytes []byte) ([]byte, error) {
+	// First try decoding with TxDecoder
+	tx, err := clientCtx.TxConfig.TxDecoder()(txBytes)
+	if err == nil {
+		return clientCtx.TxConfig.TxJSONEncoder()(tx)
+	}
+
+	// Fallback to direct unmarshaling
+	var sdkTx sdktx.Tx
+	if err := clientCtx.Codec.Unmarshal(txBytes, &sdkTx); err != nil {
+		return nil, err
+	}
+
+	return clientCtx.TxConfig.TxJSONEncoder()(&sdkTx)
+}
+
+// GetDecodeCommand returns the decode command to take serialized bytes and turn
+// it into a JSON-encoded transaction.
+func GetDecodeCommand() *cobra.Command {
+	flagHex := "hex"
+
+	cmd := &cobra.Command{
+		Use:   "decode [protobuf-byte-string]",
+		Short: "Decode a binary encoded transaction string",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			var txBytes []byte
+
+			if useHex, _ := cmd.Flags().GetBool(flagHex); useHex {
+				txBytes, err = hex.DecodeString(args[0])
+			} else {
+				txBytes, err = base64.StdEncoding.DecodeString(args[0])
+			}
+			if err != nil {
+				return err
+			}
+
+			json, err := decodeTxAndGetJSON(clientCtx, txBytes)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintBytes(json)
+		},
+	}
+
+	cmd.Flags().BoolP(flagHex, "x", false, "Treat input as hexadecimal instead of base64")
+	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) // decoding makes sense to output only json
 
 	return cmd
 }


### PR DESCRIPTION
- Attempts primary decoding signBytes with TxDecoder
- Falls back to direct protobuf unmarshaling (txBytes) if primary decode fails

This improvement provides better handling of different transaction encoding formats and increases decode reliability.

This also add support for decoding the output of mempool errors.
