### PR TITLE
v28 Upgrade Handler + Bounds Change

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -37,6 +37,7 @@ import (
 	v25 "github.com/Stride-Labs/stride/v27/app/upgrades/v25"
 	v26 "github.com/Stride-Labs/stride/v27/app/upgrades/v26"
 	v27 "github.com/Stride-Labs/stride/v27/app/upgrades/v27"
+	v28 "github.com/Stride-Labs/stride/v27/app/upgrades/v28"
 	v3 "github.com/Stride-Labs/stride/v27/app/upgrades/v3"
 	v4 "github.com/Stride-Labs/stride/v27/app/upgrades/v4"
 	v5 "github.com/Stride-Labs/stride/v27/app/upgrades/v5"
@@ -357,6 +358,16 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v27.UpgradeName,
 		v27.CreateUpgradeHandler(
+			app.mm,
+			app.configurator,
+			app.StakeibcKeeper,
+		),
+	)
+
+	// v28 upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v28.UpgradeName,
+		v28.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
 			app.StakeibcKeeper,

--- a/app/upgrades/v28/upgrades.go
+++ b/app/upgrades/v28/upgrades.go
@@ -1,0 +1,70 @@
+package v28
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	stakeibckeeper "github.com/Stride-Labs/stride/v27/x/stakeibc/keeper"
+)
+
+var (
+	UpgradeName = "v28"
+
+	OsmosisChainId = "osmosis-1"
+
+	// Redemption rate bounds updated to give ~3 months of slack on outer bounds
+	RedemptionRateOuterMinAdjustment = sdk.MustNewDecFromStr("0.05")
+	RedemptionRateOuterMaxAdjustment = sdk.MustNewDecFromStr("0.25")
+
+	// Osmosis will have a slighly larger buffer with the redemption rate
+	// since their yield is less predictable
+	OsmosisRedemptionRateBuffer = sdk.MustNewDecFromStr("0.02")
+)
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v27
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	stakeibcKeeper stakeibckeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("Starting upgrade v28...")
+
+		// Run migrations first
+		ctx.Logger().Info("Running module migrations...")
+		versionMap, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return nil, err
+		}
+
+		ctx.Logger().Info("Update redemption rate bounds...")
+		UpdateRedemptionRateBounds(ctx, stakeibcKeeper)
+
+		return versionMap, nil
+	}
+}
+
+// Updates the outer redemption rate bounds
+func UpdateRedemptionRateBounds(ctx sdk.Context, k stakeibckeeper.Keeper) {
+	ctx.Logger().Info("Updating redemption rate outer bounds...")
+
+	for _, hostZone := range k.GetAllHostZone(ctx) {
+		// Give osmosis a bit more slack since OSMO stakers collect real yield
+		outerAdjustment := RedemptionRateOuterMaxAdjustment
+		if hostZone.ChainId == OsmosisChainId {
+			outerAdjustment = outerAdjustment.Add(OsmosisRedemptionRateBuffer)
+		}
+
+		outerMinDelta := hostZone.RedemptionRate.Mul(RedemptionRateOuterMinAdjustment)
+		outerMaxDelta := hostZone.RedemptionRate.Mul(outerAdjustment)
+
+		outerMin := hostZone.RedemptionRate.Sub(outerMinDelta)
+		outerMax := hostZone.RedemptionRate.Add(outerMaxDelta)
+
+		hostZone.MinRedemptionRate = outerMin
+		hostZone.MaxRedemptionRate = outerMax
+
+		k.SetHostZone(ctx, hostZone)
+	}
+}

--- a/app/upgrades/v28/upgrades.go
+++ b/app/upgrades/v28/upgrades.go
@@ -11,15 +11,9 @@ import (
 var (
 	UpgradeName = "v28"
 
-	OsmosisChainId = "osmosis-1"
-
-	// Redemption rate bounds updated to give ~3 months of slack on outer bounds
-	RedemptionRateOuterMinAdjustment = sdk.MustNewDecFromStr("0.05")
-	RedemptionRateOuterMaxAdjustment = sdk.MustNewDecFromStr("0.25")
-
-	// Osmosis will have a slighly larger buffer with the redemption rate
-	// since their yield is less predictable
-	OsmosisRedemptionRateBuffer = sdk.MustNewDecFromStr("0.02")
+	// Redemption rate bounds updated to give slack on outer bounds
+	RedemptionRateOuterMinAdjustment = sdk.MustNewDecFromStr("0.50")
+	RedemptionRateOuterMaxAdjustment = sdk.MustNewDecFromStr("1.00")
 )
 
 // CreateUpgradeHandler creates an SDK upgrade handler for v27
@@ -50,14 +44,8 @@ func UpdateRedemptionRateBounds(ctx sdk.Context, k stakeibckeeper.Keeper) {
 	ctx.Logger().Info("Updating redemption rate outer bounds...")
 
 	for _, hostZone := range k.GetAllHostZone(ctx) {
-		// Give osmosis a bit more slack since OSMO stakers collect real yield
-		outerAdjustment := RedemptionRateOuterMaxAdjustment
-		if hostZone.ChainId == OsmosisChainId {
-			outerAdjustment = outerAdjustment.Add(OsmosisRedemptionRateBuffer)
-		}
-
 		outerMinDelta := hostZone.RedemptionRate.Mul(RedemptionRateOuterMinAdjustment)
-		outerMaxDelta := hostZone.RedemptionRate.Mul(outerAdjustment)
+		outerMaxDelta := hostZone.RedemptionRate.Mul(RedemptionRateOuterMaxAdjustment)
 
 		outerMin := hostZone.RedemptionRate.Sub(outerMinDelta)
 		outerMax := hostZone.RedemptionRate.Add(outerMaxDelta)

--- a/app/upgrades/v28/upgrades_test.go
+++ b/app/upgrades/v28/upgrades_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Stride-Labs/stride/v27/app/apptesting"
-	v27 "github.com/Stride-Labs/stride/v27/app/upgrades/v27"
 	v28 "github.com/Stride-Labs/stride/v27/app/upgrades/v28"
 	stakeibctypes "github.com/Stride-Labs/stride/v27/x/stakeibc/types"
 )
@@ -57,21 +56,14 @@ func (s *UpgradeTestSuite) SetupTestUpdateRedemptionRateBounds() func() {
 		{
 			ChainId:                        "chain-0",
 			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.0"),
-			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("0.95"), // 1 - 5% = 0.95
-			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.25"), // 1 + 25% = 1.25
+			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("0.5"), // 1 - 50% = 0.95
+			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("2.0"), // 1 + 100% = 1.25
 		},
 		{
 			ChainId:                        "chain-1",
 			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.1"),
-			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("1.045"), // 1.1 - 5% = 1.045
-			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.375"), // 1.1 + 25% = 1.375
-		},
-		{
-			// Max outer for osmo uses 12% instead of 10%
-			ChainId:                        v27.OsmosisChainId,
-			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.25"),
-			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("1.1875"), // 1.25 - 5% = 1.1875
-			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.5875"), // 1.25 + 27% = 1.5875
+			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("0.55"), // 1.1 - 50% = 0.55
+			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("2.2"),  // 1.1 + 100% = 2.2
 		},
 	}
 

--- a/app/upgrades/v28/upgrades_test.go
+++ b/app/upgrades/v28/upgrades_test.go
@@ -1,0 +1,98 @@
+package v28_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/v27/app/apptesting"
+	v27 "github.com/Stride-Labs/stride/v27/app/upgrades/v27"
+	v28 "github.com/Stride-Labs/stride/v27/app/upgrades/v28"
+	stakeibctypes "github.com/Stride-Labs/stride/v27/x/stakeibc/types"
+)
+
+type UpdateRedemptionRateBounds struct {
+	ChainId                        string
+	CurrentRedemptionRate          sdk.Dec
+	ExpectedMinOuterRedemptionRate sdk.Dec
+	ExpectedMaxOuterRedemptionRate sdk.Dec
+}
+
+type UpdateRedemptionRateInnerBounds struct {
+	ChainId                        string
+	CurrentRedemptionRate          sdk.Dec
+	ExpectedMinInnerRedemptionRate sdk.Dec
+	ExpectedMaxInnerRedemptionRate sdk.Dec
+}
+
+type UpgradeTestSuite struct {
+	apptesting.AppTestHelper
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (s *UpgradeTestSuite) TestUpgrade() {
+	upgradeHeight := int64(4)
+
+	// Set state before upgrade
+	checkRedemptionRates := s.SetupTestUpdateRedemptionRateBounds()
+
+	// Run upgrade
+	s.ConfirmUpgradeSucceededs(v28.UpgradeName, upgradeHeight)
+
+	// Confirm state after upgrade
+	checkRedemptionRates()
+}
+
+func (s *UpgradeTestSuite) SetupTestUpdateRedemptionRateBounds() func() {
+	// Define test cases consisting of an initial redemption rate and expected bounds
+	testCases := []UpdateRedemptionRateBounds{
+		{
+			ChainId:                        "chain-0",
+			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.0"),
+			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("0.95"), // 1 - 5% = 0.95
+			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.25"), // 1 + 25% = 1.25
+		},
+		{
+			ChainId:                        "chain-1",
+			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.1"),
+			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("1.045"), // 1.1 - 5% = 1.045
+			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.375"), // 1.1 + 25% = 1.375
+		},
+		{
+			// Max outer for osmo uses 12% instead of 10%
+			ChainId:                        v27.OsmosisChainId,
+			CurrentRedemptionRate:          sdk.MustNewDecFromStr("1.25"),
+			ExpectedMinOuterRedemptionRate: sdk.MustNewDecFromStr("1.1875"), // 1.25 - 5% = 1.1875
+			ExpectedMaxOuterRedemptionRate: sdk.MustNewDecFromStr("1.5875"), // 1.25 + 27% = 1.5875
+		},
+	}
+
+	// Create a host zone for each test case
+	for _, tc := range testCases {
+		hostZone := stakeibctypes.HostZone{
+			ChainId:        tc.ChainId,
+			RedemptionRate: tc.CurrentRedemptionRate,
+		}
+		s.App.StakeibcKeeper.SetHostZone(s.Ctx, hostZone)
+	}
+
+	// Return callback to check store after upgrade
+	return func() {
+		// Confirm they were all updated
+		for _, tc := range testCases {
+			hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, tc.ChainId)
+			s.Require().True(found)
+
+			s.Require().Equal(tc.ExpectedMinOuterRedemptionRate, hostZone.MinRedemptionRate, "%s - min outer", tc.ChainId)
+			s.Require().Equal(tc.ExpectedMaxOuterRedemptionRate, hostZone.MaxRedemptionRate, "%s - max outer", tc.ChainId)
+		}
+	}
+}


### PR DESCRIPTION
Adds an upgrade handler for the v28 upgrade.

Also adjusts the outer bounds for all host zones in the v28 upgrade.