### PR TITLE
[DO NOT MERGE] PoA migration rehearsal

### DIFF
--- a/app/upgrades/v33/constants.go
+++ b/app/upgrades/v33/constants.go
@@ -8,9 +8,11 @@ import (
 // UpgradeName is the SDK upgrade plan name. Match the binary release tag.
 const UpgradeName = "v33"
 
-// AdminMultisigAddress is the bech32 address that POA recognizes as its admin
-// post-upgrade
-const AdminMultisigAddress = "stride1fduug6m38gyuqt3wcgc2kcgr9nnte0n7ssn27e"
+// REHEARSAL ONLY — DO NOT MERGE
+// AdminMultisigAddress points at the integration-tests `admin` account so the
+// rehearsal can drive POA admin behavior with a known signer. The mainnet
+// multisig address lives on the `main` branch.
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
 
 // ExpectedValidatorCount is enforced by the upgrade handler. Panics if
 // consumerKeeper.GetAllCCValidator returns a different count.

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -199,6 +199,14 @@ func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk r
 // Phase 2: Set all validator weights to their target values
 func UpdateValidatorWeights(ctx sdk.Context, sk stakeibckeeper.Keeper) error {
 	for _, chainId := range utils.StringMapKeys(NewValidators) {
+		// Skip rather than error, for the same reason ReconcileOsmosisDelegations does: an error
+		// here fails the upgrade and halts the chain, and non-mainnet environments (dockernet,
+		// testnets, integration-tests) carry none of the mainnet host zones these weights target.
+		if _, found := sk.GetHostZone(ctx, chainId); !found {
+			ctx.Logger().Error(fmt.Sprintf("v33: host zone %s not found, skipping new validators", chainId))
+			continue
+		}
+
 		validators := NewValidators[chainId]
 		ctx.Logger().Info(fmt.Sprintf("Adding %d new validators to %s...", len(validators), chainId))
 		for _, val := range validators {
@@ -215,12 +223,14 @@ func UpdateValidatorWeights(ctx sdk.Context, sk stakeibckeeper.Keeper) error {
 
 	for _, chainId := range utils.StringMapKeys(TargetWeights) {
 		weights := TargetWeights[chainId]
-		ctx.Logger().Info(fmt.Sprintf("Setting validator weights for %s...", chainId))
 
 		hostZone, found := sk.GetHostZone(ctx, chainId)
 		if !found {
-			return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", chainId)
+			ctx.Logger().Error(fmt.Sprintf("v33: host zone %s not found, skipping weight update", chainId))
+			continue
 		}
+
+		ctx.Logger().Info(fmt.Sprintf("Setting validator weights for %s...", chainId))
 
 		weightMap := make(map[string]uint64, len(weights))
 		for _, w := range weights {

--- a/app/upgrades/v33/validators.json
+++ b/app/upgrades/v33/validators.json
@@ -1,10 +1,10 @@
 {
-  "94532a622413b9ef925fb078805f2e4ced675018": "Polkachu",
-  "56b2473d1218a34d8e2c5350abd839a8243f78b1": "L5",
-  "ba3d14838e86271106f1e9210a3cbf40896ab849": "Imperator",
-  "5cb08dcc3b15fffa4e326a1ffbd2ddf02b04e2e7": "Cosmostation",
-  "fe4e54245813c4a53221fb4c8b053d30afc9fb0e": "Keplr",
-  "47a8d36a0b8a7c15e1a3751ad5f1dd12bc90dd6d": "Stakecito",
-  "43c91e4908a233331d1d30512af703962b25c5ee": "Citadel.one",
-  "4b86b55befcad8fcb34959ea2cacc21cd61111e7": "CryptoCrew"
+  "f5d85500835f5a8004ed3396e5a8fbfbe272c973": "Validator1",
+  "deae162a52b136a2f79a9a7c767be2a133b026c7": "Validator2",
+  "adf1e4665afabc9cd2c3541ef0cca31e81ce7f44": "Validator3",
+  "ab7f8434c6599f0c399ab2e6ca906d10db6a1b63": "Validator4",
+  "6dc24282649f5d2d72db21db9c8af5f7dd8e06c7": "Validator5",
+  "9dc4e8f9bad7774c305ddfedc8c4661b9b4f6ad2": "Validator6",
+  "4dbd54765995ff7c168902899148d080e51bc409": "Validator7",
+  "1f84d6ea8d9dfa399bc1f712063c69b0008d8dcc": "Validator8"
 }

--- a/app/upgrades/v33/validators.json.REHEARSAL_ONLY
+++ b/app/upgrades/v33/validators.json.REHEARSAL_ONLY
@@ -1,0 +1,6 @@
+This directory's `validators.json` has been replaced with TEST consensus
+addresses on the `poa-migration-rehearsal` branch. DO NOT MERGE this branch.
+
+If you are reviewing a v33 PR and see this file, the PR is including
+rehearsal artifacts. The mainnet validators.json should map 8 real
+mainnet hex consensus addresses to monikers like "Polkachu", "L5", etc.

--- a/docs/superpowers/plans/2026-04-30-poa-migration-rehearsal.md
+++ b/docs/superpowers/plans/2026-04-30-poa-migration-rehearsal.md
@@ -1,0 +1,1150 @@
+# POA Migration Rehearsal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run a one-time v32 → v33 (ICS → POA) migration rehearsal on the k8s integration-tests network with 8 Stride validators (5 govenators + 3 PSS-only) to validate the migration handler under multi-node consensus.
+
+**Architecture:** Strip integration-tests network down to Stride-only with 8 validators. Pin cons keys offline so they match test-only constants baked into a rehearsal-only fork of `validators.json`, `PoaValidatorSet`, and `AdminMultisigAddress`. Build v32+v33 upgrade image, run, propose upgrade, run 4 post-upgrade verification checks.
+
+**Tech Stack:** Bash scripts, Helm, kubectl, Cosmos SDK CLI (`strided`), Go (test-only edits to v33 source).
+
+**Companion spec:** `docs/superpowers/specs/2026-04-30-poa-migration-rehearsal-design.md`
+
+**Branch:** `poa-migration-rehearsal` — this work is not for merge.
+
+**Expected test breakage on this branch:** `app/upgrades/v33/mainnet_export_test.go` will fail because mainnet state's real cons addresses won't be in our test `validators.json`. This is acceptable — branch is throwaway.
+
+---
+
+## Phase 1: Pre-rehearsal one-time state generation
+
+### Task 1: Write the rehearsal-state generator script
+
+**Files:**
+- Create: `integration-tests/scripts/generate_rehearsal_state.sh`
+
+This script produces all the deterministic inputs we need to bake into both the integration-tests config AND the v33 source. Run once locally; capture its output for use in later tasks.
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/bin/bash
+# generate_rehearsal_state.sh
+# One-time helper for the POA migration rehearsal.
+# Produces: 8 priv_validator_key.json blobs (cons keys), their hex consensus
+# addresses, and operator bech32 addresses derived from each validator
+# mnemonic. Outputs everything to a single JSON document on stdout for the
+# implementer to copy into keys.json, validators.json, and PoaValidatorSet.
+#
+# Requires: strided binary on PATH (any recent version that knows
+# `strided init` and `strided keys`).
+
+set -eu
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+KEYS_FILE="${KEYS_FILE:-integration-tests/network/configs/keys.json}"
+NUM_VALIDATORS=8
+
+# Ensure 8 validator entries exist in keys.json. If only 5 are present today,
+# the script generates 3 fresh mnemonics and prints them so the implementer
+# can append them to keys.json before re-running.
+existing_count=$(jq '.validators | length' "$KEYS_FILE")
+if [[ "$existing_count" -lt "$NUM_VALIDATORS" ]]; then
+    echo "ERROR: keys.json has only $existing_count validators; need $NUM_VALIDATORS." >&2
+    echo "Generating $((NUM_VALIDATORS - existing_count)) fresh mnemonic(s):" >&2
+    for ((i=existing_count+1; i<=NUM_VALIDATORS; i++)); do
+        mnemonic=$(strided keys mnemonic 2>/dev/null)
+        echo "  val${i}: ${mnemonic}" >&2
+    done
+    echo "Append the above to keys.json::validators[] then re-run." >&2
+    exit 1
+fi
+
+# Generate 8 cons keys using `strided init`. We write the priv_validator_key.json
+# verbatim — same shape strided expects on disk.
+declare -a CONS_KEYS_JSON
+declare -a HEX_ADDRS
+
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    home="${WORKDIR}/cons-${i}"
+    strided init "tmp-${i}" --chain-id rehearsal --home "$home" >/dev/null 2>&1
+    cons_key=$(cat "${home}/config/priv_validator_key.json")
+    hex_addr=$(jq -r '.address' <<<"$cons_key" | tr 'A-Z' 'a-z')
+
+    CONS_KEYS_JSON[$i]="$cons_key"
+    HEX_ADDRS[$i]="$hex_addr"
+done
+
+# Derive operator bech32 from each validator mnemonic.
+declare -a OPERATORS
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    mnemonic=$(jq -r ".validators[$i].mnemonic" "$KEYS_FILE")
+    name="rehearsal-val-$i"
+    # Use a fresh keyring per loop to avoid name collisions across runs.
+    keyring="${WORKDIR}/keyring-${i}"
+    echo "$mnemonic" | strided keys add "$name" \
+        --recover --keyring-backend test --home "$keyring" >/dev/null 2>&1
+    operator=$(strided keys show "$name" -a \
+        --keyring-backend test --home "$keyring")
+    OPERATORS[$i]="$operator"
+done
+
+# Emit a single JSON document the implementer can paste into the relevant files.
+jq -n \
+  --argjson cons_keys "$(printf '%s\n' "${CONS_KEYS_JSON[@]}" | jq -s .)" \
+  --argjson hex_addrs "$(printf '%s\n' "${HEX_ADDRS[@]}" | jq -R . | jq -s .)" \
+  --argjson operators "$(printf '%s\n' "${OPERATORS[@]}" | jq -R . | jq -s .)" \
+  '{
+     cons_keys: $cons_keys,
+     hex_addrs: $hex_addrs,
+     operators: $operators
+   }'
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x integration-tests/scripts/generate_rehearsal_state.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/scripts/generate_rehearsal_state.sh
+git commit -m "feat(rehearsal): add cons-key/operator generator script"
+```
+
+---
+
+### Task 2: Add 3 new validator mnemonics to keys.json
+
+**Files:**
+- Modify: `integration-tests/network/configs/keys.json` (append val6, val7, val8 entries)
+
+The generator script above will fail with a clear message and print 3 fresh mnemonics to copy in. This task captures the result.
+
+- [ ] **Step 1: Run the generator (it will fail)**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+bash integration-tests/scripts/generate_rehearsal_state.sh
+```
+
+Expected: exits with `ERROR: keys.json has only 5 validators` plus 3 mnemonics on stderr.
+
+- [ ] **Step 2: Append val6, val7, val8 entries to keys.json**
+
+The existing `validators` array in `integration-tests/network/configs/keys.json` has 5 entries. Add 3 more, using the mnemonics from Step 1's stderr output:
+
+```json
+{
+  "name": "val6",
+  "mnemonic": "<mnemonic 1 from generator output>"
+},
+{
+  "name": "val7",
+  "mnemonic": "<mnemonic 2 from generator output>"
+},
+{
+  "name": "val8",
+  "mnemonic": "<mnemonic 3 from generator output>"
+}
+```
+
+- [ ] **Step 3: Verify keys.json parses and has 8 entries**
+
+```bash
+jq '.validators | length' integration-tests/network/configs/keys.json
+```
+
+Expected: `8`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration-tests/network/configs/keys.json
+git commit -m "feat(rehearsal): add val6-val8 mnemonics for 8-validator rehearsal"
+```
+
+---
+
+### Task 3: Run generator and capture cons keys + addresses
+
+**Files:**
+- Modify: `integration-tests/network/configs/keys.json` (add `cons_keys` array)
+
+- [ ] **Step 1: Run the generator and save output**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+bash integration-tests/scripts/generate_rehearsal_state.sh \
+    > /tmp/rehearsal-state.json
+```
+
+Expected: exits 0; file is valid JSON with `cons_keys` (array of 8 objects), `hex_addrs` (array of 8 hex strings), `operators` (array of 8 stride1... bech32s).
+
+- [ ] **Step 2: Verify output shape**
+
+```bash
+jq '.cons_keys | length, .hex_addrs | length, .operators | length' /tmp/rehearsal-state.json
+```
+
+Expected: three lines, each `8`.
+
+- [ ] **Step 3: Inject `cons_keys` into keys.json**
+
+```bash
+jq --slurpfile s /tmp/rehearsal-state.json \
+   '. + {cons_keys: $s[0].cons_keys}' \
+   integration-tests/network/configs/keys.json \
+   > /tmp/keys.json && \
+mv /tmp/keys.json integration-tests/network/configs/keys.json
+```
+
+- [ ] **Step 4: Verify keys.json has cons_keys array**
+
+```bash
+jq '.cons_keys | length' integration-tests/network/configs/keys.json
+```
+
+Expected: `8`.
+
+- [ ] **Step 5: Save the hex_addrs and operators arrays for later tasks**
+
+Keep `/tmp/rehearsal-state.json` around — Tasks 10 and 11 will read `hex_addrs` and `operators` from it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add integration-tests/network/configs/keys.json
+git commit -m "feat(rehearsal): pin 8 cons keys in keys.json"
+```
+
+---
+
+## Phase 2: Integration-tests config updates
+
+### Task 4: Strip cosmoshub and osmosis from values.yaml
+
+**Files:**
+- Modify: `integration-tests/network/values.yaml`
+
+- [ ] **Step 1: Replace values.yaml contents**
+
+```yaml
+namespace: integration
+
+images:
+  chains: gcr.io/stride-nodes/integration-tests/chains
+  relayer: gcr.io/stride-nodes/integration-tests/relayer:v2.5.2
+  hermes: gcr.io/stride-nodes/integration-tests/hermes:v1.9.0
+
+activeChains:
+  - stride
+
+# No relayers — Stride is the only chain in this rehearsal network.
+relayers: []
+
+chainConfigs:
+  stride:
+    binary: strided
+    version: latest
+    numValidators: 8
+    home: .stride
+    denom: ustrd
+    decimals: 6
+```
+
+- [ ] **Step 2: Lint helm chart**
+
+```bash
+cd integration-tests && make lint
+```
+
+Expected: `1 chart(s) linted, 0 chart(s) failed`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/values.yaml
+git commit -m "feat(rehearsal): trim values.yaml to stride-only with 8 validators"
+```
+
+---
+
+### Task 5: Pin cons keys in init-chain.sh
+
+**Files:**
+- Modify: `integration-tests/network/scripts/init-chain.sh`
+
+The `add_validators` function (lines ~62-96 of init-chain.sh) currently calls `binaryd init` for each validator (which generates a fresh `priv_validator_key.json`). We want to overwrite that file with the pinned cons key from `keys.json::cons_keys[i-1]` BEFORE the pubkey is read for `add-consumer-section`.
+
+- [ ] **Step 1: Modify the validator loop in `add_validators()`**
+
+In `init-chain.sh`, find the `add_validators()` function. Inside the `for (( i=1; i <= $NUM_VALIDATORS; i++ ))` loop, after the `if [[ "$i" == "1" ]]; then validator_home=${CHAIN_HOME} else ... $BINARY init ... fi` block, add this just before the `# Save the node IDs and keys to the API` comment:
+
+```bash
+# Overwrite the auto-generated cons key with the pinned rehearsal cons key.
+# The index in cons_keys is i-1 (jq is 0-indexed; the loop is 1-indexed).
+cons_key_index=$((i - 1))
+jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+    > ${validator_home}/config/priv_validator_key.json
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/init-chain.sh
+```
+
+Expected: no output (exit 0).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/init-chain.sh
+git commit -m "feat(rehearsal): pin cons keys in init-chain.sh"
+```
+
+---
+
+### Task 6: Pin cons keys in init-node.sh
+
+**Files:**
+- Modify: `integration-tests/network/scripts/init-node.sh`
+
+Each non-main validator pod runs `init-node.sh` which downloads its `priv_validator_key.json` from the API (originally uploaded by pod 0). With Task 5's change, that uploaded file is already the pinned cons key — but we add a belt-and-suspenders overwrite for self-containment.
+
+- [ ] **Step 1: Add overwrite to `update_config()`**
+
+In `init-node.sh::update_config()`, after the line:
+
+```bash
+download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json 
+```
+
+Add:
+
+```bash
+# Belt-and-suspenders: ensure the downloaded cons key matches the pinned one
+# from keys.json. This makes the script self-contained even if pod 0's
+# pinning step ever regresses.
+cons_key_index=$((VALIDATOR_INDEX - 1))
+jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+    > ${CHAIN_HOME}/config/priv_validator_key.json
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/init-node.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/init-node.sh
+git commit -m "feat(rehearsal): pin cons keys in init-node.sh"
+```
+
+---
+
+### Task 7: Skip govenator registration on pods 5-7
+
+**Files:**
+- Modify: `integration-tests/network/scripts/create-validator.sh`
+
+- [ ] **Step 1: Add the skip guard**
+
+`create-validator.sh` already sources `scripts/config.sh` which sets
+`POD_INDEX=${HOSTNAME##*-}`. Replace the existing `main()` function with:
+
+```bash
+main() {
+    # PSS-only validators: pods with index >= 5 do NOT register as govenators.
+    # This mirrors the mainnet shape where ~3 of 8 PSS validators have
+    # ICS-key-assigned consensus keys not in x/staking, exercising the
+    # distrwrapper stake-iteration path post-upgrade.
+    if [[ "$POD_INDEX" -ge 5 ]]; then
+        echo "Skipping govenator registration for PSS-only validator (pod $POD_INDEX)"
+        exit 0
+    fi
+
+    echo "Adding validator..."
+    wait_for_startup
+    add_keys
+    create_validator
+    echo "Done"
+}
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/create-validator.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/create-validator.sh
+git commit -m "feat(rehearsal): skip govenator registration on pods 5-7"
+```
+
+---
+
+### Task 8: Vote from val1-val5 in upgrade.sh
+
+**Files:**
+- Modify: `integration-tests/network/scripts/upgrade.sh`
+
+Currently `upgrade.sh` hardcodes `STRIDED0`, `STRIDED1`, `STRIDED2` and votes from val1, val2, val3. With 5 govenators we want votes from val1–val5.
+
+- [ ] **Step 1: Replace upgrade.sh in full**
+
+Replace the entire contents of `integration-tests/network/scripts/upgrade.sh` with:
+
+```bash
+#!/bin/bash
+
+# NOTE: This script should be run locally (outside of the k8s pod)
+
+set -eu
+
+NAMESPACE=integration
+UPGRADE_BUFFER=45 # blocks
+
+# Helper to invoke strided in a specific validator pod.
+strided_in() {
+    pod_index="$1"; shift
+    kubectl exec -it stride-validator-$pod_index -c validator -n $NAMESPACE -- strided "$@"
+}
+
+trim_tx() {
+    grep -E "code:|txhash:" | sed 's/^[[:space:]]*//'
+}
+
+upgrade_name=$(kubectl exec stride-validator-0 -c validator -n $NAMESPACE -- printenv UPGRADE_NAME)
+latest_height=$(strided_in 0 status | jq -r 'if .SyncInfo then .SyncInfo.latest_block_height else .sync_info.latest_block_height end')
+upgrade_height=$((latest_height+UPGRADE_BUFFER))
+
+echo -e "\nSubmitting proposal for $upgrade_name at height $upgrade_height...\n"
+kubectl exec -it stride-validator-0 -c validator -n $NAMESPACE -- \
+    bash scripts/propose_upgrade.sh $upgrade_name $upgrade_height | trim_tx
+
+sleep 5
+echo -e "\nProposal:\n"
+proposal_id=$(strided_in 0 q gov proposals --output json | jq -r '.proposals | max_by(.id | tonumber).id')
+strided_in 0 query gov proposal $proposal_id
+
+sleep 1
+echo -e "\nVoting on proposal #$proposal_id...\n"
+for i in 0 1 2 3 4; do
+    val_name="val$((i + 1))"
+    echo "${val_name}:"
+    strided_in "$i" tx gov vote $proposal_id yes --from "$val_name" -y | trim_tx
+done
+
+sleep 5
+echo -e "\nVote confirmation:\n"
+strided_in 0 query gov tally $proposal_id
+
+echo -e "\nProposal Status:\n"
+while true; do
+    status=$(strided_in 0 query gov proposal $proposal_id --output json | jq -r '.proposal.status')
+    if [[ "$status" == "PROPOSAL_STATUS_VOTING_PERIOD" ]]; then
+        echo "Proposal still in progress..."
+        sleep 5
+    elif [[ "$status" == "PROPOSAL_STATUS_PASSED" ]]; then
+        echo "Proposal passed!"
+        exit 0
+    elif [[ "$status" == "PROPOSAL_STATUS_REJECTED" ]]; then
+        echo "Proposal Failed!"
+        exit 1
+    else
+        echo "Unknown proposal status: $status"
+        exit 1
+    fi
+done
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/upgrade.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/upgrade.sh
+git commit -m "feat(rehearsal): vote from val1-val5 in upgrade.sh"
+```
+
+---
+
+## Phase 3: Smoke test v32 spinup
+
+### Task 9: Build the upgrade image and verify v32 startup
+
+This task validates Phase 2's config edits before we touch v33 source. Build the upgrade image (which contains both v32 and v33 binaries — the v33 here is whatever the branch currently has, with mainnet `validators.json`/`PoaValidatorSet`/`AdminMultisigAddress` still intact). Cosmovisor will boot from v32 and never trigger the upgrade since we won't propose it. We just verify the v32 startup phase works against our edited config.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Verify clean working tree**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+git status --short
+```
+
+Expected: empty output. The upgrade build script does `git checkout v32.0.0` internally and refuses to run if there are uncommitted changes.
+
+- [ ] **Step 2: Build the upgrade image**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride/integration-tests
+UPGRADE_OLD_VERSION=v32.0.0 make build-stride-upgrade
+```
+
+Expected: build succeeds, image pushed to `gcr.io/stride-nodes/integration-tests/chains/stride:latest`.
+
+- [ ] **Step 2: Spin up the network**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride/integration-tests
+make start
+```
+
+Expected: helm install completes, `make wait-for-startup` exits 0 once all 8 stride pods are ready.
+
+- [ ] **Step 3: Verify 8 cons validators present**
+
+```bash
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q ccvconsumer all-cc-validators --output json \
+    | jq '. | length'
+```
+
+Expected: `8`.
+
+- [ ] **Step 4: Verify cons hex addresses match the pinned values**
+
+```bash
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q ccvconsumer all-cc-validators --output json \
+    | jq -r '.[].address' | sort \
+> /tmp/onchain-hex-addrs.txt
+
+jq -r '.hex_addrs[]' /tmp/rehearsal-state.json | sort \
+> /tmp/expected-hex-addrs.txt
+
+diff /tmp/onchain-hex-addrs.txt /tmp/expected-hex-addrs.txt
+```
+
+Expected: no diff (both lists identical, sorted).
+
+- [ ] **Step 5: Verify exactly 5 govenators**
+
+```bash
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q staking validators --output json \
+    | jq '.validators | length'
+```
+
+Expected: `5`.
+
+- [ ] **Step 6: Verify all 8 pods are signing blocks**
+
+```bash
+for i in $(seq 0 7); do
+  kubectl exec -n integration stride-validator-$i -c validator -- \
+    strided status | jq -r '.sync_info.latest_block_height // .SyncInfo.latest_block_height'
+done
+```
+
+Expected: all 8 print non-zero heights, growing.
+
+- [ ] **Step 7: Tear down**
+
+```bash
+make stop
+```
+
+If any step above fails, **stop and debug** before proceeding to Phase 4. Fixing config issues with v33 source already edited is much harder than fixing them now.
+
+---
+
+## Phase 4: v33 source-tree rehearsal-only edits
+
+### Task 10: Replace validators.json with test cons addresses
+
+**Files:**
+- Modify: `app/upgrades/v33/validators.json` (full replacement)
+- Create: `app/upgrades/v33/validators.json.REHEARSAL_ONLY` (sidecar marker)
+
+- [ ] **Step 1: Generate the new validators.json**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+jq -r '
+  .hex_addrs as $h
+  | reduce range(0; ($h | length)) as $i ({};
+      . + { ($h[$i]): "Validator\($i + 1)" })
+' /tmp/rehearsal-state.json \
+> app/upgrades/v33/validators.json
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+jq '. | length' app/upgrades/v33/validators.json
+```
+
+Expected: `8`.
+
+```bash
+jq -r 'to_entries | .[].value' app/upgrades/v33/validators.json | sort
+```
+
+Expected: `Validator1` through `Validator8`, one per line.
+
+- [ ] **Step 3: Create the sidecar marker file**
+
+`validators.json` cannot carry a comment. The marker file is a tripwire for anyone reading the directory.
+
+```bash
+cat > app/upgrades/v33/validators.json.REHEARSAL_ONLY <<'EOF'
+This directory's `validators.json` has been replaced with TEST consensus
+addresses on the `poa-migration-rehearsal` branch. DO NOT MERGE this branch.
+
+If you are reviewing a v33 PR and see this file, the PR is including
+rehearsal artifacts. The mainnet validators.json should map 8 real
+mainnet hex consensus addresses to monikers like "Polkachu", "L5", etc.
+EOF
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/upgrades/v33/validators.json app/upgrades/v33/validators.json.REHEARSAL_ONLY
+git commit -m "rehearsal: replace v33/validators.json with test cons addresses
+
+REHEARSAL ONLY -- DO NOT MERGE. Required for the test validator set to
+pass the v33 handler's moniker join."
+```
+
+---
+
+### Task 11: Replace utils/poa.go PoaValidatorSet
+
+**Files:**
+- Modify: `utils/poa.go`
+
+- [ ] **Step 1: Read the current operators array from /tmp**
+
+```bash
+jq -r '.operators[]' /tmp/rehearsal-state.json
+```
+
+Capture the 8 stride1... addresses (one per line).
+
+- [ ] **Step 2: Replace utils/poa.go**
+
+Replace the entire contents of `utils/poa.go` with:
+
+```go
+// REHEARSAL ONLY — DO NOT MERGE
+// PoaValidatorSet has been replaced with test operator addresses generated
+// from the rehearsal validator mnemonics in
+// integration-tests/network/configs/keys.json. The mainnet set lives on the
+// `main` branch.
+
+package utils
+
+import sdkmath "cosmossdk.io/math"
+
+// WARNING: DO NOT MODIFY
+
+// Validators are paid 15% of revenue
+var PoaValPaymentRate = sdkmath.LegacyMustNewDecFromStr("0.15")
+
+type PoaValidator struct {
+	Moniker    string
+	Operator   string // sdk.AccAddress bech32 — the payout + POA OperatorAddress
+	HubAddress string
+}
+
+var PoaValidatorSet = []PoaValidator{
+	{Moniker: "Validator1", Operator: "<operator0 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator2", Operator: "<operator1 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator3", Operator: "<operator2 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator4", Operator: "<operator3 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator5", Operator: "<operator4 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator6", Operator: "<operator5 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator7", Operator: "<operator6 from rehearsal-state.json>", HubAddress: ""},
+	{Moniker: "Validator8", Operator: "<operator7 from rehearsal-state.json>", HubAddress: ""},
+}
+```
+
+Substitute the placeholder `<operator0>` ... `<operator7>` with the actual bech32 strings from Step 1.
+
+- [ ] **Step 3: Verify the file builds**
+
+```bash
+go build ./utils/...
+```
+
+Expected: no output (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add utils/poa.go
+git commit -m "rehearsal: replace PoaValidatorSet with test operator addresses
+
+REHEARSAL ONLY -- DO NOT MERGE."
+```
+
+---
+
+### Task 12: Replace AdminMultisigAddress in constants.go
+
+**Files:**
+- Modify: `app/upgrades/v33/constants.go`
+
+- [ ] **Step 1: Edit constants.go**
+
+Find:
+
+```go
+const AdminMultisigAddress = "stride1fduug6m38gyuqt3wcgc2kcgr9nnte0n7ssn27e"
+```
+
+Replace with:
+
+```go
+// REHEARSAL ONLY — DO NOT MERGE
+// AdminMultisigAddress points at the integration-tests `admin` account so the
+// rehearsal can drive POA admin behavior with a known signer. The mainnet
+// multisig address lives on the `main` branch.
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
+```
+
+- [ ] **Step 2: Verify the package builds**
+
+```bash
+go build ./app/upgrades/v33/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/upgrades/v33/constants.go
+git commit -m "rehearsal: point AdminMultisigAddress at integration-tests admin
+
+REHEARSAL ONLY -- DO NOT MERGE."
+```
+
+---
+
+## Phase 5: Build and run upgrade
+
+### Task 13: Build the v32+v33 upgrade image
+
+**Files:** none modified.
+
+`network/scripts/build.sh` requires a clean working tree (it does `git checkout v32.0.0` to build the old binary). All rehearsal commits from Phases 1-4 must already be committed before running this.
+
+The same script tags the upgrade image as `chains/stride:latest` — same tag the non-upgrade build uses — so no `values.yaml` adjustment is needed.
+
+- [ ] **Step 1: Verify clean working tree**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+git status --short
+```
+
+Expected: empty output (no uncommitted changes).
+
+- [ ] **Step 2: Build the upgrade image**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride/integration-tests
+UPGRADE_OLD_VERSION=v32.0.0 make build-stride-upgrade
+```
+
+Expected: build completes, image pushed to GCR as `gcr.io/stride-nodes/integration-tests/chains/stride:latest`. The image contains v32 at `cosmovisor/genesis/bin/strided` and v33 (built from this branch with all rehearsal edits) at `cosmovisor/upgrades/v33/bin/strided`. The build script auto-detects `v33` as the upgrade name from `ls app/upgrades | sort -V | tail -1`.
+
+- [ ] **Step 3: Verify both binaries are in the local image**
+
+```bash
+docker run --rm core:stride-upgrade-old strided version
+docker run --rm core:stride strided version
+```
+
+Expected: first prints `v32.0.0` (or close); second prints a version string from the current branch.
+
+---
+
+### Task 14: Spin up network on v32 and trigger upgrade
+
+**Files:** none modified.
+
+- [ ] **Step 1: Spin up the network**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride/integration-tests
+make start
+```
+
+Expected: helm install completes; `make wait-for-startup` exits 0.
+
+- [ ] **Step 2: Re-run the Task 9 sanity checks**
+
+```bash
+# 8 cons validators
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q ccvconsumer all-cc-validators --output json | jq '. | length'
+# Expected: 8
+
+# 5 govenators
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q staking validators --output json | jq '.validators | length'
+# Expected: 5
+```
+
+- [ ] **Step 3: Snapshot pre-upgrade state**
+
+```bash
+# Pre-upgrade validator hash from a recent block
+PRE_HEIGHT=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided status | jq -r '.sync_info.latest_block_height // .SyncInfo.latest_block_height')
+PRE_HASH=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q block --type=height $PRE_HEIGHT --output json \
+    | jq -r '.block.header.validators_hash')
+echo "Pre-upgrade height: $PRE_HEIGHT, validators_hash: $PRE_HASH"
+```
+
+Save these values — they're used in Task 15.
+
+- [ ] **Step 4: Submit and pass the upgrade**
+
+```bash
+make upgrade-stride
+```
+
+Expected: prints proposal submission, 5 votes (one per val1-val5), tally output, and `Proposal passed!`.
+
+- [ ] **Step 5: Wait for the upgrade to execute**
+
+The upgrade height is `latest_height + 45` from when the proposal was submitted. Wait for cosmovisor to swap binaries:
+
+```bash
+kubectl logs -n integration stride-validator-0 -c validator -f
+```
+
+Watch for `UPGRADE NEEDED` panic, binary swap, and the chain resuming on v33. Ctrl-C once you see new blocks being signed post-restart.
+
+---
+
+## Phase 6: Post-upgrade tests
+
+### Task 15: Test 1 — block production continues
+
+- [ ] **Step 1: Verify all 8 pods recovered post-upgrade**
+
+```bash
+for i in $(seq 0 7); do
+  height=$(kubectl exec -n integration stride-validator-$i -c validator -- \
+    strided status | jq -r '.sync_info.latest_block_height // .SyncInfo.latest_block_height')
+  echo "validator-$i: $height"
+done
+```
+
+Expected: all 8 print heights well past the upgrade height (and increasing if you re-run).
+
+- [ ] **Step 2: Read the post-upgrade validators_hash**
+
+Pick a height a few blocks past the upgrade height:
+
+```bash
+POST_HEIGHT=<value from Step 1, e.g., upgrade_height + 5>
+POST_HASH=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q block --type=height $POST_HEIGHT --output json \
+    | jq -r '.block.header.validators_hash')
+echo "Post-upgrade height: $POST_HEIGHT, validators_hash: $POST_HASH"
+```
+
+- [ ] **Step 3: Compare to pre-upgrade**
+
+```bash
+echo "Pre:  $PRE_HASH"
+echo "Post: $POST_HASH"
+[[ "$PRE_HASH" == "$POST_HASH" ]] && echo "PASS" || echo "FAIL"
+```
+
+Expected: `PASS`.
+
+If FAIL: chain has shifted validators across the upgrade — the migration is broken. Stop, capture logs, do not proceed.
+
+---
+
+### Task 16: Test 2 — tx fees route to POA
+
+- [ ] **Step 1: Find the POA module account address**
+
+```bash
+POA_ADDR=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q auth module-account poa --output json \
+    | jq -r '.account.value.address // .account.address')
+echo "POA module account: $POA_ADDR"
+```
+
+- [ ] **Step 2: Find the fee_collector module account address**
+
+```bash
+FEE_ADDR=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q auth module-account fee_collector --output json \
+    | jq -r '.account.value.address // .account.address')
+echo "fee_collector: $FEE_ADDR"
+```
+
+- [ ] **Step 3: Snapshot balances**
+
+```bash
+PRE_POA=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $POA_ADDR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+PRE_FEE=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $FEE_ADDR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "Pre-tx — POA: $PRE_POA, fee_collector: $PRE_FEE"
+```
+
+- [ ] **Step 4: Submit a tx with non-zero fees**
+
+```bash
+ADMIN_ADDR=stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8
+FAUCET_ADDR=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided keys show faucet -a)
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided tx bank send $FAUCET_ADDR $ADMIN_ADDR 100ustrd \
+    --fees 5000ustrd --from faucet -y
+```
+
+- [ ] **Step 5: Wait one block, snapshot again**
+
+```bash
+sleep 6
+POST_POA=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $POA_ADDR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "Post-tx — POA: $POST_POA (was $PRE_POA, +$((POST_POA - PRE_POA)))"
+```
+
+Expected: `POST_POA - PRE_POA == 5000` (or close to it, accounting for any inflation that landed in the same block — the *delta* should at minimum include the 5000 fee).
+
+If POA went up by ≥5000: PASS — fees routed to POA. If POA is unchanged and `fee_collector` went up by 5000: FAIL — ante handler change didn't take effect.
+
+---
+
+### Task 17: Test 3 — govenator rewards accrue and withdraw
+
+- [ ] **Step 1: Pick a delegator (val1's self-delegation)**
+
+```bash
+DELEGATOR=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided keys show val1 -a)
+VALIDATOR=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q staking validators --output json \
+    | jq -r '.validators[0].operator_address')
+echo "Delegator: $DELEGATOR, Validator: $VALIDATOR"
+```
+
+- [ ] **Step 2: Pre-baseline rewards**
+
+```bash
+PRE_REWARDS=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q distribution rewards $DELEGATOR --output json \
+    | jq -r '.total[] | select(.denom=="ustrd").amount // "0"')
+echo "Pre-baseline rewards: $PRE_REWARDS"
+```
+
+- [ ] **Step 3: Wait 10–20 blocks**
+
+```bash
+sleep 60
+```
+
+- [ ] **Step 4: Post-baseline rewards**
+
+```bash
+POST_REWARDS=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q distribution rewards $DELEGATOR --output json \
+    | jq -r '.total[] | select(.denom=="ustrd").amount // "0"')
+echo "Post-baseline rewards: $POST_REWARDS"
+```
+
+Expected: `POST_REWARDS > PRE_REWARDS` (strict increase). If equal: distribution isn't allocating — distrwrapper bug.
+
+- [ ] **Step 5: Snapshot delegator bank balance**
+
+```bash
+PRE_BAL=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $DELEGATOR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "Pre-withdraw balance: $PRE_BAL"
+```
+
+- [ ] **Step 6: Withdraw rewards**
+
+```bash
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided tx distribution withdraw-rewards $VALIDATOR \
+    --fees 5000ustrd --from val1 -y
+sleep 6
+```
+
+- [ ] **Step 7: Verify balance increased**
+
+```bash
+POST_BAL=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $DELEGATOR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "Post-withdraw balance: $POST_BAL (delta: $((POST_BAL - PRE_BAL)))"
+```
+
+Expected: `POST_BAL > PRE_BAL - 5000` (i.e., rewards > tx fee). The exact delta should be roughly `POST_REWARDS - 5000`.
+
+---
+
+### Task 18: Test 4 — POA fee distribution via MsgWithdrawFees
+
+- [ ] **Step 1: Confirm POA module account has accumulated balance**
+
+```bash
+POA_BAL=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $POA_ADDR --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "POA balance: $POA_BAL"
+```
+
+If $POA_BAL is small, wait more blocks and re-query — the 15% slice from `distrwrapper` should accumulate steadily.
+
+- [ ] **Step 2: Snapshot val1's operator account balance**
+
+```bash
+VAL1_OP=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided keys show val1 -a)
+PRE_VAL1=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $VAL1_OP --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "val1 pre-withdraw: $PRE_VAL1"
+
+# Cross-check: query the withdrawable amount POA thinks val1 is owed.
+WITHDRAWABLE=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q poa withdrawable-fees $VAL1_OP --output json \
+    | jq -r '.amount[] | select(.denom=="ustrd").amount // "0"')
+echo "val1 withdrawable per POA: $WITHDRAWABLE"
+```
+
+- [ ] **Step 3: Submit MsgWithdrawFees**
+
+```bash
+kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided tx poa withdraw-fees \
+    --fees 5000ustrd --from val1 -y
+sleep 6
+```
+
+`withdraw-fees` takes no positional args — the operator is inferred from the `--from` key (POA CLI: `enterprise/poa@v1.0.0/x/poa/client/cli/tx.go:234-258`).
+
+- [ ] **Step 4: Verify val1 received their 1/8 share**
+
+```bash
+POST_VAL1=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $VAL1_OP --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "val1 post-withdraw: $POST_VAL1 (delta: $((POST_VAL1 - PRE_VAL1)))"
+```
+
+Expected: `delta == WITHDRAWABLE - 5000` (within rounding). The `WITHDRAWABLE` query from Step 2 is the source of truth — POA's lazy checkpoint accounts for fees per validator, so `WITHDRAWABLE` is what you'd literally receive minus the tx fee.
+
+- [ ] **Step 5: Optional — repeat with val6 to test the PSS-only case**
+
+```bash
+VAL6_OP=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided keys show val6 -a)
+PRE_VAL6=$(kubectl exec -n integration stride-validator-0 -c validator -- \
+    strided q bank balances $VAL6_OP --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+
+kubectl exec -n integration stride-validator-5 -c validator -- \
+    strided tx poa withdraw-fees \
+    --fees 5000ustrd --from val6 -y
+sleep 6
+
+POST_VAL6=$(kubectl exec -n integration stride-validator-5 -c validator -- \
+    strided q bank balances $VAL6_OP --output json \
+    | jq -r '.balances[] | select(.denom=="ustrd").amount // "0"')
+echo "val6 post-withdraw: $POST_VAL6 (delta: $((POST_VAL6 - PRE_VAL6)))"
+```
+
+Expected: delta > 0. This confirms POA pays out to validators that have no x/staking record — the load-bearing case for the 5/3 split.
+
+Note: val6 needs ustrd in its account to pay the tx fee. If `PRE_VAL6` is 0, fund it first via `strided tx bank send` from the faucet.
+
+---
+
+### Task 19: Tear down and document
+
+**Files:** none modified (or commit a brief rehearsal-results notes file if you like).
+
+- [ ] **Step 1: Tear down the network**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride/integration-tests
+make stop
+```
+
+- [ ] **Step 2: Capture results**
+
+In whatever channel makes sense (Slack, internal doc, etc.), report:
+
+- Did Test 1 PASS? (block production / validators_hash unchanged)
+- Did Test 2 PASS? (tx fees → POA, not fee_collector)
+- Did Test 3 PASS? (govenator rewards accrue + withdraw)
+- Did Test 4 PASS? (POA `MsgWithdrawFees` paid val1 ~ 1/8 of POA balance; val6 also paid)
+- Any unexpected log lines, panics, or warnings during the upgrade
+- Wall-clock time of the upgrade (proposal pass → first post-upgrade block)
+
+If all 4 pass, the v33 migration handler is validated under multi-node consensus. Mark the rehearsal complete.
+
+---
+
+## Notes for the implementer
+
+**Branch hygiene:** Every commit on this branch should land on `poa-migration-rehearsal` and never on `main`. Before pushing, double-check `git branch --show-current`.
+
+**Expected unit-test failure:** `app/upgrades/v33/mainnet_export_test.go` will fail when run against the rehearsal-edited `validators.json` (real mainnet cons addresses won't be in our test map). This is acceptable on this branch.
+
+**If the helm install hangs:** check `kubectl get pods -n integration` and `kubectl describe pod stride-validator-0 -n integration`. Most common cause on first-time spinup with 8 vals: cluster resource quota exhausted. Mitigation: drop `cpu`/`memory` requests in `network/templates/validator.yaml` lines 107-113 from `600m`/`700M` to `400m`/`500M`.
+
+**If the upgrade fails at the upgrade height:** capture full logs from all 8 pods (`for i in $(seq 0 7); do kubectl logs -n integration stride-validator-$i -c validator > /tmp/val-$i.log; done`). The most likely failure modes:
+
+- "validator X has no moniker in v33 validators.json" — pinning didn't take effect; check Tasks 5/6 outcomes.
+- "expected 8 validators in consumer keeper, got N" — `add-consumer-section` didn't get all 8 pubkeys; check init-chain.sh ran fully.
+- POA InitGenesis panic — likely a pubkey decoding mismatch; verify the cons keys in `keys.json::cons_keys` are valid `priv_validator_key.json` blobs.
+
+**Cleanup if the rehearsal is abandoned:** `git checkout main && git branch -D poa-migration-rehearsal` deletes the branch. Throwaway by design.

--- a/docs/superpowers/specs/2026-04-30-poa-migration-rehearsal-design.md
+++ b/docs/superpowers/specs/2026-04-30-poa-migration-rehearsal-design.md
@@ -1,0 +1,401 @@
+# Stride v33 — POA Migration Rehearsal on k8s Integration-Tests
+
+## §1. Overview and objective
+
+Run a one-time rehearsal of the v32 → v33 (ICS → POA) migration on the k8s
+integration-tests network. The rehearsal validates that the migration handler
+runs cleanly end-to-end under multi-node consensus and produces the expected
+post-upgrade runtime behavior (block production, fee routing, govenator
+rewards, POA payouts).
+
+**This is a throwaway rehearsal.** The branch (`poa-migration-rehearsal`) is
+explicitly not for merge. We intentionally hardcode test-only constants into
+the v33 source to make the binary accept our test validator set, and we strip
+the integration-tests setup down to the minimum needed for the rehearsal.
+
+**Companion spec:** `2026-04-27-ics-to-poa-migration-design.md` (the v33
+migration design itself). This rehearsal exercises that migration; it does
+not modify it. Refer to the migration spec for handler internals and §6
+(testing strategy) which deferred multi-node testing to "a separate, much
+larger workstream" — this rehearsal is that workstream.
+
+**Pre-conditions:**
+
+- v33 implementation is complete on this branch (the migration handler,
+  POA wiring, distrwrapper, ante handler change, store upgrades).
+- v32.0.0 is tagged on the upstream Stride repo (it is).
+- Dev k8s cluster has capacity for ~5 cores and ~6GB allocated to a single
+  helm release.
+
+**Success criteria:**
+
+1. The v32 network spins up with 8 Stride validators producing blocks.
+2. The v33 upgrade proposal passes and cosmovisor swaps binaries cleanly.
+3. Block N+1 (post-upgrade) signs with the same 8 validators as block N.
+   No interruption to block production.
+4. Tx fees submitted post-upgrade land in the POA module account, not in
+   `fee_collector`.
+5. Govenator delegators continue to accrue rewards and can withdraw them.
+6. POA validators can pull their share of accumulated fees via
+   `MsgWithdrawFees` and the resulting balance landings match the
+   expected pro-rata split.
+
+**Non-goals:**
+
+- Testing the LS revenue auction → strdburner pipeline (covered by unit
+  tests; would require adding a host zone — not worth the setup cost).
+- Testing gov proposals spanning the upgrade height (low marginal value
+  over the design doc's Test 2 / Test 3).
+- Testing slashing (POA doesn't slash).
+- Testing the POA admin path (`MsgUpdateValidators`) — upstream POA code,
+  not a Stride concern; admin presence is verified by querying params.
+- Production-grade hygiene on test fixtures (the cons keys we generate are
+  test-only by construction).
+
+## §2. Network shape
+
+```
+                 ┌──────────────────────────┐
+                 │  Stride (8 validators)   │
+                 │  - chain-id: STRIDE      │
+                 │  - bootstrap: ICS via    │
+                 │    add-consumer-section  │
+                 │  - 5 govenators (vals    │
+                 │    0–4); vals 5–7 are    │
+                 │    PSS-only              │
+                 │  - v32 → v33 upgrade     │
+                 └──────────────────────────┘
+```
+
+No Hub, no relayers, no host zones. Per the ICS provider investigation
+(see brainstorm history): a fixed 8-validator opt-in PSS allowlist with no
+rotations / slashes / opt-in events generates **zero** provider→consumer
+IBC packets. The `add-consumer-section` genesis-injection shortcut produces
+observably identical consumer keeper state to a real Hub provider for our
+scenario. The migration handler reads consumer keeper state, not IBC
+channel state, so the shortcut is sufficient.
+
+The 5/3 govenator split mirrors the mainnet shape where ~3 of 8 PSS
+validators have ICS-key-assigned consensus keys not in `x/staking`. This
+exercises the `app/distrwrapper` stake-iteration path under multi-node
+consensus — the exact case that exists to prevent a chain halt at every
+BeginBlock post-migration.
+
+## §3. Cons-key pinning and validator setup
+
+The v33 handler enforces strict joins across two compile-time maps
+(`app/upgrades/v33/validators.json` and `utils/poa.go::PoaValidatorSet`).
+Any consensus address in `ccvconsumer` that lacks a moniker entry, or any
+moniker that lacks an operator entry, halts the upgrade. Test validators
+generated fresh by `binaryd init` would not match the mainnet hex addresses
+baked into `validators.json`, so we pin the cons keys.
+
+**Approach:**
+
+1. Pre-generate 8 cons keys offline. Easiest mechanism: run `strided init
+   tmp-N --chain-id rehearsal --home /tmp/cons-N` 8 times (N=0..7) and copy
+   the resulting `/tmp/cons-N/config/priv_validator_key.json` for each.
+   (CometBFT `gen-validator` would also work but the `init` path is
+   guaranteed to produce the exact JSON shape strided expects.)
+2. Stash the 8 blobs in `network/configs/keys.json` under a new `cons_keys`
+   array (indexed 0–7, matching pod indices).
+3. Modify `init-chain.sh` and `init-node.sh` to overwrite the
+   auto-generated `priv_validator_key.json` with the pre-generated blob
+   for the corresponding pod index, *before* any chain initialization that
+   binds to the cons key.
+4. Compute the hex address for each pinned cons key. These are the values
+   we bake into the rehearsal-specific `validators.json`.
+
+**Validator role split:**
+
+- Pods 0–4 (val1–val5): both PSS validators (cons key in `ccvconsumer`)
+  and govenators (registered via `tx staking create-validator`).
+- Pods 5–7 (val6–val8): PSS validators only. `create-validator.sh` skips
+  these via a `[[ "$POD_INDEX" -ge 5 ]] && exit 0` guard at the top.
+
+## §4. Source-tree edits on this branch
+
+All three edits live on `poa-migration-rehearsal` and are explicitly never
+merged. Each modified source file gets a top-of-file comment:
+
+```
+// REHEARSAL ONLY — DO NOT MERGE
+```
+
+**`app/upgrades/v33/validators.json`** — replace the 8 mainnet entries
+with the 8 hex addresses derived from the pinned cons keys. Monikers can
+be `Validator1`–`Validator8`:
+
+```json
+{
+  "<hex_addr_pod0>": "Validator1",
+  "<hex_addr_pod1>": "Validator2",
+  ...
+  "<hex_addr_pod7>": "Validator8"
+}
+```
+
+**`utils/poa.go::PoaValidatorSet`** — replace the 8 mainnet entries with
+8 monikers → operator bech32s. Operator bech32s are derived from each
+validator's mnemonic in `keys.json` (the `stride1...` account — *not* a
+`stridevaloper1...` address; per the existing `PoaValidatorSet` shape,
+`Operator` is an `sdk.AccAddress` bech32). `HubAddress` is unused in the
+rehearsal path; leave it empty:
+
+```go
+var PoaValidatorSet = []PoaValidator{
+    {Moniker: "Validator1", Operator: "stride1...", HubAddress: ""},
+    ...
+    {Moniker: "Validator8", Operator: "stride1...", HubAddress: ""},
+}
+```
+
+**`app/upgrades/v33/constants.go::AdminMultisigAddress`** — replace
+the mainnet multisig address with the existing `admin` account from
+`keys.json`:
+
+```go
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
+```
+
+These three edits make the v33 binary accept the test validator set as
+its migration input. They are simultaneously the reason this branch must
+never be merged: shipping any of them to mainnet would point the upgrade
+handler at fictional validators with a test admin.
+
+## §5. Integration-tests edits
+
+**`integration-tests/network/values.yaml`:**
+
+- Drop `cosmoshub` and `osmosis` from `activeChains`.
+- Drop both relayer entries (`stride-cosmoshub` and `stride-osmosis`,
+  both relayer and hermes types).
+- Bump `chainConfigs.stride.numValidators: 3 → 8`.
+- Optionally trim `chainConfigs` to remove unused `cosmoshub` and
+  `osmosis` blocks.
+
+**`integration-tests/network/configs/keys.json`:**
+
+- Add 3 more validator entries (`val6`, `val7`, `val8`) with fresh
+  mnemonics generated via `strided keys add --recover` flow or any
+  bip39 generator. Currently the file has val1–val5.
+- Add a top-level `cons_keys` array of 8 entries, each containing the
+  full `priv_validator_key.json` blob produced by
+  `strided tendermint gen-validator`.
+
+**`integration-tests/network/scripts/init-chain.sh`:**
+
+- After `binaryd init` runs (which generates `priv_validator_key.json`
+  in `${validator_home}/config/`), overwrite that file with the cons
+  key from `keys.json` for the matching pod index. The function loops
+  `i = 1..NUM_VALIDATORS`, so the cons-key index is `i-1`.
+- The validator pubkeys collected for `add-consumer-section` should
+  now reflect the pinned cons keys (since they're read from the
+  overwritten `priv_validator_key.json`).
+
+**`integration-tests/network/scripts/init-node.sh`:**
+
+- After `download_shared_file ... priv_validator_key.json`, additionally
+  overwrite with the pinned cons key for `VALIDATOR_INDEX`. (The shared
+  file already comes from the main node which had its key pinned; this
+  is belt-and-suspenders to make the script self-contained if the
+  pinning logic ever runs only on the main node.)
+
+**`integration-tests/network/scripts/create-validator.sh`:**
+
+- At the top of `main()` (after `wait_for_startup`), guard:
+  ```bash
+  POD_INDEX=${HOSTNAME##*-}
+  if [[ "$POD_INDEX" -ge 5 ]]; then
+      echo "Skipping govenator registration for PSS-only validator (pod $POD_INDEX)"
+      exit 0
+  fi
+  ```
+- Pods 5–7 thus boot with cons keys in `ccvconsumer` but no x/staking
+  record.
+
+**`integration-tests/network/scripts/upgrade.sh`:**
+
+- Currently votes from val1–val3 hardcoded. Extend to vote from
+  val1–val5. Vals 6–8 are not govenators and have no STRD to vote
+  with.
+
+## §6. Build and execution flow
+
+**Build the upgrade image:**
+
+```bash
+cd integration-tests
+UPGRADE_OLD_VERSION=v32.0.0 make build-stride-upgrade
+```
+
+This builds a single image containing both binaries (v32 from upstream
+tag, v33 from this branch) and configures cosmovisor to swap at the
+upgrade height. Per `Dockerfile.stride-upgrade`, the v32 binary lives at
+`cosmovisor/genesis/bin/strided` and the v33 binary at
+`cosmovisor/upgrades/v33/bin/strided`.
+
+**Spin up the network:**
+
+```bash
+make start
+```
+
+`helm install` deploys 8 stride validator pods. Each runs `init-chain.sh`
+(pod 0 only) and `init-node.sh` in `initContainer`, then starts cosmovisor
+with the v32 binary. Pods 0–4 run `create-validator.sh` as `postStart`;
+pods 5–7 skip it.
+
+**Verify pre-upgrade state** (before triggering the upgrade):
+
+- `kubectl exec stride-validator-0 -- strided q ccvconsumer all-cc-validators`
+  returns 8 entries.
+- `kubectl exec stride-validator-0 -- strided q staking validators`
+  returns 5 entries.
+- All 8 pods are signing blocks (check `strided status` from each).
+- Snapshot: validator hash, govenator delegation totals, govenator
+  operator account balances.
+
+**Trigger the upgrade:**
+
+```bash
+make upgrade-stride
+```
+
+Submits the v33 software-upgrade proposal at `latest_height + 45`,
+votes from val1–val5, polls until passed. Cosmovisor swaps binaries at
+the upgrade height; pods restart with v33.
+
+## §7. Test sequence
+
+All four tests run after the upgrade has executed (cosmovisor swap
+complete, network is back to producing blocks on v33).
+
+### Test 1 — block production continues
+
+The load-bearing assertion. The validator hash post-upgrade must equal
+the validator hash pre-upgrade.
+
+- Read the validator hash at the upgrade height from any validator's
+  block header (`strided q block --type=height <upgrade_height>` or via
+  CometBFT RPC).
+- Read the validator hash at upgrade_height + 5.
+- Assert equality.
+- Verify all 8 pods have advanced past upgrade_height + 5 in
+  `strided status`.
+
+If this fails, the chain has halted or the validator set has shifted.
+Recovery is manual; rehearsal halts.
+
+### Test 2 — tx fees route to POA
+
+- Pre-tx: snapshot bank balance on `fee_collector` and on the POA
+  module account address (`strided q auth module-account poa`).
+- Submit a tx (any tx — e.g., a bank send between two of the funded
+  test accounts) with non-zero fees.
+- Wait one block.
+- Post-tx: re-query both balances. The POA account balance should have
+  increased by the tx fee amount; `fee_collector` should be unchanged
+  (or net of any inflation that landed and was then drained by
+  `distrwrapper` in the same block — verify the delta is consistent).
+
+This confirms the ante handler change took effect.
+
+### Test 3 — govenator rewards accrue and are withdrawable
+
+- Pick one of the val1–val5 operator accounts.
+- Pre-baseline: `strided q distribution rewards <delegator>` to capture
+  the current reward total.
+- Wait several blocks (10–20).
+- Post-baseline: re-query. Total should have strictly increased.
+- Submit `tx distribution withdraw-rewards <validator> --from <delegator>`.
+- Verify the delegator's bank balance increased by the withdrawn amount
+  (minus tx fees).
+
+This confirms the `distrwrapper` 85% slice is being allocated correctly
+through the standard `x/distribution` machinery.
+
+### Test 4 — POA fee distribution via MsgWithdrawFees
+
+- Wait for fees to accumulate in the POA module account (test 2's tx +
+  the 15% from `distrwrapper` over several blocks).
+- Pick one validator (e.g., val1) and snapshot their bank balance.
+- Submit `tx poa withdraw-fees --from val1` (exact CLI subcommand TBD
+  during implementation; check the POA module's CLI).
+- Verify val1's bank balance increased by approximately 1/8 of the POA
+  module account balance pre-withdraw.
+- Optionally repeat for val6 (a non-govenator) to confirm POA pays out
+  to validators that have no x/staking record — the load-bearing case
+  for the 5/3 split.
+
+This confirms POA's lazy checkpoint accounting and pays out the actual
+distributable amount.
+
+## §8. Risks specific to the rehearsal
+
+### R1: 8 pods exceed dev cluster capacity
+
+At current pod limits (600m CPU / 700M memory each), 8 stride pods need
+4.8 cores / 5.6GB. Should fit; if not, drop per-pod resources to ~400m /
+500M, or scale to 6 validators (still maintaining a 4/2 split mirror).
+
+### R2: Pinned cons keys leak
+
+The 8 generated cons keys exist only in `network/configs/keys.json` on
+this branch and produce no real-network identity. Hygiene: never copy
+this file into another branch or deployment context.
+
+### R3: Source-tree edits get merged
+
+The three edits in §4 are catastrophic if shipped to mainnet (admin =
+test account, validators = test cons addrs). Mitigations, in order of
+defensive value:
+
+- Each modified source file carries a `// REHEARSAL ONLY — DO NOT MERGE`
+  header comment (or `// REHEARSAL ONLY — DO NOT MERGE` JSON sidecar
+  comment for `validators.json` since JSON has no comments — use a
+  separate `validators.json.REHEARSAL_ONLY` marker file alongside).
+- The branch name (`poa-migration-rehearsal`) signals intent.
+- Reviewer of any v33-related PR should diff against this branch's
+  modified files as a final sanity check before approving:
+  `git diff main..poa-migration-rehearsal -- app/upgrades/v33/validators.json
+  utils/poa.go app/upgrades/v33/constants.go`.
+
+### R4: Pre-upgrade `add-consumer-section` may need adjustment for 8 vals
+
+The current loop in `init-chain.sh::add_validators` iterates
+`NUM_VALIDATORS` and concatenates pubkeys. With `NUM_VALIDATORS=8` this
+should work as-is (the binary accepts a comma-separated list of any
+length). Verify during implementation; trivial fix if not.
+
+### R5: Vals 6–8 have no genesis account funding
+
+`init-chain.sh::add_genesis_account` is called for every validator
+based on `keys.json::validators[*]`, regardless of whether they later
+become a govenator. Pods 5–7 do receive a genesis balance (so their
+operator addresses can later pay tx fees if needed for test 4) — this
+is correct, the guard in `create-validator.sh` only skips the staking
+registration, not the account funding.
+
+## §9. Out of scope
+
+- LS revenue flow testing (no host zone in the rehearsal network).
+- Public testnet rehearsal (no public testnet).
+- Multisig signing rehearsal (operational concern, not v33 correctness).
+- POA admin path (`MsgUpdateValidators`) — upstream POA code, admin
+  presence verified by query.
+- Slashing (POA doesn't slash).
+- Performance benchmarking (small dev cluster, not representative).
+- Recovery rehearsal (if upgrade fails at height N, recovery is manual
+  on the test network — same as mainnet would be, but not what we're
+  testing here).
+
+## §10. Summary
+
+8-validator Stride network on k8s, no Hub, 5/3 govenator/PSS-only split
+to mirror mainnet shape. Pin cons keys offline, bake matching test
+addresses into a rehearsal-only fork of `validators.json`,
+`PoaValidatorSet`, and `AdminMultisigAddress`. Build v32+v33 image,
+spin up, propose-upgrade-vote, run 4 post-upgrade checks: block
+continuity, tx fee routing, govenator reward accrual + withdrawal,
+POA `MsgWithdrawFees` payout. Branch is throwaway.

--- a/integration-tests/dockerfiles/Dockerfile.stride-upgrade
+++ b/integration-tests/dockerfiles/Dockerfile.stride-upgrade
@@ -42,6 +42,18 @@ WORKDIR /home/validator
 
 EXPOSE 26657 26656 1317 9090
 
-RUN echo "mv ${COSMOVISOR_HOME} ${DAEMON_HOME}/cosmovisor && cosmovisor run start --reject-config-defaults" > start.sh
+# The state volume survives container restarts but the image layers do not, so COSMOVISOR_HOME
+# reappears on every start while ${DAEMON_HOME}/cosmovisor persists. Moving unconditionally
+# therefore succeeds only on the first start: afterwards mv nests the source inside the existing
+# destination, and the start after that dies on the collision. That kills the pod at the upgrade
+# height, right when cosmovisor restarts the daemon.
+#
+# Only seed the directory when it is absent. Never delete and re-move it - post-upgrade the
+# `current` symlink points at upgrades/${UPGRADE_NAME}, and replacing the directory would silently
+# roll the node back to the genesis binary.
+RUN printf '%s\n' \
+    '[ -d "${DAEMON_HOME}/cosmovisor" ] || mv ${COSMOVISOR_HOME} ${DAEMON_HOME}/cosmovisor' \
+    'cosmovisor run start --reject-config-defaults' \
+    > start.sh
 
 CMD ["bash", "start.sh" ]

--- a/integration-tests/network/configs/keys.json
+++ b/integration-tests/network/configs/keys.json
@@ -81,5 +81,95 @@
       "name": "user1",
       "mnemonic": "brief play describe burden half aim soccer carbon hope wait output play vacuum joke energy crucial output mimic cruise brother document rail anger leaf"
     }
+  ],
+  "cons_keys": [
+    {
+      "address": "F5D85500835F5A8004ED3396E5A8FBFBE272C973",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "QMRyBecP82ZGFEfknEIjFXDRmMkLbpdMoX5r5stiV+8="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "g0aXN6hAQq1ZGUMm8zvDlW1g7QJ7pK0gSlIFM1yM8llAxHIF5w/zZkYUR+ScQiMVcNGYyQtul0yhfmvmy2JX7w=="
+      }
+    },
+    {
+      "address": "DEAE162A52B136A2F79A9A7C767BE2A133B026C7",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "gCN/4CnO4hx+UvB5bANa3bHfqs98Mz5yiYVfAfb52CU="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "Yod4a9QPEPJeXx2m2ugYENSh4FASbCrSYXE7wQVe+YOAI3/gKc7iHH5S8HlsA1rdsd+qz3wzPnKJhV8B9vnYJQ=="
+      }
+    },
+    {
+      "address": "ADF1E4665AFABC9CD2C3541EF0CCA31E81CE7F44",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "DkCeh9Eu7yaadCXSL19+KYclncEqDc7bjcpdn/v1A5s="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "QvnFHSJmkDh3nGD/1daNxQ7cMEDb0okXHJQd39gADdcOQJ6H0S7vJpp0JdIvX34phyWdwSoNztuNyl2f+/UDmw=="
+      }
+    },
+    {
+      "address": "AB7F8434C6599F0C399AB2E6CA906D10DB6A1B63",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "DKs0MeM7s8fpZ2x8mmFEakmSBLL30a8/wUdkrUoVesw="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "gx4umUos7a6YHAbpZvv3VCvnW/LwPRCGTyyoaabIG0EMqzQx4zuzx+lnbHyaYURqSZIEsvfRrz/BR2StShV6zA=="
+      }
+    },
+    {
+      "address": "6DC24282649F5D2D72DB21DB9C8AF5F7DD8E06C7",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "RCNCOPKtoxE+7b7JM3Zv9PRC7X9zkqgogOEmQ2IL1fA="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "upSyfAg6BoD2xJ/xGKDfUT4RSEJgu+ImGt9Oj1oLcV1EI0I48q2jET7tvskzdm/09ELtf3OSqCiA4SZDYgvV8A=="
+      }
+    },
+    {
+      "address": "9DC4E8F9BAD7774C305DDFEDC8C4661B9B4F6AD2",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "k+GxV06COsWyutG4U4UyI7ecmCn/Vt3NHvAAtqMQybY="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "V8+ztwuq1rdfvmCNt0JaP5/tI5w5srpwb4pJ4hwWpsOT4bFXToI6xbK60bhThTIjt5yYKf9W3c0e8AC2oxDJtg=="
+      }
+    },
+    {
+      "address": "4DBD54765995FF7C168902899148D080E51BC409",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "MFMW3ZZpmwFA7aKJYGIM006qIWMG+PML625IkGxM1js="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "9DHEcrmI4WdVEZ5T30fgawgRfSkOWjB5NMb0D0BBq+4wUxbdlmmbAUDtoolgYgzTTqohYwb48wvrbkiQbEzWOw=="
+      }
+    },
+    {
+      "address": "1F84D6EA8D9DFA399BC1F712063C69B0008D8DCC",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "hdu4gBQ4M7vRw9VDGJgGhj/pepfVPdn7US+IfuRyPYU="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "EYcwM8gQZVi5sZz2nOWrcObJ8OZO0gvscZ2WUCStmO2F27iAFDgzu9HD1UMYmAaGP+l6l9U92ftRL4h+5HI9hQ=="
+      }
+    }
   ]
 }

--- a/integration-tests/network/configs/keys.json
+++ b/integration-tests/network/configs/keys.json
@@ -1,74 +1,85 @@
 {
-    
-    "admin": {
-      "name": "admin",
-      "address": "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8",
-      "mnemonic": "tone cause tribe this switch near host damage idle fragile antique tail soda alien depth write wool they rapid unfold body scan pledge soft"
+  "admin": {
+    "name": "admin",
+    "address": "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8",
+    "mnemonic": "tone cause tribe this switch near host damage idle fragile antique tail soda alien depth write wool they rapid unfold body scan pledge soft"
+  },
+  "faucet": {
+    "name": "faucet",
+    "mnemonic": "chimney become stuff spoil resource supply picture divorce casual curve check web valid survey zebra various pet sphere timber friend faint blame mansion film"
+  },
+  "validators": [
+    {
+      "name": "val1",
+      "mnemonic": "close soup mirror crew erode defy knock trigger gather eyebrow tent farm gym gloom base lemon sleep weekend rich forget diagram hurt prize fly"
     },
-    "faucet": {
-      "name": "faucet",
-      "mnemonic": "chimney become stuff spoil resource supply picture divorce casual curve check web valid survey zebra various pet sphere timber friend faint blame mansion film"
+    {
+      "name": "val2",
+      "mnemonic": "turkey miss hurry unable embark hospital kangaroo nuclear outside term toy fall buffalo book opinion such moral meadow wing olive camp sad metal banner"
     },
-    "validators": [
-      {
-        "name": "val1",
-        "mnemonic": "close soup mirror crew erode defy knock trigger gather eyebrow tent farm gym gloom base lemon sleep weekend rich forget diagram hurt prize fly"
-      },
-      {
-        "name": "val2",
-        "mnemonic": "turkey miss hurry unable embark hospital kangaroo nuclear outside term toy fall buffalo book opinion such moral meadow wing olive camp sad metal banner"
-      },
-      {
-        "name": "val3",
-        "mnemonic": "tenant neck ask season exist hill churn rice convince shock modify evidence armor track army street stay light program harvest now settle feed wheat"
-      },
-      {
-        "name": "val4",
-        "mnemonic": "tail forward era width glory magnet knock shiver cup broken turkey upgrade cigar story agent lake transfer misery sustain fragile parrot also air document"
-      },
-      {
-        "name": "val5",
-        "mnemonic": "crime lumber parrot enforce chimney turtle wing iron scissors jealous indicate peace empty game host protect juice submit motor cause second picture nuclear area"
-      }
-    ],
-    "relayers": [
-      {
-        "name": "rly1",
-        "mnemonic": "fringe secret hair noise royal inform remove release mother fish swamp swim piece later course glimpse sing very clutch velvet prefer hover common mass"
-      },
-      {
-        "name": "rly2",
-        "mnemonic": "floor chicken advance degree paper arch sugar kit torch auction flash fish attitude clay museum treat favorite clinic verify dose safe bright vessel east"
-      },
-      {
-        "name": "rly3",
-        "mnemonic": "belt diet provide fish knee area explain section sword fancy rebel mix fiction urge float chat move device another tourist want tackle drip good"
-      },
-      {
-        "name": "rly4",
-        "mnemonic": "video stereo milk coyote various fantasy attract leaf elevator laundry upper clinic ready recipe wreck asset make before update pitch found board tissue sniff"
-      },
-      {
-        "name": "rly5",
-        "mnemonic": "orient exit remain dance oval jealous spend baby card property struggle thank mean swing extra visit type segment wild exit height climb pause jungle"
-      },
-      {
-        "name": "rly6",
-        "mnemonic": "high awful dog toilet animal mystery zebra magnet style tube art arrow public about system odor split junk second second mixture grab fruit farm"
-      },
-      {
-        "name": "rly7",
-        "mnemonic": "bar clown steak hand dog mango vacant cradle potato axis identify surround give key noise lend must wool error broccoli relax input usage reveal"
-      },
-      {
-        "name": "rly8",
-        "mnemonic": "eagle rapid adapt nasty middle ability width rebel satisfy seminar boss sniff tape artist expose call predict burst hard pig coral item dolphin eagle"
-      }
-    ],
-    "users": [
-      {
-        "name": "user1",
-        "mnemonic": "brief play describe burden half aim soccer carbon hope wait output play vacuum joke energy crucial output mimic cruise brother document rail anger leaf"
-      }
-    ]
-  }
+    {
+      "name": "val3",
+      "mnemonic": "tenant neck ask season exist hill churn rice convince shock modify evidence armor track army street stay light program harvest now settle feed wheat"
+    },
+    {
+      "name": "val4",
+      "mnemonic": "tail forward era width glory magnet knock shiver cup broken turkey upgrade cigar story agent lake transfer misery sustain fragile parrot also air document"
+    },
+    {
+      "name": "val5",
+      "mnemonic": "crime lumber parrot enforce chimney turtle wing iron scissors jealous indicate peace empty game host protect juice submit motor cause second picture nuclear area"
+    },
+    {
+      "name": "val6",
+      "mnemonic": "boss achieve ignore end cake display gift other organ demise ostrich crouch usual crop vote knock busy juice detail excess brass myth fatal layer"
+    },
+    {
+      "name": "val7",
+      "mnemonic": "either payment void buffalo bamboo memory grow blood immune flag include castle unfair never drastic worth mosquito provide snap victory spider gloom enhance desk"
+    },
+    {
+      "name": "val8",
+      "mnemonic": "boring magic start axis kick identify arch sleep need name manage genius corn brick reveal math dwarf march grocery focus popular gun brief swim"
+    }
+  ],
+  "relayers": [
+    {
+      "name": "rly1",
+      "mnemonic": "fringe secret hair noise royal inform remove release mother fish swamp swim piece later course glimpse sing very clutch velvet prefer hover common mass"
+    },
+    {
+      "name": "rly2",
+      "mnemonic": "floor chicken advance degree paper arch sugar kit torch auction flash fish attitude clay museum treat favorite clinic verify dose safe bright vessel east"
+    },
+    {
+      "name": "rly3",
+      "mnemonic": "belt diet provide fish knee area explain section sword fancy rebel mix fiction urge float chat move device another tourist want tackle drip good"
+    },
+    {
+      "name": "rly4",
+      "mnemonic": "video stereo milk coyote various fantasy attract leaf elevator laundry upper clinic ready recipe wreck asset make before update pitch found board tissue sniff"
+    },
+    {
+      "name": "rly5",
+      "mnemonic": "orient exit remain dance oval jealous spend baby card property struggle thank mean swing extra visit type segment wild exit height climb pause jungle"
+    },
+    {
+      "name": "rly6",
+      "mnemonic": "high awful dog toilet animal mystery zebra magnet style tube art arrow public about system odor split junk second second mixture grab fruit farm"
+    },
+    {
+      "name": "rly7",
+      "mnemonic": "bar clown steak hand dog mango vacant cradle potato axis identify surround give key noise lend must wool error broccoli relax input usage reveal"
+    },
+    {
+      "name": "rly8",
+      "mnemonic": "eagle rapid adapt nasty middle ability width rebel satisfy seminar boss sniff tape artist expose call predict burst hard pig coral item dolphin eagle"
+    }
+  ],
+  "users": [
+    {
+      "name": "user1",
+      "mnemonic": "brief play describe burden half aim soccer carbon hope wait output play vacuum joke energy crucial output mimic cruise brother document rail anger leaf"
+    }
+  ]
+}

--- a/integration-tests/network/scripts/create-validator.sh
+++ b/integration-tests/network/scripts/create-validator.sh
@@ -72,6 +72,15 @@ EOF
 }
 
 main() {
+    # PSS-only validators: pods with index >= 5 do NOT register as govenators.
+    # This mirrors the mainnet shape where ~3 of 8 PSS validators have
+    # ICS-key-assigned consensus keys not in x/staking, exercising the
+    # distrwrapper stake-iteration path post-upgrade.
+    if [[ "$POD_INDEX" -ge 5 ]]; then
+        echo "Skipping govenator registration for PSS-only validator (pod $POD_INDEX)"
+        exit 0
+    fi
+
     echo "Adding validator..."
     wait_for_startup
     add_keys

--- a/integration-tests/network/scripts/init-chain.sh
+++ b/integration-tests/network/scripts/init-chain.sh
@@ -71,12 +71,18 @@ add_validators() {
         add_genesis_account "$validator_key" "${VALIDATOR_BALANCE}${DENOM}"
 
         # Use a separate directory for the non-main nodes so we can generate unique validator keys
-        if [[ "$i" == "1" ]]; then 
+        if [[ "$i" == "1" ]]; then
             validator_home=${CHAIN_HOME}
-        else 
+        else
             validator_home=/tmp/${CHAIN_NAME}-${name} && rm -rf $validator_home
             $BINARY init $name --chain-id $CHAIN_ID --overwrite --home ${validator_home} &> /dev/null
         fi
+
+        # Overwrite the auto-generated cons key with the pinned rehearsal cons key.
+        # The index in cons_keys is i-1 (jq is 0-indexed; the loop is 1-indexed).
+        cons_key_index=$((i - 1))
+        jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+            > ${validator_home}/config/priv_validator_key.json
 
         # Save the node IDs and keys to the API
         $BINARY tendermint show-node-id --home ${validator_home} > node_id.txt

--- a/integration-tests/network/scripts/init-node.sh
+++ b/integration-tests/network/scripts/init-node.sh
@@ -57,7 +57,13 @@ update_config() {
     sed -i -E "s|node = \".*\"|node = \"tcp://localhost:${RPC_PORT}\"|g" $client_toml
 
     echo "Retrieving private keys and genesis.json..."
-    download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json 
+    download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json
+    # Belt-and-suspenders: ensure the downloaded cons key matches the pinned one
+    # from keys.json. This makes the script self-contained even if pod 0's
+    # pinning step ever regresses.
+    cons_key_index=$((VALIDATOR_INDEX - 1))
+    jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+        > ${CHAIN_HOME}/config/priv_validator_key.json
     download_shared_file ${NODE_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json  ${CHAIN_HOME}/config/node_key.json 
     download_shared_file ${GENESIS_DIR}/${CHAIN_NAME}/genesis.json ${CHAIN_HOME}/config/genesis.json 
 

--- a/integration-tests/network/scripts/upgrade.sh
+++ b/integration-tests/network/scripts/upgrade.sh
@@ -5,46 +5,46 @@
 set -eu
 
 NAMESPACE=integration
-
-EXEC0="kubectl exec -it stride-validator-0 -c validator -n $NAMESPACE -- "
-STRIDED0="kubectl exec -it stride-validator-0 -c validator -n $NAMESPACE -- strided"
-STRIDED1="kubectl exec -it stride-validator-1 -c validator -n $NAMESPACE -- strided"
-STRIDED2="kubectl exec -it stride-validator-2 -c validator -n $NAMESPACE -- strided"
-
 UPGRADE_BUFFER=45 # blocks
+
+# Helper to invoke strided in a specific validator pod.
+strided_in() {
+    pod_index="$1"; shift
+    kubectl exec -it stride-validator-$pod_index -c validator -n $NAMESPACE -- strided "$@"
+}
 
 trim_tx() {
     grep -E "code:|txhash:" | sed 's/^[[:space:]]*//'
 }
 
-upgrade_name=$(kubectl exec stride-validator-0 -c validator -- printenv UPGRADE_NAME)
-latest_height=$($STRIDED0 status | jq -r 'if .SyncInfo then .SyncInfo.latest_block_height else .sync_info.latest_block_height end')
+upgrade_name=$(kubectl exec stride-validator-0 -c validator -n $NAMESPACE -- printenv UPGRADE_NAME)
+latest_height=$(strided_in 0 status | jq -r 'if .SyncInfo then .SyncInfo.latest_block_height else .sync_info.latest_block_height end')
 upgrade_height=$((latest_height+UPGRADE_BUFFER))
 
 echo -e "\nSubmitting proposal for $upgrade_name at height $upgrade_height...\n"
-$EXEC0 bash scripts/propose_upgrade.sh $upgrade_name $upgrade_height | trim_tx
+kubectl exec -it stride-validator-0 -c validator -n $NAMESPACE -- \
+    bash scripts/propose_upgrade.sh $upgrade_name $upgrade_height | trim_tx
 
 sleep 5
 echo -e "\nProposal:\n"
-proposal_id=$($STRIDED0 q gov proposals --output json | jq -r '.proposals | max_by(.id | tonumber).id')
-$STRIDED0 query gov proposal $proposal_id
+proposal_id=$(strided_in 0 q gov proposals --output json | jq -r '.proposals | max_by(.id | tonumber).id')
+strided_in 0 query gov proposal $proposal_id
 
 sleep 1
 echo -e "\nVoting on proposal #$proposal_id...\n"
-echo "Val1:"
-$STRIDED0 tx gov vote $proposal_id yes --from val1 -y | trim_tx
-echo "Val2:"
-$STRIDED1 tx gov vote $proposal_id yes --from val2 -y | trim_tx
-echo "Val3:"
-$STRIDED2 tx gov vote $proposal_id yes --from val3 -y | trim_tx
+for i in 0 1 2 3 4; do
+    val_name="val$((i + 1))"
+    echo "${val_name}:"
+    strided_in "$i" tx gov vote $proposal_id yes --from "$val_name" -y | trim_tx
+done
 
 sleep 5
 echo -e "\nVote confirmation:\n"
-$STRIDED0 query gov tally $proposal_id
+strided_in 0 query gov tally $proposal_id
 
 echo -e "\nProposal Status:\n"
 while true; do
-    status=$($STRIDED0 query gov proposal $proposal_id --output json | jq -r '.proposal.status')
+    status=$(strided_in 0 query gov proposal $proposal_id --output json | jq -r '.proposal.status')
     if [[ "$status" == "PROPOSAL_STATUS_VOTING_PERIOD" ]]; then
         echo "Proposal still in progress..."
         sleep 5
@@ -54,7 +54,7 @@ while true; do
     elif [[ "$status" == "PROPOSAL_STATUS_REJECTED" ]]; then
         echo "Proposal Failed!"
         exit 1
-    else 
+    else
         echo "Unknown proposal status: $status"
         exit 1
     fi

--- a/integration-tests/network/values.yaml
+++ b/integration-tests/network/values.yaml
@@ -7,54 +7,15 @@ images:
 
 activeChains:
   - stride
-  - cosmoshub
-  - osmosis
 
-# type can be either "relayer" or "hermes"
-relayers:
-  - name: stride-cosmoshub
-    type: relayer
-    chainA: stride
-    chainB: cosmoshub
-  - name: stride-osmosis
-    type: relayer
-    chainA: stride
-    chainB: osmosis
-  # We start with hermes as a backup relayer
-  - name: stride-cosmoshub
-    type: hermes
-    chainA: stride
-    chainB: cosmoshub
-    createPaths: false
-  - name: stride-osmosis
-    type: hermes
-    chainA: stride
-    chainB: osmosis
-    createPaths: false
+# No relayers — Stride is the only chain in this rehearsal network.
+relayers: []
 
 chainConfigs:
   stride:
     binary: strided
     version: latest
-    numValidators: 3
+    numValidators: 8
     home: .stride
     denom: ustrd
     decimals: 6
-
-  cosmoshub:
-    binary: gaiad
-    version: v22.1.0
-    numValidators: 1
-    home: .gaia
-    denom: uatom
-    decimals: 6
-
-  osmosis:
-    binary: osmosisd
-    version: v28.0.0
-    numValidators: 1
-    home: .osmosisd
-    denom: uosmo
-    decimals: 6
-
-

--- a/integration-tests/scripts/generate_rehearsal_state.sh
+++ b/integration-tests/scripts/generate_rehearsal_state.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# generate_rehearsal_state.sh
+# One-time helper for the POA migration rehearsal.
+# Produces: 8 priv_validator_key.json blobs (cons keys), their hex consensus
+# addresses, and operator bech32 addresses derived from each validator
+# mnemonic. Outputs everything to a single JSON document on stdout for the
+# implementer to copy into keys.json, validators.json, and PoaValidatorSet.
+#
+# Requires: strided binary on PATH (any recent version that knows
+# `strided init` and `strided keys`).
+
+set -eu
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+KEYS_FILE="${KEYS_FILE:-integration-tests/network/configs/keys.json}"
+NUM_VALIDATORS=8
+
+# Ensure 8 validator entries exist in keys.json. If only 5 are present today,
+# the script generates 3 fresh mnemonics and prints them so the implementer
+# can append them to keys.json before re-running.
+existing_count=$(jq '.validators | length' "$KEYS_FILE")
+if [[ "$existing_count" -lt "$NUM_VALIDATORS" ]]; then
+    echo "ERROR: keys.json has only $existing_count validators; need $NUM_VALIDATORS." >&2
+    echo "Generating $((NUM_VALIDATORS - existing_count)) fresh mnemonic(s):" >&2
+    for ((i=existing_count+1; i<=NUM_VALIDATORS; i++)); do
+        mnemonic=$(strided keys mnemonic 2>/dev/null)
+        echo "  val${i}: ${mnemonic}" >&2
+    done
+    echo "Append the above to keys.json::validators[] then re-run." >&2
+    exit 1
+fi
+
+# Generate 8 cons keys using `strided init`. We write the priv_validator_key.json
+# verbatim — same shape strided expects on disk.
+declare -a CONS_KEYS_JSON
+declare -a HEX_ADDRS
+
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    home="${WORKDIR}/cons-${i}"
+    strided init "tmp-${i}" --chain-id rehearsal --home "$home" >/dev/null 2>&1
+    cons_key=$(cat "${home}/config/priv_validator_key.json")
+    hex_addr=$(jq -r '.address' <<<"$cons_key" | tr 'A-Z' 'a-z')
+
+    CONS_KEYS_JSON[$i]="$cons_key"
+    HEX_ADDRS[$i]="$hex_addr"
+done
+
+# Derive operator bech32 from each validator mnemonic.
+declare -a OPERATORS
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    mnemonic=$(jq -r ".validators[$i].mnemonic" "$KEYS_FILE")
+    name="rehearsal-val-$i"
+    # Use a fresh keyring per loop to avoid name collisions across runs.
+    keyring="${WORKDIR}/keyring-${i}"
+    echo "$mnemonic" | strided keys add "$name" \
+        --recover --keyring-backend test --home "$keyring" >/dev/null 2>&1
+    operator=$(strided keys show "$name" -a \
+        --keyring-backend test --home "$keyring")
+    OPERATORS[$i]="$operator"
+done
+
+# Emit a single JSON document the implementer can paste into the relevant files.
+jq -n \
+  --argjson cons_keys "$(printf '%s\n' "${CONS_KEYS_JSON[@]}" | jq -s .)" \
+  --argjson hex_addrs "$(printf '%s\n' "${HEX_ADDRS[@]}" | jq -R . | jq -s .)" \
+  --argjson operators "$(printf '%s\n' "${OPERATORS[@]}" | jq -R . | jq -s .)" \
+  '{
+     cons_keys: $cons_keys,
+     hex_addrs: $hex_addrs,
+     operators: $operators
+   }'

--- a/utils/poa.go
+++ b/utils/poa.go
@@ -1,3 +1,9 @@
+// REHEARSAL ONLY — DO NOT MERGE
+// PoaValidatorSet has been replaced with test operator addresses generated
+// from the rehearsal validator mnemonics in
+// integration-tests/network/configs/keys.json. The mainnet set lives on the
+// `main` branch.
+
 package utils
 
 import sdkmath "cosmossdk.io/math"
@@ -14,12 +20,12 @@ type PoaValidator struct {
 }
 
 var PoaValidatorSet = []PoaValidator{
-	{Moniker: "Polkachu", Operator: "stride1gp957czryfgyvxwn3tfnyy2f0t9g2p4pxxdj7c", HubAddress: "cosmosvalcons1m7fg8k39k2tyym5hgwrpf5wx9hqsr8vywuyrtm"},
-	{Moniker: "L5", Operator: "stride1wj9ckvakuzgvlgw3hwpmsfjxvsc7uke73ps4u8", HubAddress: "cosmosvalcons1c5e86exd7jsyhcfqdejltdsagjfrvv8xv22368"},
-	{Moniker: "Imperator", Operator: "stride13u4dsapth4m3hef3z8qgjtdnv06predefnndkw", HubAddress: "cosmosvalcons1pdpwglc4fcjdzqvyhvfwxg684trpc6uqck5sxk"},
-	{Moniker: "Cosmostation", Operator: "stride1jj9z2xwxesuy65n90dujsak554eqkrr2ygyan2", HubAddress: "cosmosvalcons1px0zkz2cxvc6lh34uhafveea9jnaagckmrlsye"},
-	{Moniker: "Keplr", Operator: "stride1j79tw5chf34u88s30gxchzx2cu080elm4hqg5j", HubAddress: "cosmosvalcons1vz42ewp04wwepjed7z4qenj925gpakgvap4q2u"},
-	{Moniker: "Stakecito", Operator: "stride1qe8uuf5x69c526h4nzxwv4ltftr73v7qr7y9vq", HubAddress: "cosmosvalcons1upc05nc9pwhhagnkr3f2dft327qxsxfeyvajsu"},
-	{Moniker: "Citadel.one", Operator: "stride1rgwn0h67xmuluymk4vvhtl4tqtgfg39j9zuk2z", HubAddress: "cosmosvalcons1f6cjsfn47ujttypx7gtncglsmjvndugc2zelqx"},
-	{Moniker: "CryptoCrew", Operator: "stride1smuvvnjj6w7x6ytq9kdgvlj6er99y6648s3der", HubAddress: "cosmosvalcons1jufcrrd9gze26sxd82ppse03eg5g5xa2gplt6p"},
+	{Moniker: "Validator1", Operator: "stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7", HubAddress: ""},
+	{Moniker: "Validator2", Operator: "stride17kht2x2ped6qytr2kklevtvmxpw7wq9rmuc3ca", HubAddress: ""},
+	{Moniker: "Validator3", Operator: "stride1nnurja9zt97huqvsfuartetyjx63tc5zq8s6fv", HubAddress: ""},
+	{Moniker: "Validator4", Operator: "stride1py0fvhdtq4au3d9l88rec6vyda3e0wtt9szext", HubAddress: ""},
+	{Moniker: "Validator5", Operator: "stride1c5jnf370kaxnv009yhc3jt27f549l5u36chzem", HubAddress: ""},
+	{Moniker: "Validator6", Operator: "stride1eudadx6z3dp6pa4sgqx740tyvuasfh4nrt7rc2", HubAddress: ""},
+	{Moniker: "Validator7", Operator: "stride1fm497naw27ck2d4z6z4ujcwq929ad5gexwvz8f", HubAddress: ""},
+	{Moniker: "Validator8", Operator: "stride1gfvjzmrucy9xemzqktvg28m8n40wpv6l4fam6r", HubAddress: ""},
 }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Throwaway rehearsal branch. Test-only constants are hardcoded into v33 source (`validators.json`, `constants.go`, `utils/poa.go`), each carrying a `// REHEARSAL ONLY — DO NOT MERGE` marker. This branch exists to run the migration on a live network, not to merge.

## Purpose

Run the v32 → v33 (ICS → POA) migration on an **8-validator, Stride-only** network — 5 govenators (with x/staking records) + 3 PSS-only validators (without) — to validate the migration handler under multi-node consensus and exercise POA-specific behavior.

This complements #1505, which runs the same migration on the standard 3-validator network with host zones and then runs `make test-core`. Where #1505 asks *"does the existing product still work after the upgrade,"* this branch asks *"is the upgrade itself correct at mainnet shape."* The 5/3 split is the piece #1505 structurally cannot cover.

## Rehearsal result — all tests pass

Run on the `integration` cluster, 8 Stride validators, upgrade at height 109.

**The upgrade itself:** all 8 validators swapped binaries via cosmovisor with **0 pod restarts**, `applying ABCI validator updates total=8`, `Upgrade v33 complete.` POA came up with 8 validators at total power 800 and the expected admin.

| Task | Test | Result |
|---|---|---|
| 15 | Block production continues; validator hash unchanged | ✅ `DHwama1jFBvzdBVQFdYhkKAvO7N72reAiWW+MCBZx6Q=` identical at heights 58, 109 and 130 |
| 16 | Tx fees route to POA, not `fee_collector` | ✅ POA `390,462,303 → 485,124,831` (+94,662,528); `fee_collector` drained to **0** |
| 17 | Govenator rewards accrue and withdraw | ✅ rewards `1,653,757,035 → 1,689,239,412` (+35,482,377); withdrew **1,724,716,788** net of fee |
| 18 | `MsgWithdrawFees` payout, incl. PSS-only validator | ✅ val1 **+115,360,737**; val6 **+322,424,704** |

### Task 18 is the load-bearing one

The 5/3 split was confirmed directly on-chain:

- `strided q staking validators` returns exactly `val1 val2 val3 val4 val5`
- **val6 has no x/staking record at all** (0 matches)
- POA nonetheless credited val6 `320,950,055ustrd` withdrawable, and `MsgWithdrawFees` paid out `322,424,704`

That confirms POA distributes to validators the staking module doesn't know about — the case the 5/3 split exists to prove.

### One evidence caveat

val1's `MsgWithdrawFees` was confirmed by **balance delta**, not a tx receipt — the `q tx` lookup never resolved (tx-indexing quirk on that node). The delta is unambiguous (+115,360,737 against a 112,407,064 withdrawable, with no other tx in flight, and POA's lazy checkpoint pays what is owed at execution rather than at query time), but it is inference from balances. val6's withdrawal returned `code: 0` cleanly.

## Two fixes were required to run this at all

Both cherry-picked from #1505; neither is specific to this branch's fixtures.

1. **`integration-tests/dockerfiles/Dockerfile.stride-upgrade` — idempotent `start.sh`.** The old one-liner moved `COSMOVISOR_HOME` into the daemon home unconditionally. The state volume is an `emptyDir` that survives container restarts while image layers do not, so the move succeeded only on the first start; afterwards `mv` nested the source inside the destination and the next start died on the collision. Since `DAEMON_RESTART_AFTER_UPGRADE=true` restarts the container the moment cosmovisor swaps binaries, **every upgrade test killed its own validators at the upgrade height**, then masked the original error behind `mv` failures on all subsequent restarts. This fix is generally useful and has already landed on `poa-migration-scripts` as `b4b85308a`.

2. **`app/upgrades/v33/upgrades.go` — skip absent host zones in `UpdateValidatorWeights`.** It hard-failed on the first missing host zone, and its constants reference ten mainnet host zones that no test network has. The upgrade halted at `failed to add validator celestiavaloper1nxdm2... to celestia: Host Zone (celestia) not found`. Now skips with an `Error` log, matching `ReconcileOsmosisDelegations` directly above it, which already documents the same reasoning. Mainnet is unaffected — it has all ten zones, verified separately against a mainnet state export where this step applied 331 weight changes successfully.

## Runbook corrections found while executing

The plan doc in `docs/superpowers/plans/2026-04-30-poa-migration-rehearsal.md` has stale commands:

- `strided q ccvconsumer all-cc-validators` does not exist in this ICS version (only `next-fee-distribution`, `params`, `provider-info`, `throttle-state`). Verify the consensus set via each pod's `strided status .validator_info.address` instead.
- All `poa` subcommands need **`strided2`** — `strided` on `PATH` is the v32 binary and has no `poa` command. Only the node itself is swapped to v33 by cosmovisor.
- Rewards and withdrawable-fees are now coin **strings** (`"1582792281.504000000000000000ustrd"`), not `{denom, amount}` objects, so `jq '.total[] | select(.denom=="ustrd")'` errors. `withdrawable-fees` also nests under `.fees.fees[0]`.
- `staking validators[0]` is not val1; ordering is not guaranteed. Take val1's operator address from its own `distribution rewards` response.

## Merge posture

Nothing here merges. The only reusable fix is already on `poa-migration-scripts`. Pre-merge defense:

```bash
git diff main..poa-migration-rehearsal -- \
    app/upgrades/v33/validators.json \
    app/upgrades/v33/validators.json.REHEARSAL_ONLY \
    app/upgrades/v33/constants.go \
    utils/poa.go
```

Non-empty means the branch still carries throwaway state.
