### PR TITLE
fix(stakeibc): remediate v32 stuck unbondings

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -439,6 +439,8 @@ func (app *StrideApp) setupUpgradeHandlers(appOpts servertypes.AppOptions) {
 			app.BankKeeper,
 			app.AccountKeeper,
 			app.DistrKeeper,
+			app.RecordsKeeper,
+			app.StakeibcKeeper,
 		),
 	)
 

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -6,14 +6,24 @@ import (
 
 	ccvconsumerkeeper "github.com/cosmos/interchain-security/v7/x/ccv/consumer/keeper"
 
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	poakeeper "github.com/cosmos/cosmos-sdk/enterprise/poa/x/poa/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	epochstypes "github.com/Stride-Labs/stride/v32/x/epochs/types"
+	recordskeeper "github.com/Stride-Labs/stride/v32/x/records/keeper"
+	recordstypes "github.com/Stride-Labs/stride/v32/x/records/types"
+	stakeibckeeper "github.com/Stride-Labs/stride/v32/x/stakeibc/keeper"
+	stakeibctypes "github.com/Stride-Labs/stride/v32/x/stakeibc/types"
 )
 
 // CreateUpgradeHandler returns the v33 upgrade handler that migrates Stride
@@ -30,6 +40,8 @@ func CreateUpgradeHandler(
 	bankKeeper bankkeeper.Keeper,
 	accountKeeper authkeeper.AccountKeeper,
 	distrKeeper distrkeeper.Keeper,
+	recordsKeeper recordskeeper.Keeper,
+	stakeibcKeeper stakeibckeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(goCtx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(goCtx)
@@ -40,6 +52,11 @@ func CreateUpgradeHandler(
 		ctx.Logger().Info("v33: running module migrations...")
 		versionMap, err := mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {
+			return nil, err
+		}
+
+		ctx.Logger().Info("Reconciling Osmosis phantom delegations...")
+		if err := ReconcileOsmosisDelegations(ctx, stakeibcKeeper, recordsKeeper); err != nil {
 			return nil, err
 		}
 
@@ -65,4 +82,97 @@ func CreateUpgradeHandler(
 		ctx.Logger().Info(fmt.Sprintf("Upgrade %s complete.", UpgradeName))
 		return versionMap, nil
 	}
+}
+
+const OsmosisChainId = "osmosis-1"
+
+// ValidatorReconciliation records the true on-chain delegation for an Osmosis validator whose
+// tracked Delegation drifted above reality after the v32 rebalance (an undelegation executed on
+// Osmosis but its ack was lost, so the record was never decremented). See the remediation spec:
+// docs/incidents/2026-v32-unbonding-remediation.md
+type ValidatorReconciliation struct {
+	Name              string
+	Address           string
+	OnChainDelegation sdkmath.Int // uosmo
+}
+
+// OsmosisPhantomDelegations lists the validators to reconcile and their current on-chain delegation.
+//
+// !!! RE-VERIFY these against live on-chain state immediately before the upgrade height !!!
+// (query the delegation ICA osmo1npfl4vmmmf4yqhcemz95mvqujgdnlhrlxfzhlhz2gru8g2t749xqr9zm5e).
+// cosmostation and chorus_one currently hold 0 on-chain; pryzmstakedrop holds ~60,662.8 OSMO.
+var OsmosisPhantomDelegations = []ValidatorReconciliation{
+	{Name: "cosmostation", Address: "osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4", OnChainDelegation: sdkmath.ZeroInt()},
+	{Name: "chorus_one", Address: "osmovaloper15urq2dtp9qce4fyc85m6upwm9xul3049wh9czc", OnChainDelegation: sdkmath.ZeroInt()},
+	{Name: "pryzmstakedrop", Address: "osmovaloper14n8pf9uxhuyxqnqryvjdr8g68na98wn5amq3e5", OnChainDelegation: sdkmath.NewInt(60_662_797_124)},
+}
+
+// ReconcileOsmosisDelegations fixes the OSMO delegation-record drift from the v32-rebalance incident
+// without moving user funds:
+//
+//  1. For each affected validator, set its tracked Delegation to its true on-chain value and reduce
+//     HostZone.TotalDelegations by the difference (the "phantom" that was never decremented).
+//  2. Credit the reconciled total back as a DELEGATION_QUEUE deposit record, so it is counted in the
+//     redemption rate (undelegatedBalance) and re-delegated from the delegation account's stranded
+//     liquid by the normal delegation flow - the same mechanism reinvestment uses
+//     (see x/stakeibc/keeper/icacallbacks_reinvest.go).
+//
+// Because the deposit-record credit equals the TotalDelegations reduction exactly, the redemption
+// rate is unchanged. Once the phantom records are gone, the stuck OSMO redemptions retry against
+// real validators and unbond/burn/pay through the normal path - no manual burn or sweep here.
+func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk recordskeeper.Keeper) error {
+	hostZone, found := sk.GetHostZone(ctx, OsmosisChainId)
+	if !found {
+		return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", OsmosisChainId)
+	}
+
+	totalReduction := sdkmath.ZeroInt()
+	for _, reconciliation := range OsmosisPhantomDelegations {
+		validator, index, found := stakeibckeeper.GetValidatorFromAddress(hostZone.Validators, reconciliation.Address)
+		if !found {
+			return errorsmod.Wrapf(stakeibctypes.ErrValidatorNotFound,
+				"validator %s (%s) not found on %s", reconciliation.Name, reconciliation.Address, OsmosisChainId)
+		}
+		// Guard against a stale constant: we should only ever be REDUCING a phantom, never inflating.
+		if validator.Delegation.IsNil() || validator.Delegation.LT(reconciliation.OnChainDelegation) {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest,
+				"validator %s tracked delegation %v is below the expected on-chain amount %v; re-verify constants",
+				reconciliation.Address, validator.Delegation, reconciliation.OnChainDelegation)
+		}
+
+		reduction := validator.Delegation.Sub(reconciliation.OnChainDelegation)
+		validator.Delegation = reconciliation.OnChainDelegation
+		hostZone.Validators[index] = &validator
+		totalReduction = totalReduction.Add(reduction)
+
+		ctx.Logger().Info(fmt.Sprintf("v33: reconciled %s delegation to %v (-%v)",
+			reconciliation.Name, reconciliation.OnChainDelegation, reduction))
+	}
+
+	if totalReduction.IsZero() {
+		ctx.Logger().Info("v33: no phantom delegation to reconcile on Osmosis")
+		return nil
+	}
+
+	hostZone.TotalDelegations = hostZone.TotalDelegations.Sub(totalReduction)
+	sk.SetHostZone(ctx, hostZone)
+
+	// Credit the reconciled amount so the redemption rate is preserved and the stranded liquid is
+	// re-delegated by the normal flow.
+	strideEpoch, found := sk.GetEpochTracker(ctx, epochstypes.STRIDE_EPOCH)
+	if !found {
+		return errorsmod.Wrapf(sdkerrors.ErrNotFound, "stride epoch tracker not found")
+	}
+	rk.AppendDepositRecord(ctx, recordstypes.DepositRecord{
+		Amount:             totalReduction,
+		Denom:              hostZone.HostDenom,
+		HostZoneId:         OsmosisChainId,
+		Status:             recordstypes.DepositRecord_DELEGATION_QUEUE,
+		Source:             recordstypes.DepositRecord_WITHDRAWAL_ICA,
+		DepositEpochNumber: strideEpoch.EpochNumber,
+	})
+
+	ctx.Logger().Info(fmt.Sprintf("v33: created DELEGATION_QUEUE deposit record for %v %s (rate-preserving credit of reconciled phantom)",
+		totalReduction, hostZone.HostDenom))
+	return nil
 }

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -23,7 +23,6 @@ import (
 	recordskeeper "github.com/Stride-Labs/stride/v32/x/records/keeper"
 	recordstypes "github.com/Stride-Labs/stride/v32/x/records/types"
 	stakeibckeeper "github.com/Stride-Labs/stride/v32/x/stakeibc/keeper"
-	stakeibctypes "github.com/Stride-Labs/stride/v32/x/stakeibc/types"
 )
 
 // CreateUpgradeHandler returns the v33 upgrade handler that migrates Stride
@@ -133,14 +132,20 @@ func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk r
 	for _, reconciliation := range OsmosisPhantomDelegations {
 		validator, index, found := stakeibckeeper.GetValidatorFromAddress(hostZone.Validators, reconciliation.Address)
 		if !found {
-			return errorsmod.Wrapf(stakeibctypes.ErrValidatorNotFound,
-				"validator %s (%s) not found on %s", reconciliation.Name, reconciliation.Address, OsmosisChainId)
+			// A drifted constant must never halt the upgrade — log loudly and skip this validator.
+			ctx.Logger().Error(fmt.Sprintf(
+				"v33: validator %s (%s) not found on %s — skipping its reconciliation",
+				reconciliation.Name, reconciliation.Address, OsmosisChainId))
+			continue
 		}
-		// Guard against a stale constant: we should only ever be REDUCING a phantom, never inflating.
+		// Guard against a stale constant: we only ever REDUCE a phantom, never inflate. On drift
+		// (tracked already at/below the constant) we skip this validator rather than halt the upgrade.
 		if validator.Delegation.IsNil() || validator.Delegation.LT(reconciliation.OnChainDelegation) {
-			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest,
-				"validator %s tracked delegation %v is below the expected on-chain amount %v; re-verify constants",
-				reconciliation.Address, validator.Delegation, reconciliation.OnChainDelegation)
+			ctx.Logger().Error(fmt.Sprintf(
+				"v33: validator %s tracked delegation %v is below expected on-chain amount %v — "+
+					"re-verify constants; skipping its reconciliation",
+				reconciliation.Address, validator.Delegation, reconciliation.OnChainDelegation))
+			continue
 		}
 
 		reduction := validator.Delegation.Sub(reconciliation.OnChainDelegation)

--- a/app/upgrades/v33/upgrades.go
+++ b/app/upgrades/v33/upgrades.go
@@ -123,7 +123,10 @@ var OsmosisPhantomDelegations = []ValidatorReconciliation{
 func ReconcileOsmosisDelegations(ctx sdk.Context, sk stakeibckeeper.Keeper, rk recordskeeper.Keeper) error {
 	hostZone, found := sk.GetHostZone(ctx, OsmosisChainId)
 	if !found {
-		return errorsmod.Wrapf(stakeibctypes.ErrHostZoneNotFound, "host zone %s not found", OsmosisChainId)
+		// Skip rather than error: an error here fails the upgrade and halts the chain, and
+		// non-mainnet environments (dockernet, testnets) don't have the osmosis-1 host zone
+		ctx.Logger().Info(fmt.Sprintf("v33: host zone %s not found, skipping phantom delegation reconciliation", OsmosisChainId))
+		return nil
 	}
 
 	totalReduction := sdkmath.ZeroInt()

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -444,3 +444,72 @@ func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_Idempotent() {
 	s.Require().Equal(firstTotal, hostZoneAfter.TotalDelegations, "second run must not change TotalDelegations")
 	s.Require().Len(s.osmoDelegationQueueRecords(), 1, "second run must not create another deposit record")
 }
+
+// A drifted constant (tracked delegation below the expected on-chain amount) must skip that
+// validator and still reconcile the rest, rather than halting the upgrade.
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_SkipsDriftedValidator() {
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, stakeibctypes.EpochTracker{
+		EpochIdentifier: epochstypes.STRIDE_EPOCH,
+		EpochNumber:     42,
+	})
+
+	// pryzm tracked below its on-chain constant → drift → must be skipped
+	driftedPryzm := v33.OsmosisPhantomDelegations[2].OnChainDelegation.Sub(sdkmath.NewInt(1))
+	trackedTotal := trackedCosmostation.Add(trackedChorusOne).Add(driftedPryzm)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, stakeibctypes.HostZone{
+		ChainId:          v33.OsmosisChainId,
+		HostDenom:        "uosmo",
+		TotalDelegations: trackedTotal,
+		Validators: []*stakeibctypes.Validator{
+			{Address: cosmostation, Delegation: trackedCosmostation},
+			{Address: chorusOne, Delegation: trackedChorusOne},
+			{Address: pryzm, Delegation: driftedPryzm},
+		},
+	})
+
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "drift must be skipped, not an error")
+
+	hostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+	delegations := map[string]sdkmath.Int{}
+	for _, v := range hostZone.Validators {
+		delegations[v.Address] = v.Delegation
+	}
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[cosmostation], "cosmostation still reconciled")
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[chorusOne], "chorus_one still reconciled")
+	s.Require().Equal(driftedPryzm, delegations[pryzm], "drifted pryzmstakedrop left untouched")
+
+	// Credit reflects only the two reductions that were actually applied
+	appliedReduction := trackedCosmostation.Add(trackedChorusOne)
+	s.Require().Equal(trackedTotal.Sub(appliedReduction), hostZone.TotalDelegations, "TotalDelegations reduced only by applied reductions")
+	records := s.osmoDelegationQueueRecords()
+	s.Require().Len(records, 1)
+	s.Require().Equal(appliedReduction, records[0].Amount, "credit equals only the applied reductions")
+}
+
+// A phantom validator absent from the host zone must be skipped, with the rest still reconciled.
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_SkipsMissingValidator() {
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, stakeibctypes.EpochTracker{
+		EpochIdentifier: epochstypes.STRIDE_EPOCH,
+		EpochNumber:     42,
+	})
+
+	// pryzm is not on the host zone at all → skipped
+	trackedTotal := trackedCosmostation.Add(trackedChorusOne)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, stakeibctypes.HostZone{
+		ChainId:          v33.OsmosisChainId,
+		HostDenom:        "uosmo",
+		TotalDelegations: trackedTotal,
+		Validators: []*stakeibctypes.Validator{
+			{Address: cosmostation, Delegation: trackedCosmostation},
+			{Address: chorusOne, Delegation: trackedChorusOne},
+		},
+	})
+
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "missing validator must be skipped, not an error")
+
+	records := s.osmoDelegationQueueRecords()
+	s.Require().Len(records, 1)
+	s.Require().Equal(trackedTotal, records[0].Amount, "credit equals the reductions for the present validators")
+}

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/Stride-Labs/stride/v32/app/apptesting"
 	v33 "github.com/Stride-Labs/stride/v32/app/upgrades/v33"
 	"github.com/Stride-Labs/stride/v32/utils"
+	epochstypes "github.com/Stride-Labs/stride/v32/x/epochs/types"
+	recordstypes "github.com/Stride-Labs/stride/v32/x/records/types"
+	stakeibctypes "github.com/Stride-Labs/stride/v32/x/stakeibc/types"
 )
 
 type UpgradeTestSuite struct {
@@ -332,4 +335,104 @@ func (s *UpgradeTestSuite) populateValidatorMonikers() {
 type poaVal struct {
 	pk    cryptotypes.PubKey
 	power int64
+}
+
+// Tracked (pre-migration) delegations for the three phantom validators; each is > its on-chain target
+var (
+	cosmostation = v33.OsmosisPhantomDelegations[0].Address
+	chorusOne    = v33.OsmosisPhantomDelegations[1].Address
+	pryzm        = v33.OsmosisPhantomDelegations[2].Address
+
+	trackedCosmostation = sdkmath.NewInt(258_638_300000)
+	trackedChorusOne    = sdkmath.NewInt(231_057_000000)
+	trackedPryzm        = sdkmath.NewInt(185_390_600000)
+)
+
+func (s *UpgradeTestSuite) setupOsmosisPhantomState() (trackedTotal, expectedReduction sdkmath.Int) {
+	s.App.StakeibcKeeper.SetEpochTracker(s.Ctx, stakeibctypes.EpochTracker{
+		EpochIdentifier: epochstypes.STRIDE_EPOCH,
+		EpochNumber:     42,
+	})
+
+	trackedTotal = trackedCosmostation.Add(trackedChorusOne).Add(trackedPryzm)
+	s.App.StakeibcKeeper.SetHostZone(s.Ctx, stakeibctypes.HostZone{
+		ChainId:          v33.OsmosisChainId,
+		HostDenom:        "uosmo",
+		TotalDelegations: trackedTotal,
+		Validators: []*stakeibctypes.Validator{
+			{Address: cosmostation, Delegation: trackedCosmostation},
+			{Address: chorusOne, Delegation: trackedChorusOne},
+			{Address: pryzm, Delegation: trackedPryzm},
+		},
+	})
+
+	// reduction = tracked - on-chain target, summed
+	expectedReduction = trackedCosmostation.
+		Add(trackedChorusOne).
+		Add(trackedPryzm.Sub(v33.OsmosisPhantomDelegations[2].OnChainDelegation))
+	return trackedTotal, expectedReduction
+}
+
+func (s *UpgradeTestSuite) osmoDelegationQueueRecords() []recordstypes.DepositRecord {
+	var out []recordstypes.DepositRecord
+	for _, r := range s.App.RecordsKeeper.GetAllDepositRecord(s.Ctx) {
+		if r.HostZoneId == v33.OsmosisChainId && r.Status == recordstypes.DepositRecord_DELEGATION_QUEUE {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations() {
+	trackedTotal, expectedReduction := s.setupOsmosisPhantomState()
+
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "reconciliation should succeed")
+
+	hostZone, found := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+	s.Require().True(found)
+
+	// Each phantom validator's Delegation is set to its on-chain target
+	delegations := map[string]sdkmath.Int{}
+	for _, v := range hostZone.Validators {
+		delegations[v.Address] = v.Delegation
+	}
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[cosmostation], "cosmostation reconciled to on-chain 0")
+	s.Require().Equal(sdkmath.ZeroInt(), delegations[chorusOne], "chorus_one reconciled to on-chain 0")
+	s.Require().Equal(v33.OsmosisPhantomDelegations[2].OnChainDelegation, delegations[pryzm], "pryzmstakedrop reconciled to on-chain")
+
+	// TotalDelegations reduced by exactly the phantom
+	s.Require().Equal(trackedTotal.Sub(expectedReduction), hostZone.TotalDelegations, "TotalDelegations reduced by phantom")
+
+	// A single DELEGATION_QUEUE deposit record credits the reconciled amount
+	records := s.osmoDelegationQueueRecords()
+	s.Require().Len(records, 1, "exactly one deposit record should be created")
+	s.Require().Equal(expectedReduction, records[0].Amount, "deposit record credits the reconciled amount")
+	s.Require().Equal("uosmo", records[0].Denom, "deposit record denom")
+
+	// Rate-preservation invariant: the credit exactly offsets the TotalDelegations reduction
+	s.Require().Equal(trackedTotal.Sub(hostZone.TotalDelegations), records[0].Amount,
+		"credit must exactly offset the TotalDelegations reduction (rate preserved)")
+
+	// Internal consistency: TotalDelegations == sum of validator delegations
+	sum := sdkmath.ZeroInt()
+	for _, v := range hostZone.Validators {
+		sum = sum.Add(v.Delegation)
+	}
+	s.Require().Equal(sum, hostZone.TotalDelegations, "TotalDelegations == sum(validator.Delegation)")
+}
+
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_Idempotent() {
+	s.setupOsmosisPhantomState()
+
+	s.Require().NoError(v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper))
+	hostZone, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+	firstTotal := hostZone.TotalDelegations
+
+	// Running again must be a no-op: records already match on-chain, so no reduction and no new credit
+	s.Require().NoError(v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper))
+	hostZoneAfter, _ := s.App.StakeibcKeeper.GetHostZone(s.Ctx, v33.OsmosisChainId)
+
+	s.Require().Equal(firstTotal, hostZoneAfter.TotalDelegations, "second run must not change TotalDelegations")
+	s.Require().Len(s.osmoDelegationQueueRecords(), 1, "second run must not create another deposit record")
 }

--- a/app/upgrades/v33/upgrades_test.go
+++ b/app/upgrades/v33/upgrades_test.go
@@ -422,6 +422,14 @@ func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations() {
 	s.Require().Equal(sum, hostZone.TotalDelegations, "TotalDelegations == sum(validator.Delegation)")
 }
 
+func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_MissingHostZone() {
+	// Without the osmosis-1 host zone (e.g. dockernet or a testnet), reconciliation must
+	// no-op instead of erroring - an error would fail the upgrade and halt the chain
+	err := v33.ReconcileOsmosisDelegations(s.Ctx, s.App.StakeibcKeeper, s.App.RecordsKeeper)
+	s.Require().NoError(err, "missing host zone should be skipped, not an error")
+	s.Require().Empty(s.osmoDelegationQueueRecords(), "no deposit record should be created")
+}
+
 func (s *UpgradeTestSuite) TestReconcileOsmosisDelegations_Idempotent() {
 	s.setupOsmosisPhantomState()
 

--- a/x/stakeibc/keeper/icacallbacks_undelegate.go
+++ b/x/stakeibc/keeper/icacallbacks_undelegate.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	"github.com/cosmos/gogoproto/proto"
 	channeltypes "github.com/cosmos/ibc-go/v11/modules/core/04-channel/types"
 
@@ -140,6 +142,7 @@ func (k Keeper) MarkUndelegationAckReceived(ctx sdk.Context, hostZone types.Host
 // There may be some epoch numbers in this batch from records that have already had a full unbonding
 // and have moved onto status EXIT_TRANSFER_QUEUE
 func (k Keeper) HandleFailedUndelegation(ctx sdk.Context, chainId string, epochNumbers []uint64) error {
+	retriedEpochs := []uint64{}
 	for _, epochNumber := range epochNumbers {
 		hostZoneUnbonding, found := k.RecordsKeeper.GetHostZoneUnbondingByChainId(ctx, epochNumber, chainId)
 		if !found {
@@ -156,6 +159,23 @@ func (k Keeper) HandleFailedUndelegation(ctx sdk.Context, chainId string, epochN
 		if err != nil {
 			return err
 		}
+		retriedEpochs = append(retriedEpochs, epochNumber)
+	}
+
+	// Surface the failure as an event so operators can alert on it. A rejected undelegation
+	// (e.g. the host returning "invalid shares amount", or targeting a stale/phantom delegation)
+	// otherwise loops silently in UNBONDING_RETRY_QUEUE and can strand redemptions for weeks
+	// before anyone notices - which is exactly what happened on Injective/Osmosis after v32.
+	if len(retriedEpochs) > 0 {
+		k.Logger(ctx).Error(utils.LogWithHostZone(chainId,
+			"Undelegation failed and was moved to the retry queue for epochs %v", retriedEpochs))
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				types.EventTypeUndelegationFailed,
+				sdk.NewAttribute(types.AttributeKeyHostZone, chainId),
+				sdk.NewAttribute(types.AttributeKeyEpochNumbers, fmt.Sprint(retriedEpochs)),
+			),
+		)
 	}
 	return nil
 }

--- a/x/stakeibc/keeper/unbonding.go
+++ b/x/stakeibc/keeper/unbonding.go
@@ -276,7 +276,7 @@ func (k Keeper) applySharesRoundingSafety(
 		return unbondAmount
 	}
 	validator, _, found := GetValidatorFromAddress(hostZone.Validators, validatorCapacity.ValidatorAddress)
-	if !found || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
+	if !found || validator.SharesToTokensRate.IsNil() || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
 		return unbondAmount
 	}
 	buffer := unbondAmount.Quo(UndelegationSharesSafetyDivisor)

--- a/x/stakeibc/keeper/unbonding.go
+++ b/x/stakeibc/keeper/unbonding.go
@@ -244,6 +244,52 @@ func SortUnbondingCapacityByPriority(validatorUnbondCapacity []ValidatorUnbondCa
 	return validatorUnbondCapacity, nil
 }
 
+// UndelegationSharesSafetyDivisor determines the rounding buffer that is left behind when fully
+// draining a slashed validator: buffer = fullAmount / divisor (with a floor of 1 base unit).
+// At 1e17 this leaves at most ~1e-17 of the delegation undelegated, which comfortably covers the
+// worst-case shares rounding error (bounded by delegatorShares * 1e-18) while being economically
+// negligible. The un-drained dust remains delegated and is reconciled by the next calibration.
+var UndelegationSharesSafetyDivisor = sdkmath.NewInt(100_000_000_000_000_000)
+
+// applySharesRoundingSafety guards against the host staking module rejecting a full-balance
+// MsgUndelegate with "invalid shares amount" (ABCI code 18).
+//
+// Stride tracks each validator's delegation in native tokens, derived from the delegator shares
+// times an 18-decimal SharesToTokensRate. For a slashed validator (rate < 1) that stored rate
+// rounds slightly above the validator's exact on-chain tokens/shares ratio, so the tracked token
+// amount can imply marginally MORE shares than the ICA actually holds. When the validator is being
+// fully drained (weight 0), undelegating the full tracked amount then fails ValidateUnbondAmount
+// (sharesFromTokensTruncated(amount) > delegation.shares). Because undelegations are submitted as a
+// single atomic ICA, one such message reverts the whole batch and strands every redemption in it.
+//
+// To stay safe we leave a tiny rounding buffer on full drains of slashed validators only. The
+// remainder cascades to the next validator in GetUnbondingICAMessages, so the full redemption
+// amount is still unbonded (this relies on total real delegation >= total unbond amount, which
+// holds because every redemption is backed by real stake).
+func (k Keeper) applySharesRoundingSafety(
+	hostZone types.HostZone,
+	validatorCapacity ValidatorUnbondCapacity,
+	unbondAmount sdkmath.Int,
+) sdkmath.Int {
+	// Only relevant when this undelegation drains the validator's entire tracked delegation
+	if validatorCapacity.CurrentDelegation.IsNil() || !unbondAmount.Equal(validatorCapacity.CurrentDelegation) {
+		return unbondAmount
+	}
+	validator, _, found := GetValidatorFromAddress(hostZone.Validators, validatorCapacity.ValidatorAddress)
+	if !found || !validator.SharesToTokensRate.LT(sdkmath.LegacyOneDec()) {
+		return unbondAmount
+	}
+	buffer := unbondAmount.Quo(UndelegationSharesSafetyDivisor)
+	if buffer.IsZero() {
+		buffer = sdkmath.OneInt()
+	}
+	// Never buffer the amount down to zero
+	if buffer.GTE(unbondAmount) {
+		return unbondAmount
+	}
+	return unbondAmount.Sub(buffer)
+}
+
 // Given a total unbond amount and list of unbond capacity for each validator, sorted by unbond priority
 // Iterates through the list and unbonds as much as possible from each validator until all the
 // unbonding has been accounted for
@@ -270,6 +316,11 @@ func (k Keeper) GetUnbondingICAMessages(
 		} else {
 			unbondAmount = remainingUnbondAmount
 		}
+
+		// Leave a rounding buffer when fully draining a slashed validator so the host doesn't
+		// reject the MsgUndelegate with "invalid shares amount" (see applySharesRoundingSafety)
+		unbondAmount = k.applySharesRoundingSafety(hostZone, validatorCapacity, unbondAmount)
+
 		remainingUnbondAmount = remainingUnbondAmount.Sub(unbondAmount)
 
 		// Build the validator splits for the callback

--- a/x/stakeibc/keeper/unbonding_test.go
+++ b/x/stakeibc/keeper/unbonding_test.go
@@ -1147,6 +1147,66 @@ func (s *KeeperTestSuite) TestGetUnbondingICAMessages() {
 	}
 }
 
+// Regression test for the v32-rebalance undelegation incident (Injective/Osmosis).
+// Fully draining a slashed validator (shares-to-tokens rate < 1) must leave a small rounding
+// buffer so the host staking module doesn't reject the MsgUndelegate with "invalid shares amount".
+func (s *KeeperTestSuite) TestGetUnbondingICAMessages_SharesRoundingSafety() {
+	delegationAddress := "cosmos_DELEGATION"
+	slashedVal := "valSlashed"
+	healthyVal := "valHealthy"
+
+	hostZone := types.HostZone{
+		ChainId:              HostChainId,
+		HostDenom:            Atom,
+		DelegationIcaAddress: delegationAddress,
+		Validators: []*types.Validator{
+			{Address: slashedVal, Weight: 0, SharesToTokensRate: sdkmath.LegacyMustNewDecFromStr("0.99")},
+			{Address: healthyVal, Weight: 0, SharesToTokensRate: sdkmath.LegacyOneDec()},
+		},
+	}
+
+	fullDelegation := sdkmath.NewInt(1_000_000_000_000_000_000) // 1e18
+	expectedBuffer := fullDelegation.Quo(keeper.UndelegationSharesSafetyDivisor)
+	s.Require().True(expectedBuffer.IsPositive(), "test setup: buffer should be non-zero")
+
+	s.Run("slashed full drain is buffered and remainder cascades", func() {
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: slashedVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+			{ValidatorAddress: healthyVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, fullDelegation, capacities)
+		s.Require().NoError(err)
+		s.Require().Len(splits, 2, "buffered remainder should cascade to a second validator")
+		s.Require().Equal(fullDelegation.Sub(expectedBuffer).Int64(), splits[0].NativeTokenAmount.Int64(),
+			"slashed full drain should leave a rounding buffer")
+		s.Require().Equal(expectedBuffer.Int64(), splits[1].NativeTokenAmount.Int64(),
+			"buffered remainder should cascade to the next validator")
+		total := splits[0].NativeTokenAmount.Add(splits[1].NativeTokenAmount)
+		s.Require().Equal(fullDelegation.Int64(), total.Int64(), "total unbonded must equal requested")
+	})
+
+	s.Run("unslashed (rate == 1) full drain is not buffered", func() {
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: healthyVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, fullDelegation, capacities)
+		s.Require().NoError(err)
+		s.Require().Equal(fullDelegation.Int64(), splits[0].NativeTokenAmount.Int64(),
+			"rate == 1 validators must not be buffered")
+	})
+
+	s.Run("partial undelegation of a slashed validator is not buffered", func() {
+		partial := sdkmath.NewInt(400_000_000_000_000_000)
+		capacities := []keeper.ValidatorUnbondCapacity{
+			{ValidatorAddress: slashedVal, Capacity: fullDelegation, CurrentDelegation: fullDelegation},
+		}
+		_, splits, err := s.App.StakeibcKeeper.GetUnbondingICAMessages(hostZone, partial, capacities)
+		s.Require().NoError(err)
+		s.Require().Equal(partial.Int64(), splits[0].NativeTokenAmount.Int64(),
+			"partial drains have headroom and must not be buffered")
+	})
+}
+
 func (s *KeeperTestSuite) TestBatchSubmitUndelegateICAMessages() {
 	// The test will submit ICA's across 10 validators, in batches of 3
 	// There should be 4 ICA's submitted

--- a/x/stakeibc/types/events.go
+++ b/x/stakeibc/types/events.go
@@ -20,6 +20,7 @@ const (
 	EventTypeValidatorSharesToTokensRateChange = "validator_shares_to_tokens_rate_change"
 	EventTypeValidatorSlash                    = "validator_slash"
 	EventTypeUndelegation                      = "undelegation"
+	EventTypeUndelegationFailed                = "undelegation_failed"
 	EventTypeRedemptionSweep                   = "redemption_sweep"
 
 	AttributeKeyHostZone         = "host_zone"
@@ -38,6 +39,7 @@ const (
 	AttributeKeyNativeBaseDenom    = "native_base_denom"
 	AttributeKeyNativeIBCDenom     = "native_ibc_denom"
 	AttributeKeyTotalUnbondAmount  = "total_unbond_amount"
+	AttributeKeyEpochNumbers       = "epoch_numbers"
 	AttributeKeySweptAmount        = "swept_amount"
 	AttributeKeyLSMTokenBaseDenom  = "lsm_token_base_denom" // #nosec G101
 	AttributeKeyNativeAmount       = "native_amount"


### PR DESCRIPTION
## Context

This supersedes #1508 and rebases its v32 unbonding remediation onto current `main` after the v33 ICS-to-POA migration. It intentionally excludes the dockernet SDK repair commits and the delegation-record consistency invariant; all other source changes are retained. The Osmosis reconciliation is composed into the existing v33 handler immediately after module migrations.

After the v32 validator-weight rebalance, redemptions on `injective-1` and `osmosis-1` became stuck in `UNBONDING_RETRY_QUEUE`. The host chains rejected each retry, the atomic batches reverted, and the failures had no on-chain event.

Original incident report with on-chain evidence: https://gist.github.com/moonyandfriends/2a324c33542c37e4068f4222245f51df

## Injective

A full-balance undelegation from a slashed validator can imply marginally more shares than the ICA holds because the stored 18-decimal shares-to-tokens rate rounds above the exact ratio. The host rejects the message with `invalid shares amount`.

The fix leaves a bounded rounding buffer when fully draining a slashed validator. The remainder cascades through the existing undelegation split, and a nil-rate guard preserves existing validator behavior.

## Osmosis

A lost acknowledgement during the v32 rebalance left phantom tracked delegations on three weight-zero validators even though the undelegation executed on Osmosis. The v33 handler now reconciles those records to their on-chain values, reduces `TotalDelegations` by the phantom amount, and credits the same amount as a `DELEGATION_QUEUE` deposit record so the redemption rate remains unchanged and stranded liquid is redelegated normally.

The handler logs and skips reconciliation if `osmosis-1` is absent. The hard-coded reconciliation values must be re-verified against live state immediately before the upgrade height.

## Observability

Failed undelegations now emit an `undelegation_failed` event with the host zone and affected epoch numbers when records move to the retry queue.

## Verification

- `go test ./app/upgrades/v33 ./x/stakeibc/keeper -count=1`
- `go test ./app ./x/stakeibc/types -count=1`
- `git diff --check origin/main...HEAD`
- Confirmed no diff under `dockernet/` or in the removed invariant files

A repository-wide `go test ./...` reaches the same unrelated `utils/TestCreateModuleAccount` uniqueness panic reproduced before the rebase; this branch has no `utils` changes.

Carries forward the work and commit authorship from #1508 by @moonyandfriends.
