### PR TITLE
Fix auction query conflict

### DIFF
--- a/proto/stride/auction/query.proto
+++ b/proto/stride/auction/query.proto
@@ -12,7 +12,7 @@ option go_package = "github.com/Stride-Labs/stride/v26/x/auction/types";
 service Query {
   // Auction queries the auction info for a specific token
   rpc Auction(QueryAuctionRequest) returns (QueryAuctionResponse) {
-    option (google.api.http).get = "/stride/auction/{name}";
+    option (google.api.http).get = "/stride/auction/auction/{name}";
   }
 
   // Auctions queries the auction info for a specific token


### PR DESCRIPTION
`/stride/auction/auctions` doesn't work because it matches with route `/stride/auction/{name}`.
i updated the route to be the same as [airdrops](https://github.com/Stride-Labs/stride/blob/main/proto/stride/airdrop/query.proto#L18)

![image](https://github.com/user-attachments/assets/4f7bb4f4-5380-477d-bda6-2a64cf000784)
