### PR TITLE
fixed gosec errors

### DIFF
--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -523,7 +523,7 @@ func (s *AppTestHelper) MockClientLatestHeight(height uint64) {
 // This also mocks out the consensus state to enable testing registering interchain accounts
 func (s *AppTestHelper) MockClientAndConnection(chainId, clientId, connectionId string) {
 	clientHeight := clienttypes.Height{
-		RevisionHeight: uint64(s.Ctx.BlockHeight()),
+		RevisionHeight: utils.IntToUint(s.Ctx.BlockHeight()),
 	}
 	clientState := tendermint.ClientState{
 		ChainId:        chainId,

--- a/app/apptesting/test_helpers.go
+++ b/app/apptesting/test_helpers.go
@@ -81,7 +81,11 @@ type AppTestHelper struct {
 // AppTestHelper Constructor
 func (s *AppTestHelper) Setup() {
 	s.App = app.InitStrideTestApp(true)
-	s.Ctx = s.App.BaseApp.NewContext(false, tmtypesproto.Header{Height: 1, ChainID: StrideChainID})
+	s.Ctx = s.App.BaseApp.NewContext(false, tmtypesproto.Header{
+		Height:  1,
+		ChainID: StrideChainID,
+		Time:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,

--- a/app/upgrades/v14/upgrades.go
+++ b/app/upgrades/v14/upgrades.go
@@ -171,7 +171,7 @@ func CreateUpgradeHandler(
 
 func InitAirdrops(ctx sdk.Context, claimKeeper claimkeeper.Keeper) error {
 	duration := uint64(AirdropDuration.Seconds())
-	startTime := uint64(AirdropStartTime.Unix())
+	startTime := utils.IntToUint(AirdropStartTime.Unix())
 
 	// Add the Injective Airdrop
 	ctx.Logger().Info("Adding Injective airdrop...")

--- a/app/upgrades/v14/upgrades_test.go
+++ b/app/upgrades/v14/upgrades_test.go
@@ -271,7 +271,7 @@ func (s *UpgradeTestSuite) CheckAirdropAdded(ctx sdk.Context, airdrop *claimtype
 	// Check that an epoch was created
 	epochInfo, found := s.App.EpochsKeeper.GetEpochInfo(ctx, fmt.Sprintf("airdrop-%s", identifier))
 	s.Require().True(found, "epoch tracker should be found")
-	s.Require().Zero(epochInfo.CurrentEpoch, "epoch should be zero")
+	s.Require().Equal(epochInfo.CurrentEpoch, int64(1), "epoch should be one")
 	s.Require().Equal(epochInfo.Duration, claimtypes.DefaultEpochDuration, "epoch duration should be equal to airdrop duration")
 }
 

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/Stride-Labs/stride/v25/utils"
 )
 
 const (
@@ -71,7 +73,7 @@ func MigrateRateLimitModule(ctx sdk.Context, k ratelimitkeeper.Keeper) {
 	// the current hour and the start time is precisely on the hour
 	genesisState := ratelimittypes.DefaultGenesis()
 	hourEpoch := genesisState.HourEpoch
-	hourEpoch.EpochNumber = uint64(ctx.BlockTime().Hour())
+	hourEpoch.EpochNumber = utils.IntToUint(int64(ctx.BlockTime().Hour()))
 	hourEpoch.EpochStartTime = ctx.BlockTime().Truncate(time.Hour)
 	hourEpoch.EpochStartHeight = ctx.BlockHeight()
 	k.SetHourEpoch(ctx, hourEpoch)

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	claimkeeper "github.com/Stride-Labs/stride/v25/x/claim/keeper"
 	"github.com/Stride-Labs/stride/v25/x/claim/types"
 	claimtypes "github.com/Stride-Labs/stride/v25/x/claim/types"
@@ -47,7 +48,7 @@ func CreateUpgradeHandler(
 					Identifier:  airdropIdentifiers[idx],
 					ChainId:     airdropChainIds[idx],
 					Denom:       claimtypes.DefaultClaimDenom,
-					StartTime:   uint64(ctx.BlockTime().Unix()),
+					StartTime:   utils.IntToUint(ctx.BlockTime().Unix()),
 					Duration:    uint64(airdropDuration.Seconds()),
 				})
 				if err != nil {

--- a/app/upgrades/v7/upgrades.go
+++ b/app/upgrades/v7/upgrades.go
@@ -187,8 +187,8 @@ func AddRedemptionRateSafetyChecks(cdc codec.Codec, storeKey storetypes.StoreKey
 	k.SetParams(ctx, params)
 
 	// Get default min/max redemption rate
-	defaultMinRedemptionRate := sdk.NewDecWithPrec(int64(params.DefaultMinRedemptionRateThreshold), 2)
-	defaultMaxRedemptionRate := sdk.NewDecWithPrec(int64(params.DefaultMaxRedemptionRateThreshold), 2)
+	defaultMinRedemptionRate := sdk.NewDecWithPrec(utils.UintToInt(params.DefaultMinRedemptionRateThreshold), 2)
+	defaultMaxRedemptionRate := sdk.NewDecWithPrec(utils.UintToInt(params.DefaultMaxRedemptionRateThreshold), 2)
 
 	for _, hostZone := range GetAllHostZone(cdc, storeKey, ctx) {
 

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -76,7 +76,7 @@ func CreateUpgradeHandler(
 			Identifier:       EvmosAirdropIdentifier,
 			ChainId:          EvmosChainId,
 			Denom:            claimtypes.DefaultClaimDenom,
-			StartTime:        uint64(AirdropStartTime.Unix()),
+			StartTime:        utils.IntToUint(AirdropStartTime.Unix()),
 			Duration:         duration,
 			AutopilotEnabled: true,
 		}); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -75,6 +76,28 @@ func Uint64MapKeys[V any](m map[uint64]V) []uint64 {
 	}
 	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	return keys
+}
+
+// Converts from uint64 -> int64 with a panic check for overflow
+// This should only be used on values where it is known that overflow
+// is not possible (e.g. params, block times, etc.), as in those scenarios
+// we want to make sure we don't silently fail
+func UintToInt(u uint64) int64 {
+	if u > math.MaxInt64 {
+		panic(fmt.Sprintf("uint64 value %d too large for int64", u))
+	}
+	return int64(u)
+}
+
+// Converts from int64 -> uint64 with a panic check for underflow
+// This should only be used on values where it is known that underflow
+// is not possible (e.g. params, block times, etc.), as in those scenarios
+// we want to make sure we don't silently fail
+func IntToUint(i int64) uint64 {
+	if i < 0 {
+		panic(fmt.Sprintf("int64 value %d is negative and can't be converted to uint64", i))
+	}
+	return uint64(i)
 }
 
 //==============================  ADDRESS VERIFICATION UTILS  ================================

--- a/x/autopilot/keeper/liquidstake.go
+++ b/x/autopilot/keeper/liquidstake.go
@@ -11,6 +11,7 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	"github.com/Stride-Labs/stride/v25/x/autopilot/types"
 	stakeibckeeper "github.com/Stride-Labs/stride/v25/x/stakeibc/keeper"
 	stakeibctypes "github.com/Stride-Labs/stride/v25/x/stakeibc/types"
@@ -125,7 +126,7 @@ func (k Keeper) IBCTransferStToken(
 	}
 
 	// Use a long timeout for the transfer
-	timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + LiquidStakeForwardTransferTimeout.Nanoseconds())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().UnixNano() + LiquidStakeForwardTransferTimeout.Nanoseconds())
 
 	// Submit the transfer from the hashed address
 	transferMsg := &transfertypes.MsgTransfer{

--- a/x/claim/client/cli/tx_create_airdrop.go
+++ b/x/claim/client/cli/tx_create_airdrop.go
@@ -20,11 +20,11 @@ func CmdCreateAirdrop() *cobra.Command {
 			identifier := args[0]
 			chainId := args[1]
 			denom := args[2]
-			argStartTime, err := strconv.Atoi(args[3])
+			argStartTime, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				return err
 			}
-			argDuration, err := strconv.Atoi(args[4])
+			argDuration, err := strconv.ParseUint(args[4], 10, 64)
 			if err != nil {
 				return err
 			}
@@ -43,8 +43,8 @@ func CmdCreateAirdrop() *cobra.Command {
 				identifier,
 				chainId,
 				denom,
-				uint64(argStartTime),
-				uint64(argDuration),
+				argStartTime,
+				argDuration,
 				autopilotEnabled,
 			)
 

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -581,8 +581,8 @@ func (k Keeper) GetUserTotalClaimable(ctx sdk.Context, addr sdk.AccAddress, aird
 
 	totalClaimable := sdk.Coins{}
 
-	for action := range utils.Int32MapKeys(types.Action_name) {
-		claimableForAction, err := k.GetClaimableAmountForAction(ctx, addr, types.Action(action), airdropIdentifier, includeClaimed) //nolint:gosec // G115
+	for _, action := range utils.Int32MapKeys(types.Action_name) {
+		claimableForAction, err := k.GetClaimableAmountForAction(ctx, addr, types.Action(action), airdropIdentifier, includeClaimed)
 		if err != nil {
 			return sdk.Coins{}, err
 		}

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -582,7 +582,7 @@ func (k Keeper) GetUserTotalClaimable(ctx sdk.Context, addr sdk.AccAddress, aird
 	totalClaimable := sdk.Coins{}
 
 	for action := range utils.Int32MapKeys(types.Action_name) {
-		claimableForAction, err := k.GetClaimableAmountForAction(ctx, addr, types.Action(action), airdropIdentifier, includeClaimed)
+		claimableForAction, err := k.GetClaimableAmountForAction(ctx, addr, types.Action(action), airdropIdentifier, includeClaimed) //nolint:gosec // G115
 		if err != nil {
 			return sdk.Coins{}, err
 		}

--- a/x/claim/keeper/claim.go
+++ b/x/claim/keeper/claim.go
@@ -765,10 +765,10 @@ func (k Keeper) CreateAirdropAndEpoch(ctx sdk.Context, msg types.MsgCreateAirdro
 	airdrop := types.Airdrop{
 		AirdropIdentifier:  msg.Identifier,
 		ChainId:            msg.ChainId,
-		AirdropDuration:    time.Duration(msg.Duration * uint64(time.Second)),
+		AirdropDuration:    time.Duration(utils.UintToInt(msg.Duration) * int64(time.Second)),
 		ClaimDenom:         msg.Denom,
 		DistributorAddress: msg.Distributor,
-		AirdropStartTime:   time.Unix(int64(msg.StartTime), 0),
+		AirdropStartTime:   time.Unix(utils.UintToInt(msg.StartTime), 0),
 		AutopilotEnabled:   msg.AutopilotEnabled,
 	}
 

--- a/x/epochs/keeper/grpc_query_test.go
+++ b/x/epochs/keeper/grpc_query_test.go
@@ -2,67 +2,27 @@ package keeper_test
 
 import (
 	gocontext "context"
-	"time"
-
-	_ "github.com/stretchr/testify/suite"
 
 	"github.com/Stride-Labs/stride/v25/x/epochs/types"
 )
 
-func (suite *KeeperTestSuite) TestQueryEpochInfos() {
-	suite.SetupTest()
-	queryClient := suite.queryClient
+func (s *KeeperTestSuite) TestQueryEpochInfos() {
+	s.SetupTest()
 
-	chainStartTime := suite.Ctx.BlockTime()
+	expectedEpochs := map[string]types.EpochInfo{}
+	for _, epoch := range types.DefaultGenesis().Epochs {
+		expectedEpochs[epoch.Identifier] = epoch
+	}
 
 	// Invalid param
-	epochInfosResponse, err := queryClient.EpochInfos(gocontext.Background(), &types.QueryEpochsInfoRequest{})
-	suite.Require().NoError(err)
-	suite.Require().Len(epochInfosResponse.Epochs, 5)
+	epochInfosResponse, err := s.queryClient.EpochInfos(gocontext.Background(), &types.QueryEpochsInfoRequest{})
+	s.Require().NoError(err)
+	s.Require().Len(epochInfosResponse.Epochs, 5)
 
 	// check if EpochInfos are correct
-	suite.Require().Equal(epochInfosResponse.Epochs[0], types.EpochInfo{
-		Identifier:            "day",
-		StartTime:             chainStartTime,
-		Duration:              time.Hour * 24,
-		CurrentEpoch:          int64(0),
-		CurrentEpochStartTime: chainStartTime,
-		EpochCountingStarted:  false,
-	})
-
-	suite.Require().Equal(epochInfosResponse.Epochs[1], types.EpochInfo{
-		Identifier:            "hour",
-		StartTime:             chainStartTime,
-		Duration:              time.Hour,
-		CurrentEpoch:          int64(0),
-		CurrentEpochStartTime: chainStartTime,
-		EpochCountingStarted:  false,
-	})
-
-	suite.Require().Equal(epochInfosResponse.Epochs[2], types.EpochInfo{
-		Identifier:            "mint",
-		StartTime:             chainStartTime,
-		Duration:              time.Minute * 60,
-		CurrentEpoch:          int64(0),
-		CurrentEpochStartTime: chainStartTime,
-		EpochCountingStarted:  false,
-	})
-
-	suite.Require().Equal(epochInfosResponse.Epochs[3], types.EpochInfo{
-		Identifier:            "stride_epoch",
-		StartTime:             chainStartTime,
-		Duration:              time.Hour * 6,
-		CurrentEpoch:          int64(0),
-		CurrentEpochStartTime: chainStartTime,
-		EpochCountingStarted:  false,
-	})
-
-	suite.Require().Equal(epochInfosResponse.Epochs[4], types.EpochInfo{
-		Identifier:            "week",
-		StartTime:             chainStartTime,
-		Duration:              time.Hour * 24 * 7,
-		CurrentEpoch:          int64(0),
-		CurrentEpochStartTime: chainStartTime,
-		EpochCountingStarted:  false,
-	})
+	s.Require().Equal(epochInfosResponse.Epochs[0], expectedEpochs["day"])
+	s.Require().Equal(epochInfosResponse.Epochs[1], expectedEpochs["hour"])
+	s.Require().Equal(epochInfosResponse.Epochs[2], expectedEpochs["mint"])
+	s.Require().Equal(epochInfosResponse.Epochs[3], expectedEpochs["stride_epoch"])
+	s.Require().Equal(epochInfosResponse.Epochs[4], expectedEpochs["week"])
 }

--- a/x/icaoracle/types/ica.go
+++ b/x/icaoracle/types/ica.go
@@ -7,6 +7,8 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	proto "github.com/cosmos/gogoproto/proto"
+
+	"github.com/Stride-Labs/stride/v25/utils"
 )
 
 const (
@@ -51,7 +53,7 @@ func (i ICATx) ValidateICATx() error {
 }
 
 func (i ICATx) GetRelativeTimeoutNano() uint64 {
-	return uint64(i.RelativeTimeout.Nanoseconds())
+	return utils.IntToUint(i.RelativeTimeout.Nanoseconds())
 }
 
 func FormatICAAccountOwner(chainId string, accountType string) string {

--- a/x/interchainquery/keeper/keeper.go
+++ b/x/interchainquery/keeper/keeper.go
@@ -59,7 +59,7 @@ func (k *Keeper) SubmitICQRequest(ctx sdk.Context, query types.Query, forceUniqu
 	}
 
 	// Set the timeout using the block time and timeout duration
-	timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + query.TimeoutDuration.Nanoseconds())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().UnixNano() + query.TimeoutDuration.Nanoseconds())
 	query.TimeoutTimestamp = timeoutTimestamp
 
 	// Generate and set the query ID - optionally force it to be unique

--- a/x/interchainquery/types/query.go
+++ b/x/interchainquery/types/query.go
@@ -3,12 +3,14 @@ package types
 import (
 	fmt "fmt"
 	time "time"
+
+	"github.com/Stride-Labs/stride/v25/utils"
 )
 
 // Check if a query has timed-out by checking whether the block time is after
 // the timeout timestamp
 func (q Query) HasTimedOut(currentBlockTime time.Time) bool {
-	return q.TimeoutTimestamp < uint64(currentBlockTime.UnixNano())
+	return q.TimeoutTimestamp < utils.IntToUint(currentBlockTime.UnixNano())
 }
 
 // Prints an abbreviated query description for logging purposes

--- a/x/records/keeper/transfer.go
+++ b/x/records/keeper/transfer.go
@@ -68,7 +68,7 @@ func (k Keeper) IBCTransferLSMToken(
 	hostZoneDelegationICAAddress string,
 ) error {
 	// Build transfer message with a conservative timeout
-	timeout := uint64(ctx.BlockTime().UnixNano() + (LSMDepositTransferTimeout).Nanoseconds())
+	timeout := utils.IntToUint(ctx.BlockTime().UnixNano() + (LSMDepositTransferTimeout).Nanoseconds())
 	ibcToken := sdk.NewCoin(lsmTokenDeposit.IbcDenom, lsmTokenDeposit.Amount)
 	transferMsg := transfertypes.MsgTransfer{
 		SourcePort:       transfertypes.PortID,

--- a/x/stakedym/keeper/delegation.go
+++ b/x/stakedym/keeper/delegation.go
@@ -117,7 +117,7 @@ func (k Keeper) PrepareDelegation(ctx sdk.Context, epochNumber uint64, epochDura
 	}
 
 	// Timeout the transfer at the end of the epoch
-	timeoutTimestamp := uint64(ctx.BlockTime().Add(epochDuration).UnixNano())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().Add(epochDuration).UnixNano())
 
 	// Transfer the native tokens to the host chain
 	transferMsgDepositToDelegation := transfertypes.MsgTransfer{

--- a/x/stakedym/keeper/grpc_query.go
+++ b/x/stakedym/keeper/grpc_query.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	"github.com/Stride-Labs/stride/v25/x/stakedym/types"
 )
 
@@ -100,8 +101,8 @@ func (k Keeper) RedemptionRecords(c context.Context, req *types.QueryRedemptionR
 		return &types.QueryRedemptionRecordsResponse{}, types.ErrHostZoneNotFound
 	}
 	fourDays := time.Duration(4) * time.Hour * 24
-	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                 // 21 days
-	estimatedUnbondingTime := uint64(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
+	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                          // 21 days
+	estimatedUnbondingTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
 	for _, unbondingRecord := range unbondingRecords {
 		// Edge case: a user has submitted a redemption, but the corresponding unbonding record has not been confirmed, meaning
 		// the unbonding completion time is 0. Give a rough estimate.

--- a/x/stakedym/keeper/grpc_query.go
+++ b/x/stakedym/keeper/grpc_query.go
@@ -101,7 +101,7 @@ func (k Keeper) RedemptionRecords(c context.Context, req *types.QueryRedemptionR
 		return &types.QueryRedemptionRecordsResponse{}, types.ErrHostZoneNotFound
 	}
 	fourDays := time.Duration(4) * time.Hour * 24
-	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                          // 21 days
+	unbondingLength := time.Duration(utils.UintToInt(zone.UnbondingPeriodSeconds)) * time.Second         // 21 days
 	estimatedUnbondingTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
 	for _, unbondingRecord := range unbondingRecords {
 		// Edge case: a user has submitted a redemption, but the corresponding unbonding record has not been confirmed, meaning

--- a/x/stakedym/keeper/hooks.go
+++ b/x/stakedym/keeper/hooks.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	epochstypes "github.com/Stride-Labs/stride/v25/x/epochs/types"
 )
 
@@ -18,7 +19,7 @@ import (
 // Note: The hourly processes are meant for actions that should run ASAP,
 // but the hourly buffer makes it less expensive
 func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInfo) {
-	epochNumber := uint64(epochInfo.CurrentEpoch)
+	epochNumber := utils.IntToUint(epochInfo.CurrentEpoch)
 
 	// Every day, refresh the redemption rate and prepare delegations
 	// Every 4 days, prepare undelegations

--- a/x/stakedym/keeper/msg_server.go
+++ b/x/stakedym/keeper/msg_server.go
@@ -123,7 +123,7 @@ func (k msgServer) AdjustDelegatedBalance(goCtx context.Context, msg *types.MsgA
 	latestSlashRecordId := k.IncrementSlashRecordId(ctx)
 	slashRecord := types.SlashRecord{
 		Id:               latestSlashRecordId,
-		Time:             uint64(ctx.BlockTime().Unix()),
+		Time:             utils.IntToUint(ctx.BlockTime().Unix()),
 		NativeAmount:     msg.DelegationOffset,
 		ValidatorAddress: msg.ValidatorAddress,
 	}

--- a/x/stakedym/keeper/unbonding.go
+++ b/x/stakedym/keeper/unbonding.go
@@ -187,8 +187,8 @@ func (k Keeper) ConfirmUndelegation(ctx sdk.Context, recordId uint64, txHash str
 	delegatedBalanceBefore := hostZone.DelegatedBalance
 
 	// update the record's txhash, status, and unbonding completion time
-	unbondingLength := time.Duration(hostZone.UnbondingPeriodSeconds) * time.Second // 21 days
-	unbondingCompletionTime := uint64(ctx.BlockTime().Add(unbondingLength).Unix())  // now + 21 days
+	unbondingLength := time.Duration(hostZone.UnbondingPeriodSeconds) * time.Second         // 21 days
+	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix()) // now + 21 days
 
 	record.UndelegationTxHash = txHash
 	record.Status = types.UNBONDING_IN_PROGRESS
@@ -282,7 +282,7 @@ func (k Keeper) VerifyImpliedRedemptionRateFromUnbonding(ctx sdk.Context, stToke
 // Records are annotated with a new status UNBONDED
 func (k Keeper) MarkFinishedUnbondings(ctx sdk.Context) {
 	for _, unbondingRecord := range k.GetAllUnbondingRecordsByStatus(ctx, types.UNBONDING_IN_PROGRESS) {
-		if ctx.BlockTime().Unix() > int64(unbondingRecord.UnbondingCompletionTimeSeconds) {
+		if ctx.BlockTime().Unix() > utils.UintToInt(unbondingRecord.UnbondingCompletionTimeSeconds) {
 			unbondingRecord.Status = types.UNBONDED
 			k.SetUnbondingRecord(ctx, unbondingRecord)
 		}

--- a/x/stakedym/keeper/unbonding.go
+++ b/x/stakedym/keeper/unbonding.go
@@ -187,8 +187,8 @@ func (k Keeper) ConfirmUndelegation(ctx sdk.Context, recordId uint64, txHash str
 	delegatedBalanceBefore := hostZone.DelegatedBalance
 
 	// update the record's txhash, status, and unbonding completion time
-	unbondingLength := time.Duration(hostZone.UnbondingPeriodSeconds) * time.Second         // 21 days
-	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix()) // now + 21 days
+	unbondingLength := time.Duration(utils.UintToInt(hostZone.UnbondingPeriodSeconds)) * time.Second // 21 days
+	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix())          // now + 21 days
 
 	record.UndelegationTxHash = txHash
 	record.Status = types.UNBONDING_IN_PROGRESS

--- a/x/stakeibc/keeper/community_pool.go
+++ b/x/stakeibc/keeper/community_pool.go
@@ -134,7 +134,7 @@ func (k Keeper) QueryCommunityPoolIcaBalance(
 	if !found {
 		return errorsmod.Wrapf(types.ErrEpochNotFound, "epoch %s not found", epochstypes.STRIDE_EPOCH)
 	}
-	timeout := time.Unix(0, int64(strideEpochTracker.NextEpochStartTime))
+	timeout := time.Unix(0, utils.UintToInt(strideEpochTracker.NextEpochStartTime))
 	timeoutDuration := timeout.Sub(ctx.BlockTime())
 
 	// Submit the ICQ for the withdrawal account balance

--- a/x/stakeibc/keeper/delegation.go
+++ b/x/stakeibc/keeper/delegation.go
@@ -148,7 +148,7 @@ func (k Keeper) StakeExistingDepositsOnHostZones(ctx sdk.Context, epochNumber ui
 		}
 
 		// Submit the delegation messages in batchs
-		delegateBatchSize := int(hostZone.MaxMessagesPerIcaTx)
+		delegateBatchSize := int(utils.UintToInt(hostZone.MaxMessagesPerIcaTx))
 		numTxsSubmitted, err := k.BatchSubmitDelegationICAMessages(ctx, hostZone, depositRecord, msgs, delegations, delegateBatchSize)
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("Unable to submit delegation ICA: %s", err.Error()))

--- a/x/stakeibc/keeper/grpc_query.go
+++ b/x/stakeibc/keeper/grpc_query.go
@@ -16,6 +16,7 @@ import (
 
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	epochtypes "github.com/Stride-Labs/stride/v25/x/epochs/types"
 	"github.com/Stride-Labs/stride/v25/x/stakeibc/types"
 )
@@ -161,7 +162,7 @@ func (k Keeper) AddressUnbondings(c context.Context, req *types.QueryAddressUnbo
 						unbondingTime = unbondingStartTime + (unbondingDurationEstimate * nanosecondsInDay)
 					}
 					unbondingTime = unbondingTime + nanosecondsInDay
-					unbondingTimeStr := time.Unix(0, int64(unbondingTime)).UTC().String()
+					unbondingTimeStr := time.Unix(0, utils.UintToInt(unbondingTime)).UTC().String()
 
 					addressUnbonding := types.AddressUnbonding{
 						Address:                userRedemptionRecordAddress,

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	epochstypes "github.com/Stride-Labs/stride/v25/x/epochs/types"
 	"github.com/Stride-Labs/stride/v25/x/stakeibc/types"
 )
@@ -157,7 +158,7 @@ func (k Keeper) DisableHubTokenization(ctx sdk.Context) {
 	})
 
 	// Send the ICA tx to disable tokenization
-	timeoutTimestamp := uint64(ctx.BlockTime().Add(24 * time.Hour).UnixNano())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().Add(24 * time.Hour).UnixNano())
 	delegationOwner := types.FormatHostZoneICAOwner(hostZone.ChainId, types.ICAAccountType_DELEGATION)
 	err := k.SubmitICATxWithoutCallback(ctx, hostZone.ConnectionId, delegationOwner, msgs, timeoutTimestamp)
 	if err != nil {

--- a/x/stakeibc/keeper/icacallbacks_reinvest.go
+++ b/x/stakeibc/keeper/icacallbacks_reinvest.go
@@ -114,7 +114,7 @@ func (k Keeper) ReinvestCallback(ctx sdk.Context, packet channeltypes.Packet, ac
 	// Submit an ICQ for the rewards balance in the fee account
 	k.Logger(ctx).Info(utils.LogICACallbackWithHostZone(chainId, ICACallbackID_Reinvest, "Submitting ICQ for fee account balance"))
 
-	timeout := time.Unix(0, int64(strideEpochTracker.NextEpochStartTime))
+	timeout := time.Unix(0, utils.UintToInt(strideEpochTracker.NextEpochStartTime))
 	timeoutDuration := timeout.Sub(ctx.BlockTime())
 
 	query := icqtypes.Query{

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -190,7 +190,7 @@ func (k Keeper) GetLatestUnbondingCompletionTime(ctx sdk.Context, msgResponses [
 			return 0, errorsmod.Wrapf(types.ErrUnmarshalFailure, "Unable to unmarshal undelegation tx response: %s", err.Error())
 		}
 
-		responseCompletionTime := uint64(undelegateResponse.CompletionTime.UnixNano())
+		responseCompletionTime := utils.IntToUint(undelegateResponse.CompletionTime.UnixNano())
 		if responseCompletionTime > latestCompletionTime {
 			latestCompletionTime = responseCompletionTime
 		}

--- a/x/stakeibc/keeper/interchainaccounts.go
+++ b/x/stakeibc/keeper/interchainaccounts.go
@@ -194,7 +194,7 @@ func (k Keeper) SubmitTxs(
 
 	// Submit ICA tx
 	msgServer := icacontrollerkeeper.NewMsgServerImpl(&k.ICAControllerKeeper)
-	relativeTimeoutOffset := timeoutTimestamp - uint64(ctx.BlockTime().UnixNano())
+	relativeTimeoutOffset := timeoutTimestamp - utils.IntToUint(ctx.BlockTime().UnixNano())
 	msgSendTx := icacontrollertypes.NewMsgSendTx(owner, connectionId, relativeTimeoutOffset, packetData)
 	res, err := msgServer.SendTx(ctx, msgSendTx)
 	if err != nil {
@@ -235,7 +235,7 @@ func (k Keeper) SubmitICATxWithoutCallback(
 		Type: icatypes.EXECUTE_TX,
 		Data: txBz,
 	}
-	relativeTimeoutOffset := timeoutTimestamp - uint64(ctx.BlockTime().UnixNano())
+	relativeTimeoutOffset := timeoutTimestamp - utils.IntToUint(ctx.BlockTime().UnixNano())
 
 	// Submit ICA, no need to store callback data or register callback function
 	icaMsgServer := icacontrollerkeeper.NewMsgServerImpl(&k.ICAControllerKeeper)

--- a/x/stakeibc/keeper/interchainqueries.go
+++ b/x/stakeibc/keeper/interchainqueries.go
@@ -208,7 +208,7 @@ func (k Keeper) SubmitWithdrawalHostBalanceICQ(ctx sdk.Context, hostZone types.H
 	if !found {
 		return errorsmod.Wrapf(types.ErrEpochNotFound, "epoch %s not found", epochstypes.STRIDE_EPOCH)
 	}
-	timeout := time.Unix(0, int64(strideEpochTracker.NextEpochStartTime))
+	timeout := time.Unix(0, utils.UintToInt(strideEpochTracker.NextEpochStartTime))
 	timeoutDuration := timeout.Sub(ctx.BlockTime())
 
 	// Submit the ICQ for the withdrawal account balance

--- a/x/stakeibc/keeper/keeper.go
+++ b/x/stakeibc/keeper/keeper.go
@@ -16,6 +16,7 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	"github.com/spf13/cast"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	icacallbackskeeper "github.com/Stride-Labs/stride/v25/x/icacallbacks/keeper"
 	icqkeeper "github.com/Stride-Labs/stride/v25/x/interchainquery/keeper"
 	recordsmodulekeeper "github.com/Stride-Labs/stride/v25/x/records/keeper"
@@ -134,14 +135,14 @@ func (k Keeper) GetICATimeoutNanos(ctx sdk.Context, epochType string) (uint64, e
 func (k Keeper) GetOuterSafetyBounds(ctx sdk.Context, zone types.HostZone) (sdk.Dec, sdk.Dec) {
 	// Fetch the wide bounds
 	minSafetyThresholdInt := k.GetParam(ctx, types.KeyDefaultMinRedemptionRateThreshold)
-	minSafetyThreshold := sdk.NewDec(int64(minSafetyThresholdInt)).Quo(sdk.NewDec(100))
+	minSafetyThreshold := sdk.NewDec(utils.UintToInt(minSafetyThresholdInt)).Quo(sdk.NewDec(100))
 
 	if !zone.MinRedemptionRate.IsNil() && zone.MinRedemptionRate.IsPositive() {
 		minSafetyThreshold = zone.MinRedemptionRate
 	}
 
 	maxSafetyThresholdInt := k.GetParam(ctx, types.KeyDefaultMaxRedemptionRateThreshold)
-	maxSafetyThreshold := sdk.NewDec(int64(maxSafetyThresholdInt)).Quo(sdk.NewDec(100))
+	maxSafetyThreshold := sdk.NewDec(utils.UintToInt(maxSafetyThresholdInt)).Quo(sdk.NewDec(100))
 
 	if !zone.MaxRedemptionRate.IsNil() && zone.MaxRedemptionRate.IsPositive() {
 		maxSafetyThreshold = zone.MaxRedemptionRate

--- a/x/stakeibc/keeper/lsm.go
+++ b/x/stakeibc/keeper/lsm.go
@@ -16,6 +16,7 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	icqtypes "github.com/Stride-Labs/stride/v25/x/interchainquery/types"
 
 	recordstypes "github.com/Stride-Labs/stride/v25/x/records/types"
@@ -208,7 +209,7 @@ func (k Keeper) CalculateLSMStToken(liquidStakedShares sdkmath.Int, lsmLiquidSta
 // Determines the new slash query checkpoint, by mulitplying the query threshold percent by the current TVL
 func (k Keeper) GetUpdatedSlashQueryCheckpoint(ctx sdk.Context, totalDelegations sdkmath.Int) sdkmath.Int {
 	params := k.GetParams(ctx)
-	queryThreshold := sdk.NewDecWithPrec(int64(params.ValidatorSlashQueryThreshold), 2) // percentage
+	queryThreshold := sdk.NewDecWithPrec(utils.UintToInt(params.ValidatorSlashQueryThreshold), 2) // percentage
 	checkpoint := queryThreshold.Mul(sdk.NewDecFromInt(totalDelegations)).TruncateInt()
 	return checkpoint
 }
@@ -442,7 +443,7 @@ func (k Keeper) DetokenizeLSMDeposit(ctx sdk.Context, hostZone types.HostZone, d
 	}
 
 	// Submit the ICA with a coonservative timeout
-	timeout := uint64(ctx.BlockTime().UnixNano() + (DetokenizationTimeout).Nanoseconds())
+	timeout := utils.IntToUint(ctx.BlockTime().UnixNano() + (DetokenizationTimeout).Nanoseconds())
 	if _, err := k.SubmitTxs(
 		ctx,
 		hostZone.ConnectionId,

--- a/x/stakeibc/keeper/msg_server.go
+++ b/x/stakeibc/keeper/msg_server.go
@@ -634,7 +634,7 @@ func (k msgServer) CloseDelegationChannel(goCtx context.Context, msg *types.MsgC
 	}}
 
 	// Timeout the ICA 1 nanosecond after the current block time (so it's impossible to be relayed)
-	timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + 1)
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().UnixNano() + 1)
 	err := k.SubmitICATxWithoutCallback(ctx, hostZone.ConnectionId, delegationIcaOwner, msgSend, timeoutTimestamp)
 	if err != nil {
 		return nil, err
@@ -802,7 +802,7 @@ func (k msgServer) ToggleTradeController(
 
 	// Submit the ICA tx from the trade ICA account
 	// Timeout the ICA at 1 hour
-	timeoutTimestamp := uint64(ctx.BlockTime().Add(time.Hour).UnixNano())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().Add(time.Hour).UnixNano())
 	err = k.SubmitICATxWithoutCallback(
 		ctx,
 		tradeRoute.TradeAccount.ConnectionId,

--- a/x/stakeibc/keeper/registration.go
+++ b/x/stakeibc/keeper/registration.go
@@ -83,10 +83,10 @@ func (k Keeper) RegisterHostZone(ctx sdk.Context, msg *types.MsgRegisterHostZone
 
 	params := k.GetParams(ctx)
 	if msg.MinRedemptionRate.IsNil() || msg.MinRedemptionRate.IsZero() {
-		msg.MinRedemptionRate = sdk.NewDecWithPrec(int64(params.DefaultMinRedemptionRateThreshold), 2)
+		msg.MinRedemptionRate = sdk.NewDecWithPrec(utils.UintToInt(params.DefaultMinRedemptionRateThreshold), 2)
 	}
 	if msg.MaxRedemptionRate.IsNil() || msg.MaxRedemptionRate.IsZero() {
-		msg.MaxRedemptionRate = sdk.NewDecWithPrec(int64(params.DefaultMaxRedemptionRateThreshold), 2)
+		msg.MaxRedemptionRate = sdk.NewDecWithPrec(utils.UintToInt(params.DefaultMaxRedemptionRateThreshold), 2)
 	}
 
 	// Set the max messages per ICA tx to the default value if it's not specified

--- a/x/stakeibc/keeper/reward_converter.go
+++ b/x/stakeibc/keeper/reward_converter.go
@@ -350,7 +350,7 @@ func (k Keeper) WithdrawalRewardBalanceQuery(ctx sdk.Context, route types.TradeR
 	if !found {
 		return errorsmod.Wrap(types.ErrEpochNotFound, epochstypes.STRIDE_EPOCH)
 	}
-	timeoutDuration := time.Duration(strideEpochTracker.Duration) / 2
+	timeoutDuration := time.Duration(utils.UintToInt(strideEpochTracker.Duration)) / 2
 
 	// We need the trade route keys in the callback to look up the tradeRoute struct
 	callbackData := types.TradeRouteCallback{
@@ -400,7 +400,7 @@ func (k Keeper) TradeConvertedBalanceQuery(ctx sdk.Context, route types.TradeRou
 	if !found {
 		return errorsmod.Wrap(types.ErrEpochNotFound, epochstypes.STRIDE_EPOCH)
 	}
-	timeout := time.Unix(0, int64(strideEpochTracker.NextEpochStartTime))
+	timeout := time.Unix(0, utils.UintToInt(strideEpochTracker.NextEpochStartTime))
 	timeoutDuration := timeout.Sub(ctx.BlockTime())
 
 	// We need the trade route keys in the callback to look up the tradeRoute struct

--- a/x/stakeibc/keeper/transfer.go
+++ b/x/stakeibc/keeper/transfer.go
@@ -67,7 +67,7 @@ func (k Keeper) TransferExistingDepositsToHostZones(ctx sdk.Context, epochNumber
 		// if we onboard non-tendermint chains, we need to use the time on the host chain to
 		// calculate the timeout
 		// https://github.com/cometbft/cometbft/blob/v0.34.x/spec/consensus/bft-time.md
-		timeoutTimestamp := uint64(ctx.BlockTime().UnixNano()) + ibcTransferTimeoutNanos
+		timeoutTimestamp := utils.IntToUint(ctx.BlockTime().UnixNano()) + ibcTransferTimeoutNanos
 		msg := ibctypes.NewMsgTransfer(
 			ibctransfertypes.PortID,
 			hostZone.TransferChannelId,

--- a/x/stakeibc/keeper/unbonding.go
+++ b/x/stakeibc/keeper/unbonding.go
@@ -423,7 +423,7 @@ func (k Keeper) UnbondFromHostZone(ctx sdk.Context, hostZone types.HostZone) (er
 	}
 
 	// Get the undelegation ICA messages and split delegations for the callback
-	undelegateBatchSize := int(hostZone.MaxMessagesPerIcaTx)
+	undelegateBatchSize := int(utils.UintToInt(hostZone.MaxMessagesPerIcaTx))
 	msgs, unbondings, err := k.GetUnbondingICAMessages(
 		hostZone,
 		totalNativeUnbondAmount,

--- a/x/stakeibc/migrations/v3/convert.go
+++ b/x/stakeibc/migrations/v3/convert.go
@@ -4,6 +4,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	oldstakeibctypes "github.com/Stride-Labs/stride/v25/x/stakeibc/migrations/v3/types"
 	newstakeibctypes "github.com/Stride-Labs/stride/v25/x/stakeibc/types"
 )
@@ -26,7 +27,7 @@ var (
 //   - InternalExchangeRate is now a decimal named SharesToTokensRate
 //   - DelegationAmt renamed to Delegation
 func convertToNewValidator(oldValidator oldstakeibctypes.Validator, totalDelegations sdkmath.Int) newstakeibctypes.Validator {
-	queryThreshold := sdk.NewDecWithPrec(int64(ValidatorSlashQueryThreshold), 2) // percentage
+	queryThreshold := sdk.NewDecWithPrec(utils.UintToInt(ValidatorSlashQueryThreshold), 2) // percentage
 	slashQueryCheckpoint := queryThreshold.Mul(sdk.NewDecFromInt(totalDelegations)).TruncateInt()
 
 	// Note: The old name of "TokensToShares" was slightly misleading - it represents the conversion of shares to tokens

--- a/x/staketia/keeper/delegation.go
+++ b/x/staketia/keeper/delegation.go
@@ -52,7 +52,7 @@ func (k Keeper) PrepareDelegation(ctx sdk.Context, epochNumber uint64, epochDura
 	}
 
 	// Timeout the transfer at the end of the epoch
-	timeoutTimestamp := uint64(ctx.BlockTime().Add(epochDuration).UnixNano())
+	timeoutTimestamp := utils.IntToUint(ctx.BlockTime().Add(epochDuration).UnixNano())
 
 	// Transfer the native tokens to the host chain
 	transferMsgDepositToDelegation := transfertypes.MsgTransfer{

--- a/x/staketia/keeper/grpc_query.go
+++ b/x/staketia/keeper/grpc_query.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	"github.com/Stride-Labs/stride/v25/x/staketia/types"
 )
 
@@ -100,8 +101,8 @@ func (k Keeper) RedemptionRecords(c context.Context, req *types.QueryRedemptionR
 		return &types.QueryRedemptionRecordsResponse{}, types.ErrHostZoneNotFound
 	}
 	fourDays := time.Duration(4) * time.Hour * 24
-	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                 // 21 days
-	estimatedUnbondingTime := uint64(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
+	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                          // 21 days
+	estimatedUnbondingTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
 	for _, unbondingRecord := range unbondingRecords {
 		// Edge case: a user has submitted a redemption, but the corresponding unbonding record has not been confirmed, meaning
 		// the unbonding completion time is 0. Give a rough estimate.

--- a/x/staketia/keeper/grpc_query.go
+++ b/x/staketia/keeper/grpc_query.go
@@ -101,7 +101,7 @@ func (k Keeper) RedemptionRecords(c context.Context, req *types.QueryRedemptionR
 		return &types.QueryRedemptionRecordsResponse{}, types.ErrHostZoneNotFound
 	}
 	fourDays := time.Duration(4) * time.Hour * 24
-	unbondingLength := time.Duration(zone.UnbondingPeriodSeconds) * time.Second                          // 21 days
+	unbondingLength := time.Duration(utils.UintToInt(zone.UnbondingPeriodSeconds)) * time.Second         // 21 days
 	estimatedUnbondingTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Add(fourDays).Unix()) // 21 days from now + 4 day buffer
 	for _, unbondingRecord := range unbondingRecords {
 		// Edge case: a user has submitted a redemption, but the corresponding unbonding record has not been confirmed, meaning

--- a/x/staketia/keeper/hooks.go
+++ b/x/staketia/keeper/hooks.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	epochstypes "github.com/Stride-Labs/stride/v25/x/epochs/types"
 )
 
@@ -18,7 +19,7 @@ import (
 // Note: The hourly processes are meant for actions that should run ASAP,
 // but the hourly buffer makes it less expensive
 func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInfo) {
-	epochNumber := uint64(epochInfo.CurrentEpoch)
+	epochNumber := utils.IntToUint(epochInfo.CurrentEpoch)
 
 	// Every day, refresh the redemption rate and prepare delegations
 	// Every 4 days, prepare undelegations

--- a/x/staketia/keeper/msg_server.go
+++ b/x/staketia/keeper/msg_server.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/Stride-Labs/stride/v25/utils"
 	"github.com/Stride-Labs/stride/v25/x/staketia/types"
 )
 
@@ -128,7 +129,7 @@ func (k msgServer) AdjustDelegatedBalance(goCtx context.Context, msg *types.MsgA
 	latestSlashRecordId := k.IncrementSlashRecordId(ctx)
 	slashRecord := types.SlashRecord{
 		Id:               latestSlashRecordId,
-		Time:             uint64(ctx.BlockTime().Unix()),
+		Time:             utils.IntToUint(ctx.BlockTime().Unix()),
 		NativeAmount:     msg.DelegationOffset,
 		ValidatorAddress: msg.ValidatorAddress,
 	}

--- a/x/staketia/keeper/unbonding.go
+++ b/x/staketia/keeper/unbonding.go
@@ -272,7 +272,7 @@ func (k Keeper) ConfirmUndelegation(ctx sdk.Context, recordId uint64, txHash str
 
 	// update the record's txhash, status, and unbonding completion time
 	unbondingLength := time.Duration(staketiaHostZone.UnbondingPeriodSeconds) * time.Second // 21 days
-	unbondingCompletionTime := uint64(ctx.BlockTime().Add(unbondingLength).Unix())          // now + 21 days
+	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix()) // now + 21 days
 
 	record.UndelegationTxHash = txHash
 	record.Status = types.UNBONDING_IN_PROGRESS
@@ -330,7 +330,7 @@ func (k Keeper) BurnRedeemedStTokens(ctx sdk.Context, stTokensToBurn sdk.Coins, 
 // Records are annotated with a new status UNBONDED
 func (k Keeper) MarkFinishedUnbondings(ctx sdk.Context) {
 	for _, unbondingRecord := range k.GetAllUnbondingRecordsByStatus(ctx, types.UNBONDING_IN_PROGRESS) {
-		if ctx.BlockTime().Unix() > int64(unbondingRecord.UnbondingCompletionTimeSeconds) {
+		if ctx.BlockTime().Unix() > utils.UintToInt(unbondingRecord.UnbondingCompletionTimeSeconds) {
 			unbondingRecord.Status = types.UNBONDED
 			k.SetUnbondingRecord(ctx, unbondingRecord)
 		}

--- a/x/staketia/keeper/unbonding.go
+++ b/x/staketia/keeper/unbonding.go
@@ -271,8 +271,8 @@ func (k Keeper) ConfirmUndelegation(ctx sdk.Context, recordId uint64, txHash str
 	stDenom := utils.StAssetDenomFromHostZoneDenom(staketiaHostZone.NativeTokenDenom)
 
 	// update the record's txhash, status, and unbonding completion time
-	unbondingLength := time.Duration(staketiaHostZone.UnbondingPeriodSeconds) * time.Second // 21 days
-	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix()) // now + 21 days
+	unbondingLength := time.Duration(utils.UintToInt(staketiaHostZone.UnbondingPeriodSeconds)) * time.Second // 21 days
+	unbondingCompletionTime := utils.IntToUint(ctx.BlockTime().Add(unbondingLength).Unix())                  // now + 21 days
 
 	record.UndelegationTxHash = txHash
 	record.Status = types.UNBONDING_IN_PROGRESS


### PR DESCRIPTION
## Context
We have a lot of gosec errors due to casting between uint64 and int64. All these examples are with numbers that we know wont overflow (e.g. casting block time or params < 100).

We could either (a) use `cast` which returns an error, (b) ignore the gosec errors, or (c) cast with a utility that panics.

(a) just makes the code unreadable it's much more likely that something would get fat fingered in the fix and introduce another bug.

(b) is a bit dangerous 

The only risk with (c) is that we have a chain halt from a panic, but considering this should only be used in scenarios that are unexpected, I'd argue that we would rather just panic here rather than silently overflow.