### PR TITLE
move AuctionOffRewardCollectorBalance to BeginBlocker

### DIFF
--- a/x/stakeibc/keeper/abci.go
+++ b/x/stakeibc/keeper/abci.go
@@ -38,6 +38,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 	}
 
 	k.AssertStrideAndDayEpochRelationship(ctx)
+	k.AuctionOffRewardCollectorBalance(ctx)
 }
 
 func (k Keeper) EndBlocker(ctx sdk.Context) {

--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -89,9 +89,6 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 		// Do transfers for all reward and swapped tokens defined by the trade routes every stride epoch
 		k.TransferAllRewardTokens(ctx)
 	}
-	if epochInfo.Identifier == epochstypes.MINT_EPOCH {
-		k.AuctionOffRewardCollectorBalance(ctx)
-	}
 }
 
 func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochInfo epochstypes.EpochInfo) {}


### PR DESCRIPTION
## Summary

Refactor the `AuctionOffRewardCollectorBalance` function within the `x/stakeibc` module's `BeginBlocker` to optimize its execution frequency.

## Problem

Previously, `AuctionOffRewardCollectorBalance` was executed once every `MINT_EPOCH` (hourly on mainnet). This introduced an unnecessary delay in auctioning off collected tokens.

## Solution

This commit modifies the execution frequency of `AuctionOffRewardCollectorBalance` to run every block instead of every hour.

## Impact

By executing `AuctionOffRewardCollectorBalance` every block, the delay in auctioning off tokens is eliminated. This ensures the process is more efficient.