### PR TITLE
fix(stakeibc): v32 unbonding remediation — slashed-validator rounding fix, v33 Osmosis phantom reconciliation, retry observability

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -42,6 +42,7 @@ import (
 	v30 "github.com/Stride-Labs/stride/v32/app/upgrades/v30"
 	v31 "github.com/Stride-Labs/stride/v32/app/upgrades/v31"
 	v32 "github.com/Stride-Labs/stride/v32/app/upgrades/v32"
+	v33 "github.com/Stride-Labs/stride/v32/app/upgrades/v33"
 	v4 "github.com/Stride-Labs/stride/v32/app/upgrades/v4"
 	v5 "github.com/Stride-Labs/stride/v32/app/upgrades/v5"
 	v6 "github.com/Stride-Labs/stride/v32/app/upgrades/v6"
@@ -417,6 +418,17 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 			app.ModuleManager,
 			app.configurator,
 			app.GovKeeper,
+			app.RecordsKeeper,
+			app.StakeibcKeeper,
+		),
+	)
+
+	// v33 upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v33.UpgradeName,
+		v33.CreateUpgradeHandler(
+			app.ModuleManager,
+			app.configurator,
 			app.RecordsKeeper,
 			app.StakeibcKeeper,
 		),

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -1,0 +1,140 @@
+package v33
+
+import (
+	"context"
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	epochstypes "github.com/Stride-Labs/stride/v32/x/epochs/types"
+	recordskeeper "github.com/Stride-Labs/stride/v32/x/records/keeper"
+	recordstypes "github.com/Stride-Labs/stride/v32/x/records/types"
+	stakeibckeeper "github.com/Stride-Labs/stride/v32/x/stakeibc/keeper"
+	stakeibctypes "github.com/Stride-Labs/stride/v32/x/stakeibc/types"
+)
+
+var UpgradeName = "v33"
+
+const OsmosisChainId = "osmosis-1"
+
+// ValidatorReconciliation records the true on-chain delegation for an Osmosis validator whose
+// tracked Delegation drifted above reality after the v32 rebalance (an undelegation executed on
+// Osmosis but its ack was lost, so the record was never decremented). See the remediation spec:
+// docs/incidents/2026-v32-unbonding-remediation.md
+type ValidatorReconciliation struct {
+	Name              string
+	Address           string
+	OnChainDelegation sdkmath.Int // uosmo
+}
+
+// OsmosisPhantomDelegations lists the validators to reconcile and their current on-chain delegation.
+//
+// !!! RE-VERIFY these against live on-chain state immediately before the upgrade height !!!
+// (query the delegation ICA osmo1npfl4vmmmf4yqhcemz95mvqujgdnlhrlxfzhlhz2gru8g2t749xqr9zm5e).
+// cosmostation and chorus_one currently hold 0 on-chain; pryzmstakedrop holds ~60,662.8 OSMO.
+var OsmosisPhantomDelegations = []ValidatorReconciliation{
+	{Name: "cosmostation", Address: "osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4", OnChainDelegation: sdkmath.ZeroInt()},
+	{Name: "chorus_one", Address: "osmovaloper15urq2dtp9qce4fyc85m6upwm9xul3049wh9czc", OnChainDelegation: sdkmath.ZeroInt()},
+	{Name: "pryzmstakedrop", Address: "osmovaloper14n8pf9uxhuyxqnqryvjdr8g68na98wn5amq3e5", OnChainDelegation: sdkmath.NewInt(60_662_797_124)},
+}
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v33
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	recordsKeeper recordskeeper.Keeper,
+	stakeibcKeeper stakeibckeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(context context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(context)
+		ctx.Logger().Info(fmt.Sprintf("Starting upgrade %s...", UpgradeName))
+
+		ctx.Logger().Info("Running module migrations...")
+		versionMap, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return nil, err
+		}
+
+		ctx.Logger().Info("Reconciling Osmosis phantom delegations...")
+		if err := ReconcileOsmosisDelegations(ctx, stakeibcKeeper, recordsKeeper); err != nil {
+			return nil, err
+		}
+
+		return versionMap, nil
+	}
+}
+
+// ReconcileOsmosisDelegations fixes the OSMO delegation-record drift from the v32-rebalance incident
+// without moving user funds:
+//
+//  1. For each affected validator, set its tracked Delegation to its true on-chain value and reduce
+//     HostZone.TotalDelegations by the difference (the "phantom" that was never decremented).
+//  2. Credit the reconciled total back as a DELEGATION_QUEUE deposit record, so it is counted in the
+//     redemption rate (undelegatedBalance) and re-delegated from the delegation account's stranded
+//     liquid by the normal delegation flow - the same mechanism reinvestment uses
+//     (see x/stakeibc/keeper/icacallbacks_reinvest.go).
+//
+// Because the deposit-record credit equals the TotalDelegations reduction exactly, the redemption
+// rate is unchanged. Once the phantom records are gone, the stuck OSMO redemptions retry against
+// real validators and unbond/burn/pay through the normal path - no manual burn or sweep here.
+func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk recordskeeper.Keeper) error {
+	hostZone, found := sk.GetHostZone(ctx, OsmosisChainId)
+	if !found {
+		return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", OsmosisChainId)
+	}
+
+	totalReduction := sdkmath.ZeroInt()
+	for _, reconciliation := range OsmosisPhantomDelegations {
+		validator, index, found := stakeibckeeper.GetValidatorFromAddress(hostZone.Validators, reconciliation.Address)
+		if !found {
+			return errorsmod.Wrapf(stakeibctypes.ErrValidatorNotFound,
+				"validator %s (%s) not found on %s", reconciliation.Name, reconciliation.Address, OsmosisChainId)
+		}
+		// Guard against a stale constant: we should only ever be REDUCING a phantom, never inflating.
+		if validator.Delegation.IsNil() || validator.Delegation.LT(reconciliation.OnChainDelegation) {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest,
+				"validator %s tracked delegation %v is below the expected on-chain amount %v; re-verify constants",
+				reconciliation.Address, validator.Delegation, reconciliation.OnChainDelegation)
+		}
+
+		reduction := validator.Delegation.Sub(reconciliation.OnChainDelegation)
+		validator.Delegation = reconciliation.OnChainDelegation
+		hostZone.Validators[index] = &validator
+		totalReduction = totalReduction.Add(reduction)
+
+		ctx.Logger().Info(fmt.Sprintf("v33: reconciled %s delegation to %v (-%v)",
+			reconciliation.Name, reconciliation.OnChainDelegation, reduction))
+	}
+
+	if totalReduction.IsZero() {
+		ctx.Logger().Info("v33: no phantom delegation to reconcile on Osmosis")
+		return nil
+	}
+
+	hostZone.TotalDelegations = hostZone.TotalDelegations.Sub(totalReduction)
+	sk.SetHostZone(ctx, hostZone)
+
+	// Credit the reconciled amount so the redemption rate is preserved and the stranded liquid is
+	// re-delegated by the normal flow.
+	strideEpoch, found := sk.GetEpochTracker(ctx, epochstypes.STRIDE_EPOCH)
+	if !found {
+		return errorsmod.Wrapf(sdkerrors.ErrNotFound, "stride epoch tracker not found")
+	}
+	rk.AppendDepositRecord(ctx, recordstypes.DepositRecord{
+		Amount:             totalReduction,
+		Denom:              hostZone.HostDenom,
+		HostZoneId:         OsmosisChainId,
+		Status:             recordstypes.DepositRecord_DELEGATION_QUEUE,
+		Source:             recordstypes.DepositRecord_WITHDRAWAL_ICA,
+		DepositEpochNumber: strideEpoch.EpochNumber,
+	})
+
+	ctx.Logger().Info(fmt.Sprintf("v33: created DELEGATION_QUEUE deposit record for %v %s (rate-preserving credit of reconciled phantom)",
+		totalReduction, hostZone.HostDenom))
+	return nil
+}

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -85,7 +85,10 @@ func CreateUpgradeHandler(
 func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk recordskeeper.Keeper) error {
 	hostZone, found := sk.GetHostZone(ctx, OsmosisChainId)
 	if !found {
-		return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", OsmosisChainId)
+		// Skip rather than error: an error here fails the upgrade and halts the chain, and
+		// non-mainnet environments (dockernet, testnets) don't have the osmosis-1 host zone
+		ctx.Logger().Info(fmt.Sprintf("v33: host zone %s not found, skipping phantom delegation reconciliation", OsmosisChainId))
+		return nil
 	}
 
 	totalReduction := sdkmath.ZeroInt()

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -1,0 +1,126 @@
+package v33_test
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Stride-Labs/stride/v32/app/apptesting"
+	v33 "github.com/Stride-Labs/stride/v32/app/upgrades/v33"
+	epochstypes "github.com/Stride-Labs/stride/v32/x/epochs/types"
+	recordstypes "github.com/Stride-Labs/stride/v32/x/records/types"
+	stakeibctypes "github.com/Stride-Labs/stride/v32/x/stakeibc/types"
+)
+
+type UpgradeTestSuite struct {
+	apptesting.AppTestHelper
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+// Tracked (pre-migration) delegations for the three phantom validators; each is > its on-chain target
+var (
+	cosmostation = v33.OsmosisPhantomDelegations[0].Address
+	chorusOne    = v33.OsmosisPhantomDelegations[1].Address
+	pryzm        = v33.OsmosisPhantomDelegations[2].Address
+
+	trackedCosmostation = sdkmath.NewInt(258_638_300000)
+	trackedChorusOne    = sdkmath.NewInt(231_057_000000)
+	trackedPryzm        = sdkmath.NewInt(185_390_600000)
+)
+
+func (s *UpgradeTestSuite) setupOsmosisPhantomState() (trackedTotal, expectedReduction sdkmath.Int) {
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, stakeibctypes.EpochTracker{
+		EpochIdentifier: epochstypes.STRIDE_EPOCH,
+		EpochNumber:     42,
+	})
+
+	trackedTotal = trackedCosmostation.Add(trackedChorusOne).Add(trackedPryzm)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, stakeibctypes.HostZone{
+		ChainId:          v33.OsmosisChainId,
+		HostDenom:        "uosmo",
+		TotalDelegations: trackedTotal,
+		Validators: []*stakeibctypes.Validator{
+			{Address: cosmostation, Delegation: trackedCosmostation},
+			{Address: chorusOne, Delegation: trackedChorusOne},
+			{Address: pryzm, Delegation: trackedPryzm},
+		},
+	})
+
+	// reduction = tracked - on-chain target, summed
+	expectedReduction = trackedCosmostation.
+		Add(trackedChorusOne).
+		Add(trackedPryzm.Sub(v33.OsmosisPhantomDelegations[2].OnChainDelegation))
+	return trackedTotal, expectedReduction
+}
+
+func (s *UpgradeTestSuite) osmoDelegationQueueRecords() []recordstypes.DepositRecord {
+	var out []recordstypes.DepositRecord
+	for _, r := range s.App.RecordsKeeper.GetAllDepositRecord(s.Ctx) {
+		if r.HostZoneId == v33.OsmosisChainId && r.Status == recordstypes.DepositRecord_DELEGATION_QUEUE {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations() {
+	trackedTotal, expectedReduction := s.setupOsmosisPhantomState()
+
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "reconciliation should succeed")
+
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+	s.Require().True(found)
+
+	// Each phantom validator's Delegation is set to its on-chain target
+	delegations := map[string]sdkmath.Int{}
+	for _, v := range hostZone.Validators {
+		delegations[v.Address] = v.Delegation
+	}
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[cosmostation], "cosmostation reconciled to on-chain 0")
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[chorusOne], "chorus_one reconciled to on-chain 0")
+	s.Require().Equal(v33.OsmosisPhantomDelegations[2].OnChainDelegation, delegations[pryzm], "pryzmstakedrop reconciled to on-chain")
+
+	// TotalDelegations reduced by exactly the phantom
+	s.Require().Equal(trackedTotal.Sub(expectedReduction), hostZone.TotalDelegations, "TotalDelegations reduced by phantom")
+
+	// A single DELEGATION_QUEUE deposit record credits the reconciled amount
+	records := s.osmoDelegationQueueRecords()
+	s.Require().Len(records, 1, "exactly one deposit record should be created")
+	s.Require().Equal(expectedReduction, records[0].Amount, "deposit record credits the reconciled amount")
+	s.Require().Equal("uosmo", records[0].Denom, "deposit record denom")
+
+	// Rate-preservation invariant: the credit exactly offsets the TotalDelegations reduction
+	s.Require().Equal(trackedTotal.Sub(hostZone.TotalDelegations), records[0].Amount,
+		"credit must exactly offset the TotalDelegations reduction (rate preserved)")
+
+	// Internal consistency: TotalDelegations == sum of validator delegations
+	sum := sdkmath.ZeroInt()
+	for _, v := range hostZone.Validators {
+		sum = sum.Add(v.Delegation)
+	}
+	s.Require().Equal(sum, hostZone.TotalDelegations, "TotalDelegations == sum(validator.Delegation)")
+}
+
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_Idempotent() {
+	s.setupOsmosisPhantomState()
+
+	s.Require().NoError(v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper))
+	hostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+	firstTotal := hostZone.TotalDelegations
+
+	// Running again must be a no-op: records already match on-chain, so no reduction and no new credit
+	s.Require().NoError(v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper))
+	hostZoneAfter, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+
+	s.Require().Equal(firstTotal, hostZoneAfter.TotalDelegations, "second run must not change TotalDelegations")
+	s.Require().Len(s.osmoDelegationQueueRecords(), 1, "second run must not create another deposit record")
+}

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -110,6 +110,14 @@ func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations() {
 	s.Require().Equal(sum, hostZone.TotalDelegations, "TotalDelegations == sum(validator.Delegation)")
 }
 
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_MissingHostZone() {
+	// Without the osmosis-1 host zone (e.g. dockernet or a testnet), reconciliation must
+	// no-op instead of erroring - an error would fail the upgrade and halt the chain
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "missing host zone should be skipped, not an error")
+	s.Require().Empty(s.osmoDelegationQueueRecords(), "no deposit record should be created")
+}
+
 func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_Idempotent() {
 	s.setupOsmosisPhantomState()
 

--- a/dockernet/src/create_governors.sh
+++ b/dockernet/src/create_governors.sh
@@ -36,7 +36,7 @@ for (( i=1; i <= $NUM_NODES; i++ )); do
 }
 EOF
 
-  $cmd tx staking create-validator $validator_json --from $val_acct --keyring-backend test -y | TRIM_TX
+  $cmd tx staking create-validator $validator_json --from $val_acct --keyring-backend test --chain-id $CHAIN_ID -y | TRIM_TX
   sleep 2
 done
 

--- a/dockernet/src/create_governors.sh
+++ b/dockernet/src/create_governors.sh
@@ -22,9 +22,21 @@ for (( i=1; i <= $NUM_NODES; i++ )); do
   val_acct="${VAL_PREFIX}${i}"
   pub_key=$($cmd tendermint show-validator)
 
-  $cmd tx staking create-validator --amount ${STAKE_TOKENS}${DENOM} --from $val_acct \
-    --pubkey=$pub_key --commission-rate="0.10" --commission-max-rate="0.20" \
-    --commission-max-change-rate="0.01" --min-self-delegation="1" -y | TRIM_TX
+  # SDK v0.50+ create-validator takes a json file instead of flags
+  validator_json=${STATE}/$node_name/governor.json
+  cat << EOF > $validator_json
+{
+  "pubkey": $pub_key,
+  "amount": "${STAKE_TOKENS}${DENOM}",
+  "moniker": "$val_acct",
+  "commission-rate": "0.10",
+  "commission-max-rate": "0.20",
+  "commission-max-change-rate": "0.01",
+  "min-self-delegation": "1"
+}
+EOF
+
+  $cmd tx staking create-validator $validator_json --from $val_acct --keyring-backend test -y | TRIM_TX
   sleep 2
 done
 

--- a/dockernet/src/create_logs.sh
+++ b/dockernet/src/create_logs.sh
@@ -117,9 +117,9 @@ while true; do
         # Log stride staketia balances
         print_separator "STAKETIA STRIDE" $balances
 
-        deposit_address=$($STRIDE_MAIN_CMD keys show -a deposit)
-        redemption_address=$($STRIDE_MAIN_CMD keys show -a redemption)
-        claim_address=$($STRIDE_MAIN_CMD keys show -a claim)
+        deposit_address=$($STRIDE_MAIN_CMD keys show -a deposit --keyring-backend test)
+        redemption_address=$($STRIDE_MAIN_CMD keys show -a redemption --keyring-backend test)
+        claim_address=$($STRIDE_MAIN_CMD keys show -a claim --keyring-backend test)
         fee_address=$($STRIDE_MAIN_CMD q auth module-account staketia_fee_address | grep "address:" | awk '{print $2}')
 
         print_stride_balance $deposit_address    "DEPOSIT" 

--- a/dockernet/src/init_chain.sh
+++ b/dockernet/src/init_chain.sh
@@ -65,11 +65,11 @@ set_stride_genesis() {
     jq ".app_state += $interchain_accts" $genesis_config > json.tmp && mv json.tmp $genesis_config
 
     # set the staketia accounts in the staketia host zone
-    deposit_address=$($MAIN_CMD    keys show -a deposit)
-    redemption_address=$($MAIN_CMD keys show -a redemption)
-    claim_address=$($MAIN_CMD      keys show -a claim)
-    safe_address=$($MAIN_CMD       keys show -a safe)
-    operator_address=$($MAIN_CMD   keys show -a operator)
+    deposit_address=$($MAIN_CMD    keys show -a deposit --keyring-backend test)
+    redemption_address=$($MAIN_CMD keys show -a redemption --keyring-backend test)
+    claim_address=$($MAIN_CMD      keys show -a claim --keyring-backend test)
+    safe_address=$($MAIN_CMD       keys show -a safe --keyring-backend test)
+    operator_address=$($MAIN_CMD   keys show -a operator --keyring-backend test)
 
     jq '.app_state.staketia.host_zone.deposit_address = $newVal'    --arg newVal "$deposit_address"    $genesis_config > json.tmp && mv json.tmp $genesis_config
     jq '.app_state.staketia.host_zone.redemption_address = $newVal' --arg newVal "$redemption_address" $genesis_config > json.tmp && mv json.tmp $genesis_config

--- a/dockernet/src/register_host.sh
+++ b/dockernet/src/register_host.sh
@@ -33,7 +33,7 @@ fi
 echo "$CHAIN - Registering host zone..."
 $STRIDE_MAIN_CMD tx stakeibc register-host-zone \
     $CONNECTION $HOST_DENOM $ADDRESS_PREFIX $IBC_DENOM $CHANNEL 1 $LSM_ENABLED $COMMUNITY_POOL_TREASURY_ADDRESS_FLAG \
-    --gas 2000000 --from $STRIDE_ADMIN_ACCT --home $DOCKERNET_HOME/state/stride1 --keyring-backend test -y | TRIM_TX
+    --gas 2000000 --from $STRIDE_ADMIN_ACCT --home $DOCKERNET_HOME/state/stride1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
 sleep 10
 
 # Build array of validators of the form:
@@ -55,7 +55,7 @@ for (( i=1; i <= $NUM_VALS; i++ )); do
         if [[ "$i" == "1" ]]; then
             echo "$CHAIN - Submitting validator bonds..."
         fi
-        $GAIA_MAIN_CMD tx staking validator-bond $delegate_val --from ${VAL_PREFIX}${i} --keyring-backend test -y --fees 1000000ufee | TRIM_TX
+        $GAIA_MAIN_CMD tx staking validator-bond $delegate_val --from ${VAL_PREFIX}${i} --keyring-backend test --chain-id $CHAIN_ID -y --fees 1000000ufee | TRIM_TX
     fi
 done
 
@@ -67,7 +67,7 @@ echo "{\"validators\": [${validators[*]}]}" > $validator_json
 # Add host zone validators to Stride's host zone struct
 echo "$CHAIN - Registering validators..."
 $STRIDE_MAIN_CMD tx stakeibc add-validators $CHAIN_ID $validator_json --gas 1000000 \
-    --from $STRIDE_ADMIN_ACCT --keyring-backend test -y | TRIM_TX
+    --from $STRIDE_ADMIN_ACCT --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
 sleep 5
 
 # Confirm the ICA accounts have been registered before continuing

--- a/dockernet/src/register_host.sh
+++ b/dockernet/src/register_host.sh
@@ -33,7 +33,7 @@ fi
 echo "$CHAIN - Registering host zone..."
 $STRIDE_MAIN_CMD tx stakeibc register-host-zone \
     $CONNECTION $HOST_DENOM $ADDRESS_PREFIX $IBC_DENOM $CHANNEL 1 $LSM_ENABLED $COMMUNITY_POOL_TREASURY_ADDRESS_FLAG \
-    --gas 2000000 --from $STRIDE_ADMIN_ACCT --home $DOCKERNET_HOME/state/stride1 -y | TRIM_TX
+    --gas 2000000 --from $STRIDE_ADMIN_ACCT --home $DOCKERNET_HOME/state/stride1 --keyring-backend test -y | TRIM_TX
 sleep 10
 
 # Build array of validators of the form:
@@ -55,7 +55,7 @@ for (( i=1; i <= $NUM_VALS; i++ )); do
         if [[ "$i" == "1" ]]; then
             echo "$CHAIN - Submitting validator bonds..."
         fi
-        $GAIA_MAIN_CMD tx staking validator-bond $delegate_val --from ${VAL_PREFIX}${i} -y --fees 1000000ufee | TRIM_TX
+        $GAIA_MAIN_CMD tx staking validator-bond $delegate_val --from ${VAL_PREFIX}${i} --keyring-backend test -y --fees 1000000ufee | TRIM_TX
     fi
 done
 
@@ -67,7 +67,7 @@ echo "{\"validators\": [${validators[*]}]}" > $validator_json
 # Add host zone validators to Stride's host zone struct
 echo "$CHAIN - Registering validators..."
 $STRIDE_MAIN_CMD tx stakeibc add-validators $CHAIN_ID $validator_json --gas 1000000 \
-    --from $STRIDE_ADMIN_ACCT -y | TRIM_TX
+    --from $STRIDE_ADMIN_ACCT --keyring-backend test -y | TRIM_TX
 sleep 5
 
 # Confirm the ICA accounts have been registered before continuing

--- a/dockernet/upgrades/Dockerfile.cosmovisor
+++ b/dockernet/upgrades/Dockerfile.cosmovisor
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1
-FROM golang:1.22-alpine3.20 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 
 ARG old_commit_hash
 ARG stride_admin_address
@@ -25,7 +25,7 @@ RUN git checkout $old_commit_hash \
 # Install wasm
 RUN WASMVM_VERSION=$(cat go.mod | grep github.com/CosmWasm/wasmvm | awk '{print $2}') \
     && wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$(uname -m).a \
-    -O /lib/libwasmvm_muslc.a
+    -O /lib/libwasmvm_muslc.$(uname -m).a
 
 # Build the old stride binary
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/dockernet/upgrades/submit_upgrade.sh
+++ b/dockernet/upgrades/submit_upgrade.sh
@@ -11,7 +11,7 @@ PROPOSAL_ID=1
 printf "PROPOSAL\n"
 $STRIDE_MAIN_CMD tx gov submit-legacy-proposal software-upgrade $UPGRADE_NAME \
     --title $UPGRADE_NAME --description "description" --no-validate \
-    --upgrade-height $UPGRADE_HEIGHT --from val1 --keyring-backend test -y | TRIM_TX
+    --upgrade-height $UPGRADE_HEIGHT --from val1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
 
 sleep 5
 printf "\nPROPOSAL CONFIRMATION\n"
@@ -19,7 +19,7 @@ $STRIDE_MAIN_CMD query gov proposals
 
 sleep 5 
 printf "\nDEPOSIT\n"
-$STRIDE_MAIN_CMD tx gov deposit $PROPOSAL_ID 10000001ustrd --from val1 --keyring-backend test -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov deposit $PROPOSAL_ID 10000001ustrd --from val1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
 
 sleep 5
 printf "\nDEPOSIT CONFIRMATION\n"
@@ -27,9 +27,9 @@ $STRIDE_MAIN_CMD query gov deposits $PROPOSAL_ID
 
 sleep 5
 printf "\nVOTING\n"
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val1 --keyring-backend test -y | TRIM_TX
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val2 --keyring-backend test -y | TRIM_TX
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val3 --keyring-backend test -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val2 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val3 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
 
 sleep 5
 printf "\nVOTE CONFIRMATION\n"

--- a/dockernet/upgrades/submit_upgrade.sh
+++ b/dockernet/upgrades/submit_upgrade.sh
@@ -9,9 +9,12 @@ UPGRADE_HEIGHT="${UPGRADE_HEIGHT:-150}"
 PROPOSAL_ID=1
 
 printf "PROPOSAL\n"
-$STRIDE_MAIN_CMD tx gov submit-legacy-proposal software-upgrade $UPGRADE_NAME \
-    --title $UPGRADE_NAME --description "description" --no-validate \
-    --upgrade-height $UPGRADE_HEIGHT --from val1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID -y | TRIM_TX
+# SDK v0.50+ removed the legacy software-upgrade gov proposal; use the modern
+# x/upgrade command which submits a gov v1 proposal wrapping MsgSoftwareUpgrade
+$STRIDE_MAIN_CMD tx upgrade software-upgrade $UPGRADE_NAME \
+    --title $UPGRADE_NAME --summary "description" --no-validate \
+    --upgrade-height $UPGRADE_HEIGHT --deposit 10000001ustrd \
+    --from val1 --keyring-backend test --chain-id $STRIDE_CHAIN_ID --gas 400000 -y | TRIM_TX
 
 sleep 5
 printf "\nPROPOSAL CONFIRMATION\n"

--- a/dockernet/upgrades/submit_upgrade.sh
+++ b/dockernet/upgrades/submit_upgrade.sh
@@ -11,7 +11,7 @@ PROPOSAL_ID=1
 printf "PROPOSAL\n"
 $STRIDE_MAIN_CMD tx gov submit-legacy-proposal software-upgrade $UPGRADE_NAME \
     --title $UPGRADE_NAME --description "description" --no-validate \
-    --upgrade-height $UPGRADE_HEIGHT --from val1 -y | TRIM_TX
+    --upgrade-height $UPGRADE_HEIGHT --from val1 --keyring-backend test -y | TRIM_TX
 
 sleep 5
 printf "\nPROPOSAL CONFIRMATION\n"
@@ -19,7 +19,7 @@ $STRIDE_MAIN_CMD query gov proposals
 
 sleep 5 
 printf "\nDEPOSIT\n"
-$STRIDE_MAIN_CMD tx gov deposit $PROPOSAL_ID 10000001ustrd --from val1 -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov deposit $PROPOSAL_ID 10000001ustrd --from val1 --keyring-backend test -y | TRIM_TX
 
 sleep 5
 printf "\nDEPOSIT CONFIRMATION\n"
@@ -27,9 +27,9 @@ $STRIDE_MAIN_CMD query gov deposits $PROPOSAL_ID
 
 sleep 5
 printf "\nVOTING\n"
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val1 -y | TRIM_TX
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val2 -y | TRIM_TX
-$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val3 -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val1 --keyring-backend test -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val2 --keyring-backend test -y | TRIM_TX
+$STRIDE_MAIN_CMD tx gov vote $PROPOSAL_ID yes --from val3 --keyring-backend test -y | TRIM_TX
 
 sleep 5
 printf "\nVOTE CONFIRMATION\n"

--- a/x/stakeibc/keeper/abci.go
+++ b/x/stakeibc/keeper/abci.go
@@ -38,6 +38,10 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 	}
 
 	k.AssertStrideAndDayEpochRelationship(ctx)
+
+	// Log-only check that the internal delegation records are self-consistent
+	// (TotalDelegations == sum of validator delegations) so accounting drift is caught early
+	k.CheckDelegationRecordsConsistent(ctx)
 }
 
 func (k Keeper) EndBlocker(ctx sdk.Context) {

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdkmath "cosmossdk.io/math"
 
 	"github.com/Stride-Labs/stride/v32/utils"
@@ -139,6 +141,7 @@ func (k Keeper) MarkUndelegationAckReceived(ctx sdk.Context, hostZone types.Host
 // There may be some epoch numbers in this batch from records that have already had a full unbonding
 // and have moved onto status EXIT_TRANSFER_QUEUE
 func (k Keeper) HandleFailedUndelegation(ctx sdk.Context, chainId string, epochNumbers []uint64) error {
+	retriedEpochs := []uint64{}
 	for _, epochNumber := range epochNumbers {
 		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochNumber, chainId)
 		if !found {
@@ -155,6 +158,23 @@ func (k Keeper) HandleFailedUndelegation(ctx sdk.Context, chainId string, epochN
 		if err != nil {
 			return err
 		}
+		retriedEpochs = append(retriedEpochs, epochNumber)
+	}
+
+	// Surface the failure as an event so operators can alert on it. A rejected undelegation
+	// (e.g. the host returning "invalid shares amount", or targeting a stale/phantom delegation)
+	// otherwise loops silently in UNBONDING_RETRY_QUEUE and can strand redemptions for weeks
+	// before anyone notices - which is exactly what happened on Injective/Osmosis after v32.
+	if len(retriedEpochs) > 0 {
+		k.Logger(ctx).Error(utils.LogWithHostZone(chainId,
+			"Undelegation failed and was moved to the retry queue for epochs %v", retriedEpochs))
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				types.EventTypeUndelegationFailed,
+				sdk.NewAttribute(types.AttributeKeyHostZone, chainId),
+				sdk.NewAttribute(types.AttributeKeyEpochNumbers, fmt.Sprint(retriedEpochs)),
+			),
+		)
 	}
 	return nil
 }

--- a/x/stakeibc/keeper/invariants.go
+++ b/x/stakeibc/keeper/invariants.go
@@ -4,8 +4,10 @@ package keeper
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/Stride-Labs/stride/v32/utils"
 	epochtypes "github.com/Stride-Labs/stride/v32/x/epochs/types"
 	"github.com/Stride-Labs/stride/v32/x/stakeibc/types"
 )
@@ -24,6 +26,34 @@ func (k Keeper) AssertStrideAndDayEpochRelationship(ctx sdk.Context) {
 	if dayEpoch.Duration/strideEpoch.Duration != StrideEpochsPerDayEpoch {
 		panic("The stride epoch must be 1/4th the length of the day epoch")
 	}
+}
+
+// CheckDelegationRecordsConsistent verifies, for every active host zone, that TotalDelegations
+// equals the sum of each validator's tracked Delegation. This is a cheap internal-bookkeeping
+// consistency check that catches code paths which update one value without the other.
+//
+// It is log-only (never panics or mutates state) so it can run safely in the BeginBlocker.
+// NOTE: it does NOT detect tracked-vs-on-chain drift (e.g. delegations that were undelegated on
+// the host but whose ack was lost) - that requires an interchain query; see the delegator-shares
+// / calibrate reconciliation for that class of drift.
+func (k Keeper) CheckDelegationRecordsConsistent(ctx sdk.Context) (consistent bool) {
+	consistent = true
+	for _, hostZone := range k.GetAllActiveHostZone(ctx) {
+		sum := sdkmath.ZeroInt()
+		for _, validator := range hostZone.Validators {
+			if validator.Delegation.IsNil() {
+				continue
+			}
+			sum = sum.Add(validator.Delegation)
+		}
+		if hostZone.TotalDelegations.IsNil() || !sum.Equal(hostZone.TotalDelegations) {
+			consistent = false
+			k.Logger(ctx).Error(utils.LogWithHostZone(hostZone.ChainId,
+				"delegation record inconsistency: TotalDelegations=%v but sum(validator.Delegation)=%v",
+				hostZone.TotalDelegations, sum))
+		}
+	}
+	return consistent
 }
 
 // TODO [cleanup]: Update to be CheckRedemptionRateWithinSafetyBound and only throw an error (instead of a bool)

--- a/x/stakeibc/keeper/invariants_test.go
+++ b/x/stakeibc/keeper/invariants_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/Stride-Labs/stride/v32/x/stakeibc/types"
 )
 
+func (s *KeeperTestSuite) TestCheckDelegationRecordsConsistent() {
+	// Consistent zone: TotalDelegations == sum(validator.Delegation)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, types.HostZone{
+		ChainId:          "consistent-1",
+		TotalDelegations: sdkmath.NewInt(300),
+		Validators: []*types.Validator{
+			{Address: "valA", Delegation: sdkmath.NewInt(100)},
+			{Address: "valB", Delegation: sdkmath.NewInt(200)},
+		},
+	})
+	s.Require().True(s.App.StakeibcKeeper.CheckDelegationRecordsConsistent(s.Ctx),
+		"records should be consistent")
+
+	// Inconsistent zone: TotalDelegations != sum(validator.Delegation)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, types.HostZone{
+		ChainId:          "inconsistent-1",
+		TotalDelegations: sdkmath.NewInt(999),
+		Validators: []*types.Validator{
+			{Address: "valA", Delegation: sdkmath.NewInt(100)},
+			{Address: "valB", Delegation: sdkmath.NewInt(200)},
+		},
+	})
+	s.Require().False(s.App.StakeibcKeeper.CheckDelegationRecordsConsistent(s.Ctx),
+		"drift between TotalDelegations and summed validator delegations should be flagged")
+}
+
 func (s *KeeperTestSuite) TestIsRedemptionRateWithinSafetyBounds() {
 	params := s.App.StakeibcKeeper.GetParams(s.Ctx)
 	params.DefaultMinRedemptionRateThreshold = 75

--- a/x/stakeibc/keeper/unbonding.go
+++ b/x/stakeibc/keeper/unbonding.go
@@ -274,7 +274,7 @@ func (k Keeper) applySharesRoundingSafety(
 		return unbondAmount
 	}
 	validator, _, found := GetValidatorFromAddress(hostZone.Validators, validatorCapacity.ValidatorAddress)
-	if !found || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
+	if !found || validator.SharesToTokensRate.IsNil() || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
 		return unbondAmount
 	}
 	buffer := unbondAmount.Quo(UndelegationSharesSafetyDivisor)

--- a/x/stakeibc/keeper/unbonding.go
+++ b/x/stakeibc/keeper/unbonding.go
@@ -242,6 +242,52 @@ func SortUnbondingCapacityByPriority(validatorUnbondCapacity []ValidatorUnbondCa
 	return validatorUnbondCapacity, nil
 }
 
+// UndelegationSharesSafetyDivisor determines the rounding buffer that is left behind when fully
+// draining a slashed validator: buffer = fullAmount / divisor (with a floor of 1 base unit).
+// At 1e17 this leaves at most ~1e-17 of the delegation undelegated, which comfortably covers the
+// worst-case shares rounding error (bounded by delegatorShares * 1e-18) while being economically
+// negligible. The un-drained dust remains delegated and is reconciled by the next calibration.
+var UndelegationSharesSafetyDivisor = sdkmath.NewInt(100_000_000_000_000_000)
+
+// applySharesRoundingSafety guards against the host staking module rejecting a full-balance
+// MsgUndelegate with "invalid shares amount" (ABCI code 18).
+//
+// Stride tracks each validator's delegation in native tokens, derived from the delegator shares
+// times an 18-decimal SharesToTokensRate. For a slashed validator (rate < 1) that stored rate
+// rounds slightly above the validator's exact on-chain tokens/shares ratio, so the tracked token
+// amount can imply marginally MORE shares than the ICA actually holds. When the validator is being
+// fully drained (weight 0), undelegating the full tracked amount then fails ValidateUnbondAmount
+// (sharesFromTokensTruncated(amount) > delegation.shares). Because undelegations are submitted as a
+// single atomic ICA, one such message reverts the whole batch and strands every redemption in it.
+//
+// To stay safe we leave a tiny rounding buffer on full drains of slashed validators only. The
+// remainder cascades to the next validator in GetUnbondingICAMessages, so the full redemption
+// amount is still unbonded (this relies on total real delegation >= total unbond amount, which
+// holds because every redemption is backed by real stake).
+func (k Keeper) applySharesRoundingSafety(
+	hostZone types.HostZone,
+	validatorCapacity ValidatorUnbondCapacity,
+	unbondAmount sdkmath.Int,
+) sdkmath.Int {
+	// Only relevant when this undelegation drains the validator's entire tracked delegation
+	if validatorCapacity.CurrentDelegation.IsNil() || !unbondAmount.Equal(validatorCapacity.CurrentDelegation) {
+		return unbondAmount
+	}
+	validator, _, found := GetValidatorFromAddress(hostZone.Validators, validatorCapacity.ValidatorAddress)
+	if !found || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
+		return unbondAmount
+	}
+	buffer := unbondAmount.Quo(UndelegationSharesSafetyDivisor)
+	if buffer.IsZero() {
+		buffer = sdkmath.OneInt()
+	}
+	// Never buffer the amount down to zero
+	if buffer.GTE(unbondAmount) {
+		return unbondAmount
+	}
+	return unbondAmount.Sub(buffer)
+}
+
 // Given a total unbond amount and list of unbond capacity for each validator, sorted by unbond priority
 // Iterates through the list and unbonds as much as possible from each validator until all the
 // unbonding has been accounted for
@@ -268,6 +314,11 @@ func (k Keeper) GetUnbondingICAMessages(
 		} else {
 			unbondAmount = remainingUnbondAmount
 		}
+
+		// Leave a rounding buffer when fully draining a slashed validator so the host doesn't
+		// reject the MsgUndelegate with "invalid shares amount" (see applySharesRoundingSafety)
+		unbondAmount = k.applySharesRoundingSafety(hostZone, validatorCapacity, unbondAmount)
+
 		remainingUnbondAmount = remainingUnbondAmount.Sub(unbondAmount)
 
 		// Build the validator splits for the callback

--- a/x/stakeibc/keeper/unbonding_test.go
+++ b/x/stakeibc/keeper/unbonding_test.go
@@ -1146,6 +1146,66 @@ func (s *KeeperTestSuite) TestGetUnbondingICAMessages() {
 	}
 }
 
+// Regression test for the v32-rebalance undelegation incident (Injective/Osmosis).
+// Fully draining a slashed validator (shares-to-tokens rate < 1) must leave a small rounding
+// buffer so the host staking module doesn't reject the MsgUndelegate with "invalid shares amount".
+func (s *KeeperTestSuite) TestGetUnbondingICAMessages_SharesRoundingSafety() {
+	delegationAddress := "cosmos_DELEGATION"
+	slashedVal := "valSlashed"
+	healthyVal := "valHealthy"
+
+	hostZone := types.HostZone{
+		ChainId:              HostChainId,
+		HostDenom:            Atom,
+		DelegationIcaAddress: delegationAddress,
+		Validators: []*types.Validator{
+			{Address: slashedVal, Weight: 0, SharesToTokensRate: sdkmath.LegacyMustNewDecFromStr("0.99")},
+			{Address: healthyVal, Weight: 0, SharesToTokensRate: sdkmath.LegacyOneDec()},
+		},
+	}
+
+	fullDelegation := sdkmath.NewInt(1_000_000_000_000_000_000) // 1e18
+	expectedBuffer := fullDelegation.Quo(keeper.UndelegationSharesSafetyDivisor)
+	s.Require().True(expectedBuffer.IsPositive(), "test setup: buffer should be non-zero")
+
+	s.Run("slashed full drain is buffered and remainder cascades", func() {
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: slashedVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+			{ValidatorAddress: healthyVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, fullDelegation, capacities)
+		s.Require().NoError(err)
+		s.Require().Len(splits, 2, "buffered remainder should cascade to a second validator")
+		s.Require().Equal(fullDelegation.Sub(expectedBuffer).Int64(), splits[0].NativeTokenAmount.Int64(),
+			"slashed full drain should leave a rounding buffer")
+		s.Require().Equal(expectedBuffer.Int64(), splits[1].NativeTokenAmount.Int64(),
+			"buffered remainder should cascade to the next validator")
+		total := splits[0].NativeTokenAmount.Add(splits[1].NativeTokenAmount)
+		s.Require().Equal(fullDelegation.Int64(), total.Int64(), "total unbonded must equal requested")
+	})
+
+	s.Run("unslashed (rate == 1) full drain is not buffered", func() {
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: healthyVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, fullDelegation, capacities)
+		s.Require().NoError(err)
+		s.Require().Equal(fullDelegation.Int64(), splits[0].NativeTokenAmount.Int64(),
+			"rate == 1 validators must not be buffered")
+	})
+
+	s.Run("partial undelegation of a slashed validator is not buffered", func() {
+		partial := sdkmath.NewInt(400_000_000_000_000_000)
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: slashedVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, partial, capacities)
+		s.Require().NoError(err)
+		s.Require().Equal(partial.Int64(), splits[0].NativeTokenAmount.Int64(),
+			"partial drains have headroom and must not be buffered")
+	})
+}
+
 func (s *KeeperTestSuite) TestBatchSubmitUndelegateICAMessages() {
 	// The test will submit ICA's across 10 validators, in batches of 3
 	// There should be 4 ICA's submitted

--- a/x/stakeibc/types/events.go
+++ b/x/stakeibc/types/events.go
@@ -20,6 +20,7 @@ const (
 	EventTypeValidatorSharesToTokensRateChange = "validator_shares_to_tokens_rate_change"
 	EventTypeValidatorSlash                    = "validator_slash"
 	EventTypeUndelegation                      = "undelegation"
+	EventTypeUndelegationFailed                = "undelegation_failed"
 	EventTypeRedemptionSweep                   = "redemption_sweep"
 
 	AttributeKeyHostZone         = "host_zone"
@@ -38,6 +39,7 @@ const (
 	AttributeKeyNativeBaseDenom    = "native_base_denom"
 	AttributeKeyNativeIBCDenom     = "native_ibc_denom"
 	AttributeKeyTotalUnbondAmount  = "total_unbond_amount"
+	AttributeKeyEpochNumbers       = "epoch_numbers"
 	AttributeKeySweptAmount        = "swept_amount"
 	AttributeKeyLSMTokenBaseDenom  = "lsm_token_base_denom" // #nosec G101
 	AttributeKeyNativeAmount       = "native_amount"


### PR DESCRIPTION
## Context

After the v32 validator-weight rebalance, redemptions on **injective-1** and **osmosis-1** became permanently stuck in `UNBONDING_RETRY_QUEUE`: every retry rebuilt the same doomed undelegation, the host chain rejected it, the atomic batch reverted, and no event or error was emitted — users waited 25+ days past their unbonding dates. The two chains failed for different reasons.

Full incident report with on-chain evidence: https://gist.github.com/moonyandfriends/2a324c33542c37e4068f4222245f51df

## Bug 1 — Injective: invalid-shares rejection on slashed-validator full drains

Stride stores each validator's shares-to-tokens rate as an 18-decimal `Dec` rounded slightly above the exact tokens/shares ratio. A full-balance `MsgUndelegate` on a slashed validator (rate < 1) can therefore imply marginally more shares than the ICA holds; the host rejects it with `invalid shares amount` (ABCI code 18), reverting the whole batch. The overshoot is bounded by `shares × 5e-19`, so it only manifests on 18-decimal denoms — INJ but never ATOM.

**Fix** (543b22dd): when fully draining a slashed validator, leave a rounding buffer of `amount / 1e17` (floor 1 base unit) so implied shares can never exceed the ICA's actual shares. The dust stays delegated and reconciles at the next calibration. Deterministic regression test included; 5bf9b6a4 guards a nil rate. The stuck epochs self-heal via the existing per-day-epoch retry, no manual action.

## Bug 2 — Osmosis: phantom delegations from a lost acknowledgement

During the v32 rebalance an undelegation ICA executed on Osmosis but its ack was never delivered (ordered channel closed first), leaving 614,423 OSMO of phantom delegations on three weight-0 validators. Every subsequent batch tried to fully drain delegations that don't exist and reverted. The undelegated tokens are not lost — they sit liquid on the delegation ICA.

**Fix** (bb8faeca): the v33 upgrade handler sets the three validators' records to their true on-chain values, reduces `TotalDelegations` by the phantom, and credits the identical amount back as a `DELEGATION_QUEUE` deposit record. The credit exactly offsets the reduction, so **the redemption rate is unchanged** (a naive decrement would cut it ~13%), and the stranded liquid re-delegates through the normal flow. 46d016c2 makes the handler skip (not halt) if the zone is absent. ⚠️ Constants must be re-verified against live state immediately before the upgrade height.

## Observability

- 2abb8312: emit an event when an undelegation fails into the retry queue (v32 loops silently — this incident went unnoticed for ~3 weeks)
- e7332c8: log-only delegation-records consistency check in BeginBlocker

## Testing

Validated end-to-end on dockernet running the real v32.0.0 binary, upgrading via cosmovisor + live gov proposal:

1. Recreated the Osmosis failure organically (deny-filtered relayer, recv-only manual delivery, surgical single-sequence timeout closing the ordered channel) — phantom + stranded liquid + redemption wedged in `UNBONDING_RETRY_QUEUE`, silent on v32, exactly like mainnet.
2. Upgraded at a gov-scheduled height: handler reconciled the phantom, redemption rate preserved (1.000124 → 1.000144, rewards drift only), stuck epoch retried to `CLAIMABLE` with zero manual record surgery.
3. Recreated the Injective shape (validator slashed 3×5% while holding Stride delegations): weight-0 full drain succeeded first-try with the rounding buffer leaving its designed dust.
4. Test account claimed every redemption, including both previously stuck epochs.

Unit tests: deterministic regression test for the rounding buffer, upgrade-handler tests, consistency-check tests.

## Ride-along: dockernet SDK-53 repairs

Five commits fixing dockernet bitrot from the SDK 53 bump (cosmovisor builder image go 1.23, explicit keyring-backend/chain-id flags, `create-validator` JSON format, modern `tx upgrade software-upgrade` command) — needed to run the upgrade test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)