### PR TITLE
skip autopilot address validation when memo is empty

### DIFF
--- a/x/autopilot/module_ibc.go
+++ b/x/autopilot/module_ibc.go
@@ -142,17 +142,17 @@ func (im IBCModule) OnRecvPacket(
 		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrapf(types.ErrInvalidReceiverLength, "receiver length: %d", len(tokenPacketData.Receiver)))
 	}
 
-	// The receiver must always be a valid address
-	// In the case of autopilot, this address is also duplicated in the autopilot payload
-	if _, err := sdk.AccAddressFromBech32(tokenPacketData.Receiver); err != nil {
-		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrap(types.ErrInvalidReceiverAddress, tokenPacketData.Receiver))
-	}
-
 	// If a valid receiver address has been provided and no memo,
 	// this is clearly just an normal IBC transfer
 	// Pass down the stack immediately instead of parsing
 	if tokenPacketData.Memo == "" {
 		return im.app.OnRecvPacket(ctx, packet, relayer)
+	}
+
+	// The receiver must always be a valid address
+	// In the case of autopilot, this address is also duplicated in the autopilot payload
+	if _, err := sdk.AccAddressFromBech32(tokenPacketData.Receiver); err != nil {
+		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrap(types.ErrInvalidReceiverAddress, tokenPacketData.Receiver))
 	}
 
 	// parse out any autopilot forwarding info

--- a/x/autopilot/module_ibc_test.go
+++ b/x/autopilot/module_ibc_test.go
@@ -1,0 +1,158 @@
+package autopilot_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/ibc-go/v7/modules/apps/transfer"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/v27/app/apptesting"
+	"github.com/Stride-Labs/stride/v27/x/autopilot"
+	recordsmodule "github.com/Stride-Labs/stride/v27/x/records"
+)
+
+type ModuleIBCTestSuite struct {
+	apptesting.AppTestHelper
+	module autopilot.IBCModule
+}
+
+func (s *ModuleIBCTestSuite) SetupTest() {
+	s.Setup()
+	// Create the full IBC stack similar to how it's done in the other tests
+	transferIBCModule := transfer.NewIBCModule(s.App.TransferKeeper)
+	recordsStack := recordsmodule.NewIBCModule(s.App.RecordsKeeper, transferIBCModule)
+	s.module = autopilot.NewIBCModule(s.App.AutopilotKeeper, recordsStack)
+}
+
+func TestModuleIBCTestSuite(t *testing.T) {
+	suite.Run(t, new(ModuleIBCTestSuite))
+}
+
+func (s *ModuleIBCTestSuite) TestOnRecvPacket_ValidBech32WithoutMemo() {
+	// Test with valid address and no memo - should bypass autopilot validation
+	validAddress := s.TestAccs[0].String()
+	tokenPacketData := transfertypes.FungibleTokenPacketData{
+		Denom:    "uatom",
+		Amount:   "1000000",
+		Sender:   "cosmos1sender",
+		Receiver: validAddress,
+		Memo:     "", // No memo = no autopilot needed
+	}
+
+	packet := channeltypes.Packet{
+		Sequence:           1,
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-0",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-1",
+		Data:               transfertypes.ModuleCdc.MustMarshalJSON(&tokenPacketData),
+	}
+
+	relayer := sdk.AccAddress("relayer")
+
+	ack := s.module.OnRecvPacket(s.Ctx, packet, relayer)
+
+	if !ack.Success() {
+		// If it fails, it should not be due to autopilot receiver address validation (error code 1506)
+		s.Require().NotContains(string(ack.Acknowledgement()), "ABCI code: 1506",
+			"valid address without memo should not fail due to autopilot address validation")
+		// It may fail due to other reasons (transfer module validation, missing denom, etc.)
+		s.T().Logf("Packet failed due to other validation (expected): %s", string(ack.Acknowledgement()))
+	}
+}
+
+// This test demonstrates that invalid bech32 addresses are now handled correctly:
+// - Without memo: Bypasses autopilot validation (gets rejected later by transfer module with error code 1)
+// - With memo: Gets caught by autopilot validation (error code 1506)
+// This is the fix for Namada's bech32m address compatibility issue
+func (s *ModuleIBCTestSuite) TestInvalidBech32AddressHandling() {
+	invalidBech32Address := "tnam1qr8h3ga7rg76s8j4w4ks7hx6a5vxrd5r4n0ux6p4ez"
+
+	// Test 1: Without memo - should bypass autopilot validation
+	tokenPacketDataNoMemo := transfertypes.FungibleTokenPacketData{
+		Denom:    "uatom",
+		Amount:   "1000000",
+		Sender:   "cosmos1sender",
+		Receiver: invalidBech32Address,
+		Memo:     "", // No memo = no autopilot processing
+	}
+
+	packetNoMemo := channeltypes.Packet{
+		Sequence:           1,
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-0",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-1",
+		Data:               transfertypes.ModuleCdc.MustMarshalJSON(&tokenPacketDataNoMemo),
+	}
+
+	// Test 2: With memo - should be caught by autopilot validation
+	tokenPacketDataWithMemo := transfertypes.FungibleTokenPacketData{
+		Denom:    "uatom",
+		Amount:   "1000000",
+		Sender:   "cosmos1sender",
+		Receiver: invalidBech32Address,
+		Memo:     `{"autopilot": {"receiver": "stride1valid", "stakeibc": {"action": "LiquidStake"}}}`,
+	}
+
+	packetWithMemo := channeltypes.Packet{
+		Sequence:           2,
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-0",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-1",
+		Data:               transfertypes.ModuleCdc.MustMarshalJSON(&tokenPacketDataWithMemo),
+	}
+
+	relayer := sdk.AccAddress("relayer")
+
+	ackNoMemo := s.module.OnRecvPacket(s.Ctx, packetNoMemo, relayer)
+	ackWithMemo := s.module.OnRecvPacket(s.Ctx, packetWithMemo, relayer)
+
+	// Verify the different error sources
+	s.Require().False(ackNoMemo.Success(), "without memo should still fail (from transfer module)")
+	s.Require().Contains(string(ackNoMemo.Acknowledgement()), "ABCI code: 1",
+		"without memo should fail with transfer module error (code 1)")
+
+	s.Require().False(ackWithMemo.Success(), "with memo should fail at autopilot validation")
+	s.Require().Contains(string(ackWithMemo.Acknowledgement()), "ABCI code: 1506",
+		"with memo should fail with autopilot validation error (code 1506)")
+}
+
+func (s *ModuleIBCTestSuite) TestOnRecvPacket_ValidBech32WithMemo() {
+	// Test that packets with valid bech32 addresses and memo pass autopilot address validation
+
+	validAddress := s.TestAccs[0].String()
+	tokenPacketData := transfertypes.FungibleTokenPacketData{
+		Denom:    "uatom",
+		Amount:   "1000000",
+		Sender:   "cosmos1sender",
+		Receiver: validAddress,
+		Memo:     `{"autopilot": {"receiver": "` + validAddress + `", "stakeibc": {"action": "LiquidStake"}}}`,
+	}
+
+	packet := channeltypes.Packet{
+		Sequence:           1,
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-0",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-1",
+		Data:               transfertypes.ModuleCdc.MustMarshalJSON(&tokenPacketData),
+	}
+
+	relayer := sdk.AccAddress("relayer")
+
+	ack := s.module.OnRecvPacket(s.Ctx, packet, relayer)
+
+	if !ack.Success() {
+		// Should not fail due to autopilot receiver address validation (error code 1506)
+		// since we're using a valid bech32 address
+		s.Require().NotContains(string(ack.Acknowledgement()), "ABCI code: 1506",
+			"valid bech32 address should pass autopilot receiver address validation")
+		// May fail for other reasons (missing host zone, invalid memo format, etc.)
+		s.T().Logf("Packet failed due to other validation (may be expected): %s", string(ack.Acknowledgement()))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes compatibility issue between Stride's autopilot IBC middleware and Namada's bech32m addresses.

## Problem

Namada uses bech32m encoding for addresses while Stride's autopilot middleware expected bech32. The autopilot middleware was validating receiver addresses before checking if autopilot processing was needed, causing all IBC packets from Namada to fail - even simple transfers that didn't require autopilot functionality.

## Solution

Reordered validation checks in `OnRecvPacket` to check for autopilot processing first:

- **Before**: Validate receiver address → Check if memo is empty
- **After**: Check if memo is empty → Validate receiver address only if autopilot is needed

This ensures:

- Packets without memos (no autopilot needed) bypass address validation entirely
- Packets with memos (autopilot needed) still get proper address validation

## Impact

Enables Namada's shielded swaps to work with Stride while maintaining existing security guarantees.
