### PR TITLE
Fix Typos in Comments and Test Assertions

### DIFF
--- a/proto/stride/mint/v1beta1/genesis.proto
+++ b/proto/stride/mint/v1beta1/genesis.proto
@@ -11,7 +11,7 @@ message GenesisState {
   // minter is a space for holding current rewards information.
   Minter minter = 1 [ (gogoproto.nullable) = false ];
 
-  // params defines all the paramaters of the module.
+  // params defines all the parameters of the module.
   Params params = 2 [ (gogoproto.nullable) = false ];
 
   // current reduction period start epoch

--- a/x/icaoracle/types/message_add_oracle_test.go
+++ b/x/icaoracle/types/message_add_oracle_test.go
@@ -73,7 +73,7 @@ func TestMsgAddOracle(t *testing.T) {
 				require.Equal(t, len(signers), 1)
 				require.Equal(t, signers[0].String(), validAdminAddress)
 
-				require.Equal(t, test.msg.ConnectionId, validConnectionId, "connnectionId")
+				require.Equal(t, test.msg.ConnectionId, validConnectionId, "connectionId")
 				require.Equal(t, test.msg.Type(), "add_oracle", "type")
 			} else {
 				require.ErrorContains(t, test.msg.ValidateBasic(), test.err, "test: %v", test.name)


### PR DESCRIPTION


**Description:**  
- Corrected a typo in the comment for the mint module's genesis state parameters.
- Fixed a typo in the test assertion for the connection ID in the ICA Oracle module.  
