### PR TITLE
disable community pool liquid stake feature

### DIFF
--- a/x/stakeibc/keeper/hooks.go
+++ b/x/stakeibc/keeper/hooks.go
@@ -83,8 +83,9 @@ func (k Keeper) BeforeEpochStart(ctx sdk.Context, epochInfo epochstypes.EpochInf
 		// to the redemption account
 		k.SweepUnbondedTokensAllHostZones(ctx)
 
+		// NOTE: Disabled in v28 as this feature is no longer being used. Uncomment to re-enable
 		// Transfers in and out of tokens for hostZones which have community pools
-		k.ProcessAllCommunityPoolTokens(ctx)
+		// k.ProcessAllCommunityPoolTokens(ctx)
 
 		// Do transfers for all reward and swapped tokens defined by the trade routes every stride epoch
 		k.TransferAllRewardTokens(ctx)


### PR DESCRIPTION
## Context
This feature spams the relayer with a bunch a queries to the community pool ICA accounts which can brick the relayer on SDK 50 chains during the non-membership proof.

Since this feature was only used by DYDX and is no longer used, we're just disabling it entirely but can re-enable it easily with an upgrade if needed.