### PR TITLE
[DO NOT MERGE] PoA migration test on standard integration-tests network

### DIFF
--- a/app/upgrades/v33/constants.go
+++ b/app/upgrades/v33/constants.go
@@ -1,3 +1,9 @@
+// REHEARSAL ONLY — DO NOT MERGE
+// This branch (poa-migration-ig-tests) replaces ExpectedValidatorCount and
+// AdminMultisigAddress with test-only values. Shipping these to mainnet
+// would point the v33 upgrade handler at the wrong admin and the wrong
+// validator count. See app/upgrades/v33/validators.json.REHEARSAL_ONLY.
+
 package v33
 
 import (
@@ -10,11 +16,11 @@ const UpgradeName = "v33"
 
 // AdminMultisigAddress is the bech32 address that POA recognizes as its admin
 // post-upgrade
-const AdminMultisigAddress = "stride1fduug6m38gyuqt3wcgc2kcgr9nnte0n7ssn27e"
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
 
 // ExpectedValidatorCount is enforced by the upgrade handler. Panics if
 // consumerKeeper.GetAllCCValidator returns a different count.
-const ExpectedValidatorCount = 8
+const ExpectedValidatorCount = 3
 
 //go:embed validators.json
 var validatorsJSON []byte

--- a/app/upgrades/v33/helpers_test.go
+++ b/app/upgrades/v33/helpers_test.go
@@ -33,7 +33,7 @@ func TestHelpersTestSuite(t *testing.T) {
 }
 
 func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_HappyPath() {
-	s.seedConsumerValidators(8)
+	s.seedConsumerValidators(3)
 
 	// Map each seeded consensus address to one of the real monikers in
 	// utils.PoaValidatorSet so SnapshotValidatorsFromICS can complete the
@@ -55,7 +55,7 @@ func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_HappyPath() {
 
 	poaValidators, err := v33.SnapshotValidatorsFromICS(s.Ctx, s.App.ConsumerKeeper)
 	s.Require().NoError(err)
-	s.Require().Len(poaValidators, 8)
+	s.Require().Len(poaValidators, 3)
 
 	for _, val := range poaValidators {
 		s.Require().NotNil(val.PubKey)
@@ -74,15 +74,15 @@ func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_HappyPath() {
 }
 
 func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_TooManyValidators() {
-	s.seedConsumerValidators(9)
+	s.seedConsumerValidators(4) // expecting 3
 
 	_, err := v33.SnapshotValidatorsFromICS(s.Ctx, s.App.ConsumerKeeper)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "expected at most 8 validators")
+	s.Require().Contains(err.Error(), "expected at most 3 validators")
 }
 
 func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_MissingMoniker() {
-	s.seedConsumerValidators(8)
+	s.seedConsumerValidators(3)
 	// Do NOT populate ValidatorMonikers — every validator hex_cons_addr lookup
 	// will miss, which should now halt the upgrade rather than silently
 	// produce empty monikers.
@@ -93,7 +93,7 @@ func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_MissingMoniker() {
 }
 
 func (s *HelpersTestSuite) TestSnapshotValidatorsFromICS_UnknownMoniker() {
-	s.seedConsumerValidators(8)
+	s.seedConsumerValidators(3)
 
 	// Populate monikers but use a value that does NOT appear in
 	// utils.PoaValidatorSet — this catches drift between the two sources of
@@ -157,7 +157,7 @@ func (s *HelpersTestSuite) TestInitializePOA_HappyPath() {
 	s.Require().NoError(err)
 	initialCount := len(initialVals)
 
-	s.seedConsumerValidators(8)
+	s.seedConsumerValidators(3)
 
 	// SnapshotValidatorsFromICS now requires every CCValidator to map to a
 	// real moniker + operator. Wire that up before the call.
@@ -180,8 +180,8 @@ func (s *HelpersTestSuite) TestInitializePOA_HappyPath() {
 
 	storedVals, err := s.App.POAKeeper.GetAllValidators(s.Ctx)
 	s.Require().NoError(err)
-	// InitializePOA should have added exactly 8 new validators from ICS.
-	s.Require().Len(storedVals, initialCount+8)
+	// InitializePOA should have added exactly 3 new validators from ICS.
+	s.Require().Len(storedVals, initialCount+3)
 
 	params, err := s.App.POAKeeper.GetParams(s.Ctx)
 	s.Require().NoError(err)

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -199,6 +199,14 @@ func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk r
 // Phase 2: Set all validator weights to their target values
 func UpdateValidatorWeights(ctx sdk.Context, sk stakeibckeeper.Keeper) error {
 	for _, chainId := range utils.StringMapKeys(NewValidators) {
+		// Skip rather than error, for the same reason ReconcileOsmosisDelegations does: an error
+		// here fails the upgrade and halts the chain, and non-mainnet environments (dockernet,
+		// testnets, integration-tests) carry none of the mainnet host zones these weights target.
+		if _, found := sk.GetHostZone(ctx, chainId); !found {
+			ctx.Logger().Error(fmt.Sprintf("v33: host zone %s not found, skipping new validators", chainId))
+			continue
+		}
+
 		validators := NewValidators[chainId]
 		ctx.Logger().Info(fmt.Sprintf("Adding %d new validators to %s...", len(validators), chainId))
 		for _, val := range validators {
@@ -215,12 +223,14 @@ func UpdateValidatorWeights(ctx sdk.Context, sk stakeibckeeper.Keeper) error {
 
 	for _, chainId := range utils.StringMapKeys(TargetWeights) {
 		weights := TargetWeights[chainId]
-		ctx.Logger().Info(fmt.Sprintf("Setting validator weights for %s...", chainId))
 
 		hostZone, found := sk.GetHostZone(ctx, chainId)
 		if !found {
-			return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", chainId)
+			ctx.Logger().Error(fmt.Sprintf("v33: host zone %s not found, skipping weight update", chainId))
+			continue
 		}
+
+		ctx.Logger().Info(fmt.Sprintf("Setting validator weights for %s...", chainId))
 
 		weightMap := make(map[string]uint64, len(weights))
 		for _, w := range weights {

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -54,7 +54,7 @@ func TestUpgradeTestSuite(t *testing.T) {
 
 func (s *UpgradeTestSuite) TestUpgrade() {
 	// ----- arrange -----
-	s.setupICSValidatorSet(8)
+	s.setupICSValidatorSet(3)
 	s.setupGovenatorState(3)
 	s.setupConsumerRewardAccounts()
 	s.setupActiveGovProposal()
@@ -81,13 +81,13 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 
 func (s *UpgradeTestSuite) checkPOAValidatorsMatchICSSnapshot() {
 	ccVals := s.App.ConsumerKeeper.GetAllCCValidator(s.Ctx)
-	s.Require().Len(ccVals, 8, "ICS seed should have 8 validators after seeding")
+	s.Require().Len(ccVals, 3, "ICS seed should have 3 validators after seeding")
 
 	poaVals, err := s.App.POAKeeper.GetAllValidators(s.Ctx)
 	s.Require().NoError(err)
-	// Pre-existing test genesis validator + 8 newly seeded ICS validators.
-	s.Require().Len(poaVals, s.initialPOAValidatorCount+8,
-		"POA should have initialCount + 8 validators after upgrade")
+	// Pre-existing test genesis validator + 3 newly seeded ICS validators.
+	s.Require().Len(poaVals, s.initialPOAValidatorCount+3,
+		"POA should have initialCount + 3 validators after upgrade")
 
 	// Build a lookup of POA validators by their consensus address so we can
 	// check each ICS validator is present with the correct pubkey and power.
@@ -187,7 +187,7 @@ func (s *UpgradeTestSuite) checkValidatorSetContinuity() {
 	// boundary, so EndBlocker at block N+1 would return [] (nothing queued).
 	// In the unit-test environment we stay in the same sdk.Context across the
 	// upgrade, so the transient store is never wiped and EndBlocker instead
-	// returns the 9 updates queued during InitGenesis (1 genesis + 8 ICS).
+	// returns the 4 updates queued during InitGenesis (1 genesis + 3 ICS).
 	//
 	// We therefore assert on _content_ rather than emptiness: the updates must
 	// correspond 1-to-1 with the ICS validators we seeded (subset check), plus
@@ -196,8 +196,8 @@ func (s *UpgradeTestSuite) checkValidatorSetContinuity() {
 	// fail the length check below.
 	updates, err := s.App.POAKeeper.EndBlocker(s.Ctx)
 	s.Require().NoError(err)
-	s.Require().Len(updates, s.initialPOAValidatorCount+8,
-		"POA EndBlocker should have exactly initialCount+8 queued updates (1 genesis + 8 ICS); got %d", len(updates))
+	s.Require().Len(updates, s.initialPOAValidatorCount+3,
+		"POA EndBlocker should have exactly initialCount+3 queued updates (1 genesis + 3 ICS); got %d", len(updates))
 
 	// Build a set of CometBFT pubkey bytes from updates for O(1) lookup.
 	updatePubKeySet := make(map[string]int64, len(updates))
@@ -371,7 +371,7 @@ func (s *UpgradeTestSuite) setupActiveGovProposal() {
 // delegation count so checkGovenatorStateUntouched can assert nothing changed.
 func (s *UpgradeTestSuite) capturePreUpgradeState() {
 	// Record how many POA validators exist before the upgrade handler adds the
-	// 8 ICS-migrated ones (the genesis bootstrap seeds 1 test validator).
+	// 3 ICS-migrated ones (the genesis bootstrap seeds 1 test validator).
 	initialVals, err := s.App.POAKeeper.GetAllValidators(s.Ctx)
 	s.Require().NoError(err)
 	s.initialPOAValidatorCount = len(initialVals)

--- a/app/upgrades/v33/validators.json
+++ b/app/upgrades/v33/validators.json
@@ -1,10 +1,5 @@
 {
-  "94532a622413b9ef925fb078805f2e4ced675018": "Polkachu",
-  "56b2473d1218a34d8e2c5350abd839a8243f78b1": "L5",
-  "ba3d14838e86271106f1e9210a3cbf40896ab849": "Imperator",
-  "5cb08dcc3b15fffa4e326a1ffbd2ddf02b04e2e7": "Cosmostation",
-  "fe4e54245813c4a53221fb4c8b053d30afc9fb0e": "Keplr",
-  "47a8d36a0b8a7c15e1a3751ad5f1dd12bc90dd6d": "Stakecito",
-  "43c91e4908a233331d1d30512af703962b25c5ee": "Citadel.one",
-  "4b86b55befcad8fcb34959ea2cacc21cd61111e7": "CryptoCrew"
+  "895b09a185636566cadc0f130d9102c3f1be7a9d": "Validator1",
+  "7018a0cfec999d75c682e04ed764bacbde6f261b": "Validator2",
+  "13e61e4263bc2c4eebf6cd7f7188cf8ff011b1fb": "Validator3"
 }

--- a/app/upgrades/v33/validators.json.REHEARSAL_ONLY
+++ b/app/upgrades/v33/validators.json.REHEARSAL_ONLY
@@ -1,0 +1,17 @@
+REHEARSAL ONLY — DO NOT MERGE
+
+This branch (poa-migration-ig-tests) replaces the 8 mainnet validators in
+validators.json with 3 test validators that match cons keys pinned in
+integration-tests/network/configs/keys.json::cons_keys. Shipping this
+file to mainnet would point the v33 upgrade handler at fictional
+validators and halt the upgrade.
+
+Companion files modified on this branch:
+  - app/upgrades/v33/constants.go (ExpectedValidatorCount, AdminMultisigAddress)
+  - utils/poa.go (PoaValidatorSet)
+
+Pre-merge sanity check on any v33-related PR:
+  git diff main..poa-migration-ig-tests -- \
+    app/upgrades/v33/validators.json \
+    app/upgrades/v33/constants.go \
+    utils/poa.go

--- a/docs/superpowers/plans/2026-05-01-poa-migration-ig-tests.md
+++ b/docs/superpowers/plans/2026-05-01-poa-migration-ig-tests.md
@@ -1,0 +1,737 @@
+# POA Migration on Standard Integration-Tests Network — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the v32 → v33 (ICS → POA) upgrade against the standard k8s integration-tests network (3 stride validators + cosmoshub + osmosis) and run `make test-core` post-upgrade.
+
+**Architecture:** Pin 3 stride consensus keys offline, bake the matching hex addresses + operator bech32s + admin into a throwaway fork of `validators.json`, `PoaValidatorSet`, and `AdminMultisigAddress`. Change `ExpectedValidatorCount` from 8 to 3. Existing hub/osmosis/relayer setup is untouched. Branch is throwaway (not for merge), same posture as `poa-migration-rehearsal`.
+
+**Tech Stack:** Bash scripts, Helm, kubectl, Cosmos SDK CLI (`strided`), Go (test-only edits to v33 source).
+
+**Companion spec:** `docs/superpowers/specs/2026-05-01-poa-migration-ig-tests-design.md`
+
+**Branch:** `poa-migration-ig-tests` — this work is not for merge.
+
+**Expected test breakage on this branch:** `app/upgrades/v33/mainnet_export_test.go` will fail because mainnet hex cons addresses are no longer in our test `validators.json`. This is acceptable — branch is throwaway. The handler's own unit tests (`app/upgrades/v33/helpers_test.go`, `app/upgrades/v33/upgrades_test.go`) install their own monikers/operators and should keep passing.
+
+---
+
+## File map
+
+**Created:**
+- `integration-tests/scripts/generate_ig_test_state.sh` — one-time helper that emits cons keys, hex addresses, and operator bech32s as a single JSON document.
+- `app/upgrades/v33/validators.json.REHEARSAL_ONLY` — sidecar marker file (JSON has no comments).
+
+**Modified (test-only, throwaway):**
+- `integration-tests/network/configs/keys.json` — add a top-level `cons_keys` array of 3 `priv_validator_key.json` blobs.
+- `integration-tests/network/scripts/init-chain.sh` — overwrite the auto-generated cons key with the pinned blob, gated on `CHAIN_NAME == "stride"`.
+- `integration-tests/network/scripts/init-node.sh` — same overwrite for non-main stride pods.
+- `app/upgrades/v33/validators.json` — replace 8 mainnet entries with 3 test entries.
+- `app/upgrades/v33/constants.go` — `ExpectedValidatorCount: 8 → 3`, swap admin to keys.json admin, add `// REHEARSAL ONLY — DO NOT MERGE` header.
+- `utils/poa.go` — replace `PoaValidatorSet` with 3 test entries, add header marker.
+
+---
+
+## Phase 1: Cons-key generator and state
+
+### Task 1: Write the generator script
+
+**Files:**
+- Create: `integration-tests/scripts/generate_ig_test_state.sh`
+
+This script produces all the deterministic inputs we need to bake into both the integration-tests config AND the v33 source: 3 `priv_validator_key.json` blobs, their lowercase-hex consensus addresses, and 3 operator bech32 addresses derived from val1/val2/val3 mnemonics.
+
+Mirrors `integration-tests/scripts/generate_rehearsal_state.sh` from the `poa-migration-rehearsal` branch, scaled down to 3 vals and reusing existing mnemonics (no need to generate new ones).
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/bin/bash
+# generate_ig_test_state.sh
+# One-time helper for the POA migration integration-tests run.
+# Produces: 3 priv_validator_key.json blobs (cons keys), their lowercase
+# hex consensus addresses, and operator bech32 addresses derived from
+# val1/val2/val3 mnemonics. Outputs a single JSON document on stdout
+# for the implementer to inject into keys.json, validators.json, and
+# PoaValidatorSet.
+#
+# Requires: strided binary on PATH (any recent version that knows
+# `strided init` and `strided keys`).
+
+set -eu
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+KEYS_FILE="${KEYS_FILE:-integration-tests/network/configs/keys.json}"
+NUM_VALIDATORS=3
+
+# Sanity-check that keys.json has at least 3 validator entries.
+existing_count=$(jq '.validators | length' "$KEYS_FILE")
+if [[ "$existing_count" -lt "$NUM_VALIDATORS" ]]; then
+    echo "ERROR: keys.json has only $existing_count validators; need $NUM_VALIDATORS." >&2
+    exit 1
+fi
+
+# Generate 3 cons keys using `strided init`. Write priv_validator_key.json
+# verbatim — same shape strided expects on disk.
+declare -a CONS_KEYS_JSON
+declare -a HEX_ADDRS
+
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    home="${WORKDIR}/cons-${i}"
+    strided init "tmp-${i}" --chain-id ig-tests --home "$home" >/dev/null 2>&1
+    cons_key=$(cat "${home}/config/priv_validator_key.json")
+    hex_addr=$(jq -r '.address' <<<"$cons_key" | tr 'A-Z' 'a-z')
+
+    CONS_KEYS_JSON[$i]="$cons_key"
+    HEX_ADDRS[$i]="$hex_addr"
+done
+
+# Derive operator bech32 from each validator mnemonic (val1, val2, val3).
+declare -a OPERATORS
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    mnemonic=$(jq -r ".validators[$i].mnemonic" "$KEYS_FILE")
+    name="ig-tests-val-$i"
+    keyring="${WORKDIR}/keyring-${i}"
+    echo "$mnemonic" | strided keys add "$name" \
+        --recover --keyring-backend test --home "$keyring" >/dev/null 2>&1
+    operator=$(strided keys show "$name" -a \
+        --keyring-backend test --home "$keyring")
+    OPERATORS[$i]="$operator"
+done
+
+# Emit a single JSON document with the cons keys, hex addrs, and operators.
+jq -n \
+  --argjson cons_keys "$(printf '%s\n' "${CONS_KEYS_JSON[@]}" | jq -s .)" \
+  --argjson hex_addrs "$(printf '%s\n' "${HEX_ADDRS[@]}" | jq -R . | jq -s .)" \
+  --argjson operators "$(printf '%s\n' "${OPERATORS[@]}" | jq -R . | jq -s .)" \
+  '{
+     cons_keys: $cons_keys,
+     hex_addrs: $hex_addrs,
+     operators: $operators
+   }'
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x integration-tests/scripts/generate_ig_test_state.sh
+```
+
+- [ ] **Step 3: Verify shell syntax**
+
+```bash
+bash -n integration-tests/scripts/generate_ig_test_state.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integration-tests/scripts/generate_ig_test_state.sh
+git commit -m "feat(ig-tests): add cons-key/operator generator script for 3-val POA test"
+```
+
+---
+
+### Task 2: Run generator and inject `cons_keys` into keys.json
+
+**Files:**
+- Modify: `integration-tests/network/configs/keys.json` (add `cons_keys` array)
+
+- [ ] **Step 1: Run the generator and save output**
+
+```bash
+cd /Users/sampocs/Documents/Projects/stride
+bash integration-tests/scripts/generate_ig_test_state.sh > /tmp/ig-test-state.json
+```
+
+Expected: exits 0; `/tmp/ig-test-state.json` is valid JSON with three top-level keys (`cons_keys`, `hex_addrs`, `operators`), each an array of length 3.
+
+- [ ] **Step 2: Verify output shape**
+
+```bash
+jq '.cons_keys | length, .hex_addrs | length, .operators | length' /tmp/ig-test-state.json
+```
+
+Expected: three lines, each `3`.
+
+- [ ] **Step 3: Inject `cons_keys` into keys.json**
+
+```bash
+jq --slurpfile s /tmp/ig-test-state.json \
+   '. + {cons_keys: $s[0].cons_keys}' \
+   integration-tests/network/configs/keys.json \
+   > /tmp/keys.json && \
+mv /tmp/keys.json integration-tests/network/configs/keys.json
+```
+
+- [ ] **Step 4: Verify keys.json has cons_keys array**
+
+```bash
+jq '.cons_keys | length' integration-tests/network/configs/keys.json
+```
+
+Expected: `3`.
+
+- [ ] **Step 5: Keep `/tmp/ig-test-state.json` around**
+
+Tasks 5 and 7 will read `hex_addrs` and `operators` from this file. Do not delete until the v33 source edits are in.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add integration-tests/network/configs/keys.json
+git commit -m "feat(ig-tests): pin 3 cons keys in keys.json"
+```
+
+---
+
+## Phase 2: Integration-tests script edits
+
+### Task 3: Pin cons keys in init-chain.sh (stride only)
+
+**Files:**
+- Modify: `integration-tests/network/scripts/init-chain.sh`
+
+The `add_validators` function loops over `NUM_VALIDATORS` for whichever chain is running. We need to overwrite the auto-generated `priv_validator_key.json` with the pinned blob from `keys.json::cons_keys[i-1]`, but ONLY for the stride chain — hub and osmosis must keep their auto-generated keys.
+
+- [ ] **Step 1: Edit `add_validators()` to overwrite cons key for stride only**
+
+Open `integration-tests/network/scripts/init-chain.sh`. Find the `for (( i=1; i <= $NUM_VALIDATORS; i++ ))` loop in `add_validators()` (around line 66). After the `if [[ "$i" == "1" ]]; then validator_home=${CHAIN_HOME} else ... fi` block (around line 79) and BEFORE the `# Save the node IDs and keys to the API` comment (around line 81), insert:
+
+```bash
+        # ig-tests POA upgrade: overwrite the auto-generated stride cons
+        # key with the pinned blob from keys.json::cons_keys[i-1]. This
+        # makes the consensus hex addresses match the values baked into
+        # app/upgrades/v33/validators.json. Hub/osmosis keep their
+        # auto-generated keys.
+        if [[ "$CHAIN_NAME" == "stride" ]]; then
+            cons_key_index=$((i - 1))
+            jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+                > ${validator_home}/config/priv_validator_key.json
+        fi
+```
+
+The result should look like:
+
+```bash
+        # Use a separate directory for the non-main nodes so we can generate unique validator keys
+        if [[ "$i" == "1" ]]; then 
+            validator_home=${CHAIN_HOME}
+        else 
+            validator_home=/tmp/${CHAIN_NAME}-${name} && rm -rf $validator_home
+            $BINARY init $name --chain-id $CHAIN_ID --overwrite --home ${validator_home} &> /dev/null
+        fi
+
+        # ig-tests POA upgrade: overwrite the auto-generated stride cons
+        # key with the pinned blob from keys.json::cons_keys[i-1]. ...
+        if [[ "$CHAIN_NAME" == "stride" ]]; then
+            cons_key_index=$((i - 1))
+            jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+                > ${validator_home}/config/priv_validator_key.json
+        fi
+
+        # Save the node IDs and keys to the API
+        $BINARY tendermint show-node-id --home ${validator_home} > node_id.txt
+```
+
+The position is critical — the overwrite must happen *before* `$BINARY tendermint show-node-id` and `validator_public_keys+=...` because both read from `priv_validator_key.json`.
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/init-chain.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/init-chain.sh
+git commit -m "feat(ig-tests): pin stride cons keys in init-chain.sh"
+```
+
+---
+
+### Task 4: Pin cons keys in init-node.sh (stride only)
+
+**Files:**
+- Modify: `integration-tests/network/scripts/init-node.sh`
+
+Non-main pods download `priv_validator_key.json` from the API. The shared file already came from a main-node init-chain that was pinned, so it's already correct — but we re-pin here for self-consistency, gated on stride.
+
+- [ ] **Step 1: Edit `update_config()` to overwrite cons key for stride only**
+
+Open `integration-tests/network/scripts/init-node.sh`. Find the existing line (around line 60):
+
+```bash
+    download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json 
+```
+
+Right after that line, insert:
+
+```bash
+
+    # ig-tests POA upgrade: re-pin the stride cons key from
+    # keys.json::cons_keys[VALIDATOR_INDEX-1] for self-consistency.
+    # The shared file already came from the pinned main node, but
+    # re-pinning here makes init-node.sh independent of init-chain.sh
+    # ordering.
+    if [[ "$CHAIN_NAME" == "stride" ]]; then
+        cons_key_index=$((VALIDATOR_INDEX - 1))
+        jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+            > ${CHAIN_HOME}/config/priv_validator_key.json
+    fi
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+```bash
+bash -n integration-tests/network/scripts/init-node.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add integration-tests/network/scripts/init-node.sh
+git commit -m "feat(ig-tests): pin stride cons keys in init-node.sh"
+```
+
+---
+
+## Phase 3: v33 source edits (REHEARSAL ONLY — DO NOT MERGE)
+
+### Task 5: Replace v33/validators.json and add sidecar marker
+
+**Files:**
+- Modify: `app/upgrades/v33/validators.json`
+- Create: `app/upgrades/v33/validators.json.REHEARSAL_ONLY`
+
+- [ ] **Step 1: Capture the 3 hex cons addresses from the generator output**
+
+```bash
+jq -r '.hex_addrs[]' /tmp/ig-test-state.json
+```
+
+Expected: 3 lines of 40-char lowercase hex, one per line. Capture these as `<hex_addr_pod0>`, `<hex_addr_pod1>`, `<hex_addr_pod2>` for use in step 2.
+
+- [ ] **Step 2: Replace `app/upgrades/v33/validators.json`**
+
+Use the Edit tool (or your editor of choice) to replace the file's contents with exactly:
+
+```json
+{
+  "<hex_addr_pod0>": "Validator1",
+  "<hex_addr_pod1>": "Validator2",
+  "<hex_addr_pod2>": "Validator3"
+}
+```
+
+Substitute each `<hex_addr_pod*>` with the actual 40-char hex from step 1.
+
+- [ ] **Step 3: Create the sidecar marker file**
+
+Create `app/upgrades/v33/validators.json.REHEARSAL_ONLY` with this content:
+
+```
+REHEARSAL ONLY — DO NOT MERGE
+
+This branch (poa-migration-ig-tests) replaces the 8 mainnet validators in
+validators.json with 3 test validators that match cons keys pinned in
+integration-tests/network/configs/keys.json::cons_keys. Shipping this
+file to mainnet would point the v33 upgrade handler at fictional
+validators and halt the upgrade.
+
+Companion files modified on this branch:
+  - app/upgrades/v33/constants.go (ExpectedValidatorCount, AdminMultisigAddress)
+  - utils/poa.go (PoaValidatorSet)
+
+Pre-merge sanity check on any v33-related PR:
+  git diff main..poa-migration-ig-tests -- \
+    app/upgrades/v33/validators.json \
+    app/upgrades/v33/constants.go \
+    utils/poa.go
+```
+
+- [ ] **Step 4: Verify validators.json parses and has 3 entries**
+
+```bash
+jq 'length' app/upgrades/v33/validators.json
+```
+
+Expected: `3`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/upgrades/v33/validators.json app/upgrades/v33/validators.json.REHEARSAL_ONLY
+git commit -m "test(ig-tests): swap validators.json to 3 test cons addresses"
+```
+
+---
+
+### Task 6: Update v33 constants.go (count + admin + marker)
+
+**Files:**
+- Modify: `app/upgrades/v33/constants.go`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `app/upgrades/v33/constants.go` with:
+
+```go
+// REHEARSAL ONLY — DO NOT MERGE
+// This branch (poa-migration-ig-tests) replaces ExpectedValidatorCount and
+// AdminMultisigAddress with test-only values. Shipping these to mainnet
+// would point the v33 upgrade handler at the wrong admin and the wrong
+// validator count. See app/upgrades/v33/validators.json.REHEARSAL_ONLY.
+
+package v33
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+// UpgradeName is the SDK upgrade plan name. Match the binary release tag.
+const UpgradeName = "v33"
+
+// AdminMultisigAddress is the bech32 address that POA recognizes as its admin
+// post-upgrade
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
+
+// ExpectedValidatorCount is enforced by the upgrade handler. Panics if
+// consumerKeeper.GetAllCCValidator returns a different count.
+const ExpectedValidatorCount = 3
+
+//go:embed validators.json
+var validatorsJSON []byte
+
+// ValidatorMonikers maps lowercase hex of the consensus address (the raw 20-byte
+// address returned by ccv consumer GetAllCCValidator) to the validator's moniker.
+// ICS does not store monikers on the consumer chain — they live on the Hub.
+// We pre-bake them so they appear correctly in POA's validator records.
+//
+// Populated from validators.json at init. Regenerate with scripts/fetch_validator_monikers.sh.
+var ValidatorMonikers = func() map[string]string {
+	m := make(map[string]string)
+	if err := json.Unmarshal(validatorsJSON, &m); err != nil {
+		panic("v33: failed to parse embedded validators.json: " + err.Error())
+	}
+	if len(m) != ExpectedValidatorCount {
+		panic("v33: validators.json has wrong validator count")
+	}
+	return m
+}()
+```
+
+The two value changes vs. main:
+- `AdminMultisigAddress`: `"stride1fduug6m38gyuqt3wcgc2kcgr9nnte0n7ssn27e"` → `"stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"` (the keys.json admin).
+- `ExpectedValidatorCount`: `8` → `3`.
+
+- [ ] **Step 2: Verify the file compiles**
+
+```bash
+go build ./app/upgrades/v33/...
+```
+
+Expected: no output (clean build). The `init`-time check on `len(m) != ExpectedValidatorCount` reads `validators.json` at compile time via `//go:embed`, so this will fail if Task 5's `validators.json` doesn't have exactly 3 entries.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/upgrades/v33/constants.go
+git commit -m "test(ig-tests): point v33 admin and count at the 3-val test setup"
+```
+
+---
+
+### Task 7: Update PoaValidatorSet in utils/poa.go
+
+**Files:**
+- Modify: `utils/poa.go`
+
+- [ ] **Step 1: Capture the 3 operator bech32s from the generator output**
+
+```bash
+jq -r '.operators[]' /tmp/ig-test-state.json
+```
+
+Expected: 3 lines of `stride1...` bech32. Capture as `<operator_val1>`, `<operator_val2>`, `<operator_val3>`.
+
+- [ ] **Step 2: Replace the `PoaValidatorSet` block**
+
+Open `utils/poa.go`. The current contents have an 8-entry `PoaValidatorSet` declared with `var PoaValidatorSet = []PoaValidator{...}`. Replace just that variable declaration block with:
+
+```go
+// REHEARSAL ONLY — DO NOT MERGE
+// This branch (poa-migration-ig-tests) replaces the 8 mainnet entries with
+// 3 test validators matching app/upgrades/v33/validators.json. See that
+// file's sidecar REHEARSAL_ONLY marker for context.
+var PoaValidatorSet = []PoaValidator{
+	{Moniker: "Validator1", Operator: "<operator_val1>", HubAddress: ""},
+	{Moniker: "Validator2", Operator: "<operator_val2>", HubAddress: ""},
+	{Moniker: "Validator3", Operator: "<operator_val3>", HubAddress: ""},
+}
+```
+
+Substitute each `<operator_val*>` with the actual `stride1...` bech32 from step 1.
+
+Leave the `PoaValidator` struct definition untouched — only the `PoaValidatorSet` slice changes.
+
+- [ ] **Step 3: Verify the file compiles**
+
+```bash
+go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run the v33 handler unit tests**
+
+```bash
+go test ./app/upgrades/v33/...
+```
+
+Expected: `helpers_test.go` and `upgrades_test.go` pass; `mainnet_export_test.go` FAILS with errors about hex addresses not present in `ValidatorMonikers`. The mainnet-export failure is expected and acceptable on this throwaway branch.
+
+If `helpers_test.go` or `upgrades_test.go` fails, something is wrong with the edits — those tests install their own monikers and operators and shouldn't be affected by the count/value swaps. Stop and investigate before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/poa.go
+git commit -m "test(ig-tests): swap PoaValidatorSet to 3 test entries"
+```
+
+---
+
+## Phase 4: Build, run, test
+
+### Task 8: Build the upgrade image
+
+**Files:** none modified — this is an image build.
+
+- [ ] **Step 1: Verify v32.0.0 tag exists locally**
+
+```bash
+git tag -l 'v32.0.0'
+```
+
+Expected: `v32.0.0`. If empty, fetch tags: `git fetch --tags`.
+
+- [ ] **Step 2: Verify working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. The `build.sh` script aborts if there are uncommitted changes (it checks out `v32.0.0` mid-build).
+
+- [ ] **Step 3: Build the upgrade image**
+
+```bash
+cd integration-tests
+UPGRADE_OLD_VERSION=v32.0.0 make build-stride-upgrade
+```
+
+Expected: builds two images (old `core:stride-v32.0.0` and new `core:stride-upgrade-old` + the latest stride image), pushes to GCR. End-to-end takes ~5-10 minutes.
+
+If this fails because the v32.0.0 build can't compile against the current local SDK, that's an upstream issue — re-tag from a known-good commit, or check the rehearsal branch for a working approach.
+
+- [ ] **Step 4: Confirm image is ready**
+
+```bash
+docker images | grep stride
+```
+
+Expected: at minimum `core:stride-upgrade-old` and a recent stride-tests image present.
+
+- [ ] **Step 5: No commit required**
+
+This step produces no source-tree changes.
+
+---
+
+### Task 9: Spin up network and verify pre-upgrade state
+
+- [ ] **Step 1: Verify k8s namespace is empty**
+
+```bash
+cd integration-tests
+make check-empty-namespace
+```
+
+Expected: exits 0. If pods exist, run `make stop` first.
+
+- [ ] **Step 2: Start the network**
+
+```bash
+make start
+```
+
+Expected: helm install completes, then `wait-for-startup` polls until all pods are ready (~3-5 minutes). Do NOT proceed until this returns.
+
+- [ ] **Step 3: Verify all 3 stride pods are producing blocks**
+
+```bash
+for i in 0 1 2; do
+    kubectl exec stride-validator-$i -c validator -n integration -- \
+        strided status | jq -r '.SyncInfo.latest_block_height // .sync_info.latest_block_height'
+done
+```
+
+Expected: 3 lines, each a positive integer. Re-run a few seconds later — heights should increase.
+
+- [ ] **Step 4: Verify ccvconsumer hex addresses match validators.json**
+
+```bash
+kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q ccvconsumer all-cc-validators --output json | jq -r '.validators[].address'
+```
+
+Expected: 3 base64-encoded addresses. To verify they match `validators.json`:
+
+```bash
+kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q ccvconsumer all-cc-validators --output json | \
+    jq -r '.validators[].address' | \
+    while read b64; do
+        echo "$b64" | base64 -d | xxd -p -c 40
+    done | sort
+```
+
+Expected: 3 lines matching exactly the keys in `app/upgrades/v33/validators.json` (sort the keys with `jq -r 'keys[]' app/upgrades/v33/validators.json | sort` to compare).
+
+If the addresses don't match, the cons-key pinning failed — check Task 3's edit and verify `keys.json::cons_keys` is non-empty.
+
+- [ ] **Step 5: Verify host zones registered**
+
+```bash
+kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q stakeibc list-host-zone --output json | jq '.host_zone | length'
+```
+
+Expected: `2` (cosmoshub + osmosis). May take a minute or two after `make start` completes.
+
+- [ ] **Step 6: No commit required**
+
+This is a runtime verification step.
+
+---
+
+### Task 10: Trigger the upgrade and verify post-upgrade state
+
+- [ ] **Step 1: Capture pre-upgrade validator hash**
+
+```bash
+PRE_HASH=$(kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q block --type=height $(kubectl exec stride-validator-0 -c validator -n integration -- \
+        strided status | jq -r '.SyncInfo.latest_block_height // .sync_info.latest_block_height') \
+    --output json | jq -r '.block.header.validators_hash')
+echo "Pre-upgrade validator hash: $PRE_HASH"
+```
+
+Save this value for step 4.
+
+- [ ] **Step 2: Submit and pass the upgrade proposal**
+
+```bash
+make upgrade-stride
+```
+
+Expected: proposal is submitted at `latest_height + 45`, val1/val2/val3 vote yes, polls until `PROPOSAL_STATUS_PASSED`. Exits 0.
+
+- [ ] **Step 3: Wait for the upgrade height to be reached and pods to restart**
+
+```bash
+# Check that all 3 stride pods are still up and producing blocks past the upgrade height
+for i in 0 1 2; do
+    height=$(kubectl exec stride-validator-$i -c validator -n integration -- \
+        strided status | jq -r '.SyncInfo.latest_block_height // .sync_info.latest_block_height')
+    echo "stride-validator-$i height: $height"
+done
+```
+
+Wait until all three heights are at least `upgrade_height + 5`. Cosmovisor will restart each pod automatically; expect a 30-60s gap as the pod restarts on the v33 binary.
+
+- [ ] **Step 4: Verify validator hash unchanged across the upgrade**
+
+```bash
+POST_HASH=$(kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q block --type=height <upgrade_height> --output json | \
+    jq -r '.block.header.validators_hash')
+echo "Post-upgrade validator hash: $POST_HASH"
+```
+
+Substitute `<upgrade_height>` with the value printed in `make upgrade-stride` output (search for "Submitting proposal for v33 at height").
+
+Expected: `POST_HASH` matches `PRE_HASH` from step 1. If different, the validator set shifted across the upgrade — investigate before proceeding.
+
+- [ ] **Step 5: Verify POA module account exists post-upgrade**
+
+```bash
+kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q auth module-account poa --output json | jq -r '.account.value.address'
+```
+
+Expected: a `stride1...` address (the POA module account). Confirms the POA module was wired in.
+
+- [ ] **Step 6: Verify x/poa params show correct admin**
+
+```bash
+kubectl exec stride-validator-0 -c validator -n integration -- \
+    strided q poa params --output json | jq -r '.params.admin'
+```
+
+Expected: `stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8` (the keys.json admin).
+
+- [ ] **Step 7: No commit required**
+
+Runtime verification.
+
+---
+
+### Task 11: Run make test-core
+
+- [ ] **Step 1: Run the test suite**
+
+```bash
+cd integration-tests
+make test-core
+```
+
+Expected: vitest runs `client/test/core.test.ts` against both `cosmoshub` and `osmosis` host zones; all tests pass.
+
+The suite covers:
+- IBC transfers (stride ↔ host)
+- Liquid staking (deposit, redemption rate, unbonding, redemption record removal)
+- Host zone state queries
+
+If any test fails, capture the failure first — most likely cause is a one-time relayer flake at the upgrade height (per spec §7 R3). Retry once: `make test-core` again. If failures persist, the failure is real — investigate before declaring success.
+
+- [ ] **Step 2: No commit required**
+
+Pure verification.
+
+---
+
+## Done
+
+Plan execution is complete when all 11 tasks above are checked off and `make test-core` has passed. The branch should NOT be merged — it has hard-coded test values in v33 source files. Pre-merge defense:
+
+```bash
+# Diff the throwaway-marked files vs. main; non-empty means the branch
+# still carries throwaway state and should not be merged.
+git diff main..poa-migration-ig-tests -- \
+    app/upgrades/v33/validators.json \
+    app/upgrades/v33/validators.json.REHEARSAL_ONLY \
+    app/upgrades/v33/constants.go \
+    utils/poa.go
+```

--- a/docs/superpowers/specs/2026-05-01-poa-migration-ig-tests-design.md
+++ b/docs/superpowers/specs/2026-05-01-poa-migration-ig-tests-design.md
@@ -1,0 +1,312 @@
+# Stride v33 — POA Migration on the Standard Integration-Tests Network
+
+## §1. Overview and objective
+
+Run the v32 → v33 (ICS → POA) migration on the standard k8s
+`integration-tests` network — the one with 3 Stride validators plus
+`cosmoshub` and `osmosis` host zones — then run `make test-core`
+against the post-upgrade chain.
+
+This complements the `poa-migration-rehearsal` branch, which scaled the
+network up to 8 stride-only validators to mirror mainnet shape. Here
+the goal is the opposite: the smallest possible delta from the everyday
+integration-tests network so that the existing `core.test.ts` suite
+keeps working post-upgrade.
+
+**This is a throwaway branch** (`poa-migration-ig-tests`), not for
+merge — same posture as the rehearsal. Test-only constants are
+hard-coded into the v33 source. Each modified file carries a top-of-file
+`// REHEARSAL ONLY — DO NOT MERGE` marker.
+
+**Companion specs:**
+- `2026-04-27-ics-to-poa-migration-design.md` — the v33 migration itself.
+- `2026-04-30-poa-migration-rehearsal-design.md` — the 8-validator rehearsal
+  this design is patterned after.
+
+**Pre-conditions:**
+- v33 implementation is complete on this branch (handler, POA wiring,
+  distrwrapper, ante handler change, store upgrades).
+- `v32.0.0` is tagged on the upstream Stride repo.
+- Existing integration-tests network can spin up `make start` cleanly.
+
+**Success criteria:**
+1. v32 network spins up with 3 stride validators, IBC channels open to
+   `cosmoshub` and `osmosis`, host zones registered.
+2. v33 upgrade proposal passes; cosmovisor swaps binaries cleanly; block
+   production continues with the same validator hash across the upgrade
+   height.
+3. Tx fees submitted post-upgrade route to the POA module account, not
+   `fee_collector`.
+4. `make test-core` passes against both `cosmoshub` and `osmosis` host
+   zones post-upgrade (IBC transfers, liquid staking, redemption,
+   unbonding).
+
+**Non-goals:**
+- POA `MsgWithdrawFees` payout (covered by rehearsal).
+- 5/3 govenator/PSS-only split (covered by rehearsal).
+- LSM / auction / autopilot / burn test suites (run them later if useful;
+  not in scope here).
+- Production-grade hygiene on test fixtures.
+
+## §2. Network shape
+
+```
+   ┌─────────────────────┐    ┌──────────────┐    ┌──────────────┐
+   │ Stride (3 vals)     │◄──►│ Cosmos Hub   │    │ Osmosis      │
+   │ - val1/val2/val3    │    │ (1 val)      │    │ (1 val)      │
+   │ - cons keys pinned  │    │ unchanged    │    │ unchanged    │
+   │ - all 3 govenators  │    └──────────────┘    └──────────────┘
+   │ - v32 → v33 upgrade │           ▲                   ▲
+   │                     │           │  relayers (rly + hermes)
+   │                     │───────────┴───────────────────┘
+   └─────────────────────┘
+```
+
+Same Helm chart, same `activeChains` (`stride`, `cosmoshub`, `osmosis`),
+same relayer entries (rly + hermes for both stride↔hub and stride↔osmosis)
+as the everyday integration-tests network. Nothing changes for hub or
+osmosis; the migration handler only touches Stride state.
+
+All 3 stride validators are also govenators (registered via
+`tx staking create-validator` in `create-validator.sh`). No PSS-only
+split — at scale 3 every validator participates, which is fine for
+exercising the post-upgrade `distrwrapper` stake-iteration path on every
+block.
+
+## §3. Pinned cons-key generation
+
+The v33 handler enforces strict joins from each consensus address (read
+from `ccvconsumer`) to a moniker (in `app/upgrades/v33/validators.json`)
+to a Stride operator bech32 (in `utils/poa.go::PoaValidatorSet`). Cons
+keys generated fresh by `binaryd init` would not match the mainnet hex
+addresses baked into `validators.json`, so we pin them.
+
+**One-time, offline:**
+
+1. Run `strided init tmp-N --chain-id ig-tests --home /tmp/cons-N` for
+   N=0,1,2.
+2. For each, capture `${home}/config/priv_validator_key.json` verbatim
+   and the lowercase hex of `.address`.
+3. Stash the 3 blobs in `integration-tests/network/configs/keys.json`
+   under a new top-level `cons_keys: [...]` array, indexed 0–2 to match
+   pod indices (`stride-validator-0` → `cons_keys[0]`, etc.).
+4. Bake the 3 hex addresses into `app/upgrades/v33/validators.json`,
+   keyed `Validator1`/`Validator2`/`Validator3`.
+5. For each of val1/val2/val3, derive the operator bech32 by recovering
+   their mnemonic from `keys.json` into a fresh keyring and running
+   `strided keys show -a`. Bake the 3 results into
+   `utils/poa.go::PoaValidatorSet`.
+
+A small generator script (`integration-tests/scripts/generate_ig_test_state.sh`,
+mirroring the rehearsal's `generate_rehearsal_state.sh` but for 3 pods)
+emits all three artifacts as a single JSON document on stdout for the
+implementer to copy into the right files.
+
+## §4. Source-tree edits on this branch
+
+All edits live on `poa-migration-ig-tests` and are explicitly never
+merged. Each modified source file carries a top-of-file marker:
+
+```
+// REHEARSAL ONLY — DO NOT MERGE
+```
+
+(For `validators.json`: JSON has no comments — drop a sibling
+`validators.json.REHEARSAL_ONLY` marker file instead.)
+
+**`app/upgrades/v33/constants.go`:**
+
+```go
+const AdminMultisigAddress = "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8"
+const ExpectedValidatorCount = 3
+```
+
+The `AdminMultisigAddress` value is the existing `admin` account from
+`integration-tests/network/configs/keys.json`. The `len(m) != ExpectedValidatorCount`
+guard in the `validatorsJSON` init block keeps working — it now requires
+exactly 3 entries in `validators.json`.
+
+**`app/upgrades/v33/validators.json`:**
+
+```json
+{
+  "<hex_addr_pod0>": "Validator1",
+  "<hex_addr_pod1>": "Validator2",
+  "<hex_addr_pod2>": "Validator3"
+}
+```
+
+The three hex addresses come from §3 step 2.
+
+**`utils/poa.go::PoaValidatorSet`:**
+
+```go
+var PoaValidatorSet = []PoaValidator{
+    {Moniker: "Validator1", Operator: "stride1<val1-acct>", HubAddress: ""},
+    {Moniker: "Validator2", Operator: "stride1<val2-acct>", HubAddress: ""},
+    {Moniker: "Validator3", Operator: "stride1<val3-acct>", HubAddress: ""},
+}
+```
+
+`Operator` is the `sdk.AccAddress` bech32 (`stride1...`) derived from
+each validator's mnemonic in `keys.json` — *not* a `stridevaloper1...`
+address. `HubAddress` is unused on this code path; leave it empty.
+
+These three edits make the v33 binary accept the 3-validator test set
+as its migration input. They are simultaneously the reason this branch
+must never be merged: shipping any of them to mainnet would point the
+upgrade handler at fictional validators with a test admin.
+
+## §5. Integration-tests edits
+
+**`integration-tests/network/configs/keys.json`:**
+- Add a top-level `cons_keys: [...]` array of 3 `priv_validator_key.json`
+  blobs (the verbatim JSON contents from §3 step 2).
+
+**`integration-tests/network/scripts/init-chain.sh`:**
+- In `add_validators` (loop `i=1..NUM_VALIDATORS`), after the per-pod
+  `binaryd init` produces `${validator_home}/config/priv_validator_key.json`,
+  overwrite that file with `cons_keys[i-1]` from `keys.json`, **before**
+  the `tendermint show-node-id` / pubkey extraction calls. This ensures
+  the comma-separated `validator_public_keys` passed to
+  `add-consumer-section` reflects the pinned keys, and the `ccvconsumer`
+  state at upgrade time matches `validators.json`.
+
+**`integration-tests/network/scripts/init-node.sh`:**
+- After the existing `download_shared_file ... priv_validator_key.json`,
+  additionally overwrite the file with `cons_keys[VALIDATOR_INDEX-1]`
+  from `keys.json`. The shared file already comes from a main node that
+  was pinned in `init-chain.sh`; this is belt-and-suspenders so the
+  node-init script is self-consistent.
+
+**`integration-tests/network/scripts/upgrade.sh`:** no change. Already
+votes from val1/val2/val3.
+
+**`integration-tests/network/scripts/create-validator.sh`:** no change.
+All 3 pods register as govenators.
+
+**`integration-tests/network/values.yaml`:** no change. `numValidators: 3`
+stays; cosmoshub, osmosis, and the 4 relayer entries stay.
+
+## §6. Build and execution flow
+
+**Build the upgrade image (once per code change to v32 or v33):**
+
+```bash
+cd integration-tests
+UPGRADE_OLD_VERSION=v32.0.0 make build-stride-upgrade
+```
+
+This produces a single image with v32 (from upstream tag) at
+`cosmovisor/genesis/bin/strided` and v33 (from this branch) at
+`cosmovisor/upgrades/v33/bin/strided`. The existing `build.sh` already
+seds the keys.json admin into `utils/admins.go` for the old binary; that
+still works.
+
+**Spin up the network:**
+
+```bash
+make start
+```
+
+`helm install` deploys 3 stride pods + 1 cosmoshub pod + 1 osmosis pod +
+relayers. Stride pods run `init-chain.sh` (pod 0 only) / `init-node.sh`
+(all pods), then start cosmovisor with the v32 binary. All 3 pods run
+`create-validator.sh` post-startup.
+
+**Verify pre-upgrade state:**
+- All 3 stride pods producing blocks (`strided status`).
+- ICA channels and host zones registered for both `cosmoshub` and
+  `osmosis` (the existing `core.test.ts` setup helpers can do this — or
+  smoke-test by hand: `strided q stakeibc list-host-zone` shows 2 entries).
+- `strided q ccvconsumer all-cc-validators` returns 3 entries with hex
+  addresses matching `validators.json`.
+
+**Trigger the upgrade:**
+
+```bash
+make upgrade-stride
+```
+
+Submits the v33 software-upgrade proposal at `latest_height + 45`,
+votes from val1/val2/val3, polls until passed. Cosmovisor swaps binaries
+at the upgrade height; pods restart with v33.
+
+**Run the tests:**
+
+```bash
+make test-core
+```
+
+This runs `client/test/core.test.ts` via vitest against both `cosmoshub`
+and `osmosis` host zones. Test suite covers IBC transfers, liquid
+staking, deposit records, redemption rate, unbonding, and redemption
+record removal — all post-upgrade.
+
+## §7. Risks
+
+### R1: Cons-key drift between keys.json and validators.json
+
+If the implementer regenerates cons keys without also regenerating
+`validators.json`, `make start` will boot but the upgrade will halt at
+`helpers.go:39` (no moniker found for the consensus hex). Mitigation:
+the generator script emits both artifacts in one pass; commit them
+together.
+
+### R2: `mainnet_export_test.go` fails on this branch
+
+Tests in `app/upgrades/v33/mainnet_export_test.go` are keyed off the
+real mainnet hex addresses, which are no longer in our test
+`validators.json`. Acceptable — same posture as the rehearsal branch.
+Don't merge.
+
+### R3: Relayer blip across the upgrade height
+
+Cosmovisor restarts the stride pods at the upgrade height. The existing
+relayer setup reconnects automatically, but if a packet is in-flight at
+that exact moment, an IBC test in `core.test.ts` may see a one-time
+flake. If this happens, retry `make test-core`; a permanent fix is out
+of scope.
+
+### R4: Source edits get merged
+
+Catastrophic if shipped to mainnet (admin would point at the test
+account, validators at fictional cons addrs). Mitigations, in order of
+defensive value:
+
+- Each modified source file carries a top-of-file `// REHEARSAL ONLY — DO NOT MERGE`
+  marker. For `validators.json`, a sibling `validators.json.REHEARSAL_ONLY`
+  marker file alongside.
+- Branch name (`poa-migration-ig-tests`) signals intent.
+- Final pre-merge sanity check on any v33-related PR:
+  `git diff main..poa-migration-ig-tests -- app/upgrades/v33/validators.json
+  utils/poa.go app/upgrades/v33/constants.go`.
+
+### R5: ICA / host-zone state survives the upgrade
+
+`core.test.ts` post-upgrade depends on host zones being registered and
+ICA channels open before the test starts. The migration handler doesn't
+touch `stakeibc` or IBC channel state, so this should hold; verify
+during implementation by re-querying host zones after the upgrade
+height. If anything regresses here, the migration handler is the place
+to look.
+
+## §8. Out of scope
+
+- POA `MsgWithdrawFees` payout — covered by rehearsal.
+- 5/3 govenator/PSS-only split — covered by rehearsal.
+- LSM / auction / autopilot / burn test suites — easy to add later by
+  invoking the corresponding `make test-*` targets; not in scope here.
+- Public testnet rehearsal.
+- Multisig signing rehearsal.
+- Performance benchmarking.
+
+## §9. Summary
+
+3-validator Stride network plus cosmoshub and osmosis on the standard
+k8s integration-tests network. Pin 3 cons keys offline, bake matching
+test addresses into a throwaway fork of `validators.json`,
+`PoaValidatorSet`, and `AdminMultisigAddress`, change
+`ExpectedValidatorCount` from 8 to 3. Build v32+v33 image, spin up,
+propose-upgrade-vote, run `make test-core` against the post-upgrade
+chain. Branch is throwaway.

--- a/integration-tests/dockerfiles/Dockerfile.stride-upgrade
+++ b/integration-tests/dockerfiles/Dockerfile.stride-upgrade
@@ -42,6 +42,18 @@ WORKDIR /home/validator
 
 EXPOSE 26657 26656 1317 9090
 
-RUN echo "mv ${COSMOVISOR_HOME} ${DAEMON_HOME}/cosmovisor && cosmovisor run start --reject-config-defaults" > start.sh
+# The state volume survives container restarts but the image layers do not, so COSMOVISOR_HOME
+# reappears on every start while ${DAEMON_HOME}/cosmovisor persists. Moving unconditionally
+# therefore succeeds only on the first start: afterwards mv nests the source inside the existing
+# destination, and the start after that dies on the collision. That kills the pod at the upgrade
+# height, right when cosmovisor restarts the daemon.
+#
+# Only seed the directory when it is absent. Never delete and re-move it - post-upgrade the
+# `current` symlink points at upgrades/${UPGRADE_NAME}, and replacing the directory would silently
+# roll the node back to the genesis binary.
+RUN printf '%s\n' \
+    '[ -d "${DAEMON_HOME}/cosmovisor" ] || mv ${COSMOVISOR_HOME} ${DAEMON_HOME}/cosmovisor' \
+    'cosmovisor run start --reject-config-defaults' \
+    > start.sh
 
 CMD ["bash", "start.sh" ]

--- a/integration-tests/network/configs/keys.json
+++ b/integration-tests/network/configs/keys.json
@@ -1,74 +1,108 @@
 {
-    
-    "admin": {
-      "name": "admin",
-      "address": "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8",
-      "mnemonic": "tone cause tribe this switch near host damage idle fragile antique tail soda alien depth write wool they rapid unfold body scan pledge soft"
+  "admin": {
+    "name": "admin",
+    "address": "stride1u20df3trc2c2zdhm8qvh2hdjx9ewh00sv6eyy8",
+    "mnemonic": "tone cause tribe this switch near host damage idle fragile antique tail soda alien depth write wool they rapid unfold body scan pledge soft"
+  },
+  "faucet": {
+    "name": "faucet",
+    "mnemonic": "chimney become stuff spoil resource supply picture divorce casual curve check web valid survey zebra various pet sphere timber friend faint blame mansion film"
+  },
+  "validators": [
+    {
+      "name": "val1",
+      "mnemonic": "close soup mirror crew erode defy knock trigger gather eyebrow tent farm gym gloom base lemon sleep weekend rich forget diagram hurt prize fly"
     },
-    "faucet": {
-      "name": "faucet",
-      "mnemonic": "chimney become stuff spoil resource supply picture divorce casual curve check web valid survey zebra various pet sphere timber friend faint blame mansion film"
+    {
+      "name": "val2",
+      "mnemonic": "turkey miss hurry unable embark hospital kangaroo nuclear outside term toy fall buffalo book opinion such moral meadow wing olive camp sad metal banner"
     },
-    "validators": [
-      {
-        "name": "val1",
-        "mnemonic": "close soup mirror crew erode defy knock trigger gather eyebrow tent farm gym gloom base lemon sleep weekend rich forget diagram hurt prize fly"
+    {
+      "name": "val3",
+      "mnemonic": "tenant neck ask season exist hill churn rice convince shock modify evidence armor track army street stay light program harvest now settle feed wheat"
+    },
+    {
+      "name": "val4",
+      "mnemonic": "tail forward era width glory magnet knock shiver cup broken turkey upgrade cigar story agent lake transfer misery sustain fragile parrot also air document"
+    },
+    {
+      "name": "val5",
+      "mnemonic": "crime lumber parrot enforce chimney turtle wing iron scissors jealous indicate peace empty game host protect juice submit motor cause second picture nuclear area"
+    }
+  ],
+  "relayers": [
+    {
+      "name": "rly1",
+      "mnemonic": "fringe secret hair noise royal inform remove release mother fish swamp swim piece later course glimpse sing very clutch velvet prefer hover common mass"
+    },
+    {
+      "name": "rly2",
+      "mnemonic": "floor chicken advance degree paper arch sugar kit torch auction flash fish attitude clay museum treat favorite clinic verify dose safe bright vessel east"
+    },
+    {
+      "name": "rly3",
+      "mnemonic": "belt diet provide fish knee area explain section sword fancy rebel mix fiction urge float chat move device another tourist want tackle drip good"
+    },
+    {
+      "name": "rly4",
+      "mnemonic": "video stereo milk coyote various fantasy attract leaf elevator laundry upper clinic ready recipe wreck asset make before update pitch found board tissue sniff"
+    },
+    {
+      "name": "rly5",
+      "mnemonic": "orient exit remain dance oval jealous spend baby card property struggle thank mean swing extra visit type segment wild exit height climb pause jungle"
+    },
+    {
+      "name": "rly6",
+      "mnemonic": "high awful dog toilet animal mystery zebra magnet style tube art arrow public about system odor split junk second second mixture grab fruit farm"
+    },
+    {
+      "name": "rly7",
+      "mnemonic": "bar clown steak hand dog mango vacant cradle potato axis identify surround give key noise lend must wool error broccoli relax input usage reveal"
+    },
+    {
+      "name": "rly8",
+      "mnemonic": "eagle rapid adapt nasty middle ability width rebel satisfy seminar boss sniff tape artist expose call predict burst hard pig coral item dolphin eagle"
+    }
+  ],
+  "users": [
+    {
+      "name": "user1",
+      "mnemonic": "brief play describe burden half aim soccer carbon hope wait output play vacuum joke energy crucial output mimic cruise brother document rail anger leaf"
+    }
+  ],
+  "cons_keys": [
+    {
+      "address": "895B09A185636566CADC0F130D9102C3F1BE7A9D",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "pGOlI0cJszb8kVqpPLr9Y3HsljrVi3UN7chJZAEo8F0="
       },
-      {
-        "name": "val2",
-        "mnemonic": "turkey miss hurry unable embark hospital kangaroo nuclear outside term toy fall buffalo book opinion such moral meadow wing olive camp sad metal banner"
-      },
-      {
-        "name": "val3",
-        "mnemonic": "tenant neck ask season exist hill churn rice convince shock modify evidence armor track army street stay light program harvest now settle feed wheat"
-      },
-      {
-        "name": "val4",
-        "mnemonic": "tail forward era width glory magnet knock shiver cup broken turkey upgrade cigar story agent lake transfer misery sustain fragile parrot also air document"
-      },
-      {
-        "name": "val5",
-        "mnemonic": "crime lumber parrot enforce chimney turtle wing iron scissors jealous indicate peace empty game host protect juice submit motor cause second picture nuclear area"
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "kJMFFRH1dbazb8fS/8jyYHmrhxoRvCebxnmvFQsfpACkY6UjRwmzNvyRWqk8uv1jceyWOtWLdQ3tyElkASjwXQ=="
       }
-    ],
-    "relayers": [
-      {
-        "name": "rly1",
-        "mnemonic": "fringe secret hair noise royal inform remove release mother fish swamp swim piece later course glimpse sing very clutch velvet prefer hover common mass"
+    },
+    {
+      "address": "7018A0CFEC999D75C682E04ED764BACBDE6F261B",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "dTAF9zUPbUyIUjY1jQyTsVp53xPS3zrmRreLKG5LX/c="
       },
-      {
-        "name": "rly2",
-        "mnemonic": "floor chicken advance degree paper arch sugar kit torch auction flash fish attitude clay museum treat favorite clinic verify dose safe bright vessel east"
-      },
-      {
-        "name": "rly3",
-        "mnemonic": "belt diet provide fish knee area explain section sword fancy rebel mix fiction urge float chat move device another tourist want tackle drip good"
-      },
-      {
-        "name": "rly4",
-        "mnemonic": "video stereo milk coyote various fantasy attract leaf elevator laundry upper clinic ready recipe wreck asset make before update pitch found board tissue sniff"
-      },
-      {
-        "name": "rly5",
-        "mnemonic": "orient exit remain dance oval jealous spend baby card property struggle thank mean swing extra visit type segment wild exit height climb pause jungle"
-      },
-      {
-        "name": "rly6",
-        "mnemonic": "high awful dog toilet animal mystery zebra magnet style tube art arrow public about system odor split junk second second mixture grab fruit farm"
-      },
-      {
-        "name": "rly7",
-        "mnemonic": "bar clown steak hand dog mango vacant cradle potato axis identify surround give key noise lend must wool error broccoli relax input usage reveal"
-      },
-      {
-        "name": "rly8",
-        "mnemonic": "eagle rapid adapt nasty middle ability width rebel satisfy seminar boss sniff tape artist expose call predict burst hard pig coral item dolphin eagle"
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "seFb4GeBAYHBE1J1YV/FDn2MCHsJPsdijgJPY3T+RUx1MAX3NQ9tTIhSNjWNDJOxWnnfE9LfOuZGt4sobktf9w=="
       }
-    ],
-    "users": [
-      {
-        "name": "user1",
-        "mnemonic": "brief play describe burden half aim soccer carbon hope wait output play vacuum joke energy crucial output mimic cruise brother document rail anger leaf"
+    },
+    {
+      "address": "13E61E4263BC2C4EEBF6CD7F7188CF8FF011B1FB",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "9xiMYD1YoMCTghcTZ66/0F0psKXzmZ1hCfPxI86IVsg="
+      },
+      "priv_key": {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "KkmVfzGOk9SXAyx9hi5UB/HM84MgUNC8nH1vYkOl1Cj3GIxgPVigwJOCFxNnrr/QXSmwpfOZnWEJ8/EjzohWyA=="
       }
-    ]
-  }
+    }
+  ]
+}

--- a/integration-tests/network/scripts/init-chain.sh
+++ b/integration-tests/network/scripts/init-chain.sh
@@ -78,6 +78,17 @@ add_validators() {
             $BINARY init $name --chain-id $CHAIN_ID --overwrite --home ${validator_home} &> /dev/null
         fi
 
+        # ig-tests POA upgrade: overwrite the auto-generated stride cons
+        # key with the pinned blob from keys.json::cons_keys[i-1]. This
+        # makes the consensus hex addresses match the values baked into
+        # app/upgrades/v33/validators.json. Hub/osmosis keep their
+        # auto-generated keys.
+        if [[ "$CHAIN_NAME" == "stride" ]]; then
+            cons_key_index=$((i - 1))
+            jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+                > ${validator_home}/config/priv_validator_key.json
+        fi
+
         # Save the node IDs and keys to the API
         $BINARY tendermint show-node-id --home ${validator_home} > node_id.txt
         upload_shared_file node_id.txt ${NODE_IDS_DIR}/${CHAIN_NAME}/${name}.txt 

--- a/integration-tests/network/scripts/init-node.sh
+++ b/integration-tests/network/scripts/init-node.sh
@@ -57,8 +57,20 @@ update_config() {
     sed -i -E "s|node = \".*\"|node = \"tcp://localhost:${RPC_PORT}\"|g" $client_toml
 
     echo "Retrieving private keys and genesis.json..."
-    download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json 
-    download_shared_file ${NODE_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json  ${CHAIN_HOME}/config/node_key.json 
+    download_shared_file ${VALIDATOR_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json ${CHAIN_HOME}/config/priv_validator_key.json
+
+    # ig-tests POA upgrade: re-pin the stride cons key from
+    # keys.json::cons_keys[VALIDATOR_INDEX-1] for self-consistency.
+    # The shared file already came from the pinned main node, but
+    # re-pinning here makes init-node.sh independent of init-chain.sh
+    # ordering.
+    if [[ "$CHAIN_NAME" == "stride" ]]; then
+        cons_key_index=$((VALIDATOR_INDEX - 1))
+        jq -r ".cons_keys[$cons_key_index]" ${KEYS_FILE} \
+            > ${CHAIN_HOME}/config/priv_validator_key.json
+    fi
+
+    download_shared_file ${NODE_KEYS_DIR}/${CHAIN_NAME}/val${VALIDATOR_INDEX}.json  ${CHAIN_HOME}/config/node_key.json
     download_shared_file ${GENESIS_DIR}/${CHAIN_NAME}/genesis.json ${CHAIN_HOME}/config/genesis.json 
 
     if [[ "$VALIDATOR_INDEX" != "1" ]]; then

--- a/integration-tests/scripts/generate_ig_test_state.sh
+++ b/integration-tests/scripts/generate_ig_test_state.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# generate_ig_test_state.sh
+# One-time helper for the POA migration integration-tests run.
+# Produces: 3 priv_validator_key.json blobs (cons keys), their lowercase
+# hex consensus addresses, and operator bech32 addresses derived from
+# val1/val2/val3 mnemonics. Outputs a single JSON document on stdout
+# for the implementer to inject into keys.json, validators.json, and
+# PoaValidatorSet.
+#
+# Requires: strided binary on PATH (any recent version that knows
+# `strided init` and `strided keys`).
+
+set -eu
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+KEYS_FILE="${KEYS_FILE:-integration-tests/network/configs/keys.json}"
+NUM_VALIDATORS=3
+
+# Sanity-check that keys.json has at least 3 validator entries.
+existing_count=$(jq '.validators | length' "$KEYS_FILE")
+if [[ "$existing_count" -lt "$NUM_VALIDATORS" ]]; then
+    echo "ERROR: keys.json has only $existing_count validators; need $NUM_VALIDATORS." >&2
+    exit 1
+fi
+
+# Generate 3 cons keys using `strided init`. Write priv_validator_key.json
+# verbatim — same shape strided expects on disk.
+declare -a CONS_KEYS_JSON
+declare -a HEX_ADDRS
+
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    home="${WORKDIR}/cons-${i}"
+    strided init "tmp-${i}" --chain-id ig-tests --home "$home" >/dev/null 2>&1
+    cons_key=$(cat "${home}/config/priv_validator_key.json")
+    hex_addr=$(jq -r '.address' <<<"$cons_key" | tr 'A-Z' 'a-z')
+
+    CONS_KEYS_JSON[$i]="$cons_key"
+    HEX_ADDRS[$i]="$hex_addr"
+done
+
+# Derive operator bech32 from each validator mnemonic (val1, val2, val3).
+declare -a OPERATORS
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    mnemonic=$(jq -r ".validators[$i].mnemonic" "$KEYS_FILE")
+    name="ig-tests-val-$i"
+    keyring="${WORKDIR}/keyring-${i}"
+    echo "$mnemonic" | strided keys add "$name" \
+        --recover --keyring-backend test --home "$keyring" >/dev/null 2>&1
+    operator=$(strided keys show "$name" -a \
+        --keyring-backend test --home "$keyring")
+    OPERATORS[$i]="$operator"
+done
+
+# Emit a single JSON document with the cons keys, hex addrs, and operators.
+jq -n \
+  --argjson cons_keys "$(printf '%s\n' "${CONS_KEYS_JSON[@]}" | jq -s .)" \
+  --argjson hex_addrs "$(printf '%s\n' "${HEX_ADDRS[@]}" | jq -R . | jq -s .)" \
+  --argjson operators "$(printf '%s\n' "${OPERATORS[@]}" | jq -R . | jq -s .)" \
+  '{
+     cons_keys: $cons_keys,
+     hex_addrs: $hex_addrs,
+     operators: $operators
+   }'

--- a/utils/poa.go
+++ b/utils/poa.go
@@ -13,13 +13,12 @@ type PoaValidator struct {
 	HubAddress string
 }
 
+// REHEARSAL ONLY — DO NOT MERGE
+// This branch (poa-migration-ig-tests) replaces the 8 mainnet entries with
+// 3 test validators matching app/upgrades/v33/validators.json. See that
+// file's sidecar REHEARSAL_ONLY marker for context.
 var PoaValidatorSet = []PoaValidator{
-	{Moniker: "Polkachu", Operator: "stride1gp957czryfgyvxwn3tfnyy2f0t9g2p4pxxdj7c", HubAddress: "cosmosvalcons1m7fg8k39k2tyym5hgwrpf5wx9hqsr8vywuyrtm"},
-	{Moniker: "L5", Operator: "stride1wj9ckvakuzgvlgw3hwpmsfjxvsc7uke73ps4u8", HubAddress: "cosmosvalcons1c5e86exd7jsyhcfqdejltdsagjfrvv8xv22368"},
-	{Moniker: "Imperator", Operator: "stride13u4dsapth4m3hef3z8qgjtdnv06predefnndkw", HubAddress: "cosmosvalcons1pdpwglc4fcjdzqvyhvfwxg684trpc6uqck5sxk"},
-	{Moniker: "Cosmostation", Operator: "stride1jj9z2xwxesuy65n90dujsak554eqkrr2ygyan2", HubAddress: "cosmosvalcons1px0zkz2cxvc6lh34uhafveea9jnaagckmrlsye"},
-	{Moniker: "Keplr", Operator: "stride1j79tw5chf34u88s30gxchzx2cu080elm4hqg5j", HubAddress: "cosmosvalcons1vz42ewp04wwepjed7z4qenj925gpakgvap4q2u"},
-	{Moniker: "Stakecito", Operator: "stride1qe8uuf5x69c526h4nzxwv4ltftr73v7qr7y9vq", HubAddress: "cosmosvalcons1upc05nc9pwhhagnkr3f2dft327qxsxfeyvajsu"},
-	{Moniker: "Citadel.one", Operator: "stride1rgwn0h67xmuluymk4vvhtl4tqtgfg39j9zuk2z", HubAddress: "cosmosvalcons1f6cjsfn47ujttypx7gtncglsmjvndugc2zelqx"},
-	{Moniker: "CryptoCrew", Operator: "stride1smuvvnjj6w7x6ytq9kdgvlj6er99y6648s3der", HubAddress: "cosmosvalcons1jufcrrd9gze26sxd82ppse03eg5g5xa2gplt6p"},
+	{Moniker: "Validator1", Operator: "stride1uk4ze0x4nvh4fk0xm4jdud58eqn4yxhrt52vv7", HubAddress: ""},
+	{Moniker: "Validator2", Operator: "stride17kht2x2ped6qytr2kklevtvmxpw7wq9rmuc3ca", HubAddress: ""},
+	{Moniker: "Validator3", Operator: "stride1nnurja9zt97huqvsfuartetyjx63tc5zq8s6fv", HubAddress: ""},
 }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Throwaway test branch — same posture as #1498 (the 8-validator rehearsal). Test-only constants are hardcoded into the v33 source; each modified file carries a top-of-file `// REHEARSAL ONLY — DO NOT MERGE` marker. This branch is for running the migration on a live network, not for merging.

## Summary

Runs the v32 → v33 (ICS → POA) migration on the **standard 3-validator `integration-tests` network** — the everyday one with 3 Stride validators plus `cosmoshub` and `osmosis` host zones — then runs `make test-core` against the post-upgrade chain.

This **complements #1498**. Where the rehearsal scales up to 8 stride-only validators to mirror mainnet shape and exercise POA-specific behavior (PSS split, `MsgWithdrawFees` payouts), this branch does the opposite: the **smallest possible delta** from the normal integration-tests network, so the existing `core.test.ts` suite keeps passing post-upgrade. The goal here is "does the existing product still work after the upgrade," not "is the upgrade itself correct at mainnet shape."

## Network shape

- Standard Helm chart, unchanged `activeChains` (`stride`, `cosmoshub`, `osmosis`) and relayers (rly + hermes for both stride↔hub and stride↔osmosis).
- 3 Stride validators, **all of them govenators** (no PSS-only split — at scale 3 everyone participates, which still exercises the `distrwrapper` stake-iteration path every block).
- Hub and Osmosis are untouched; the migration handler only mutates Stride state.

## Success criteria

1. v32 network spins up with 3 stride validators, IBC channels open to both host zones, host zones registered.
2. v33 upgrade proposal passes; cosmovisor swaps binaries cleanly; same validator hash across the upgrade height.
3. Post-upgrade tx fees route to the POA module account, not `fee_collector`.
4. `make test-core` passes against both `cosmoshub` and `osmosis` (IBC transfers, liquid staking, redemption, unbonding).

## Non-goals

- POA `MsgWithdrawFees` payout and the 5/3 govenator/PSS split — covered by #1498.
- LSM / auction / autopilot / burn suites.
- Production-grade fixture hygiene (cons keys are test-only by construction).

See `docs/superpowers/specs/2026-05-01-poa-migration-ig-tests-design.md` for the full design.